### PR TITLE
Fix pre-commit hook ordering and add --fix flags

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,28 +18,29 @@ repos:
         name: '[*] No Trailing Whitespace'
     repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
+  # language: system because the config packages aren't published yet.
+  # Consumers should use language: node with additional_dependencies.
+  - hooks:
+      # oxfmt must run before markdownlint so tables are formatted first.
+      - entry: pnpm exec oxfmt --write
+        files: \.(json[5c]?|md|ya?ml)$
+        id: oxfmt
+        language: system
+        name: oxfmt
+      - entry: pnpm exec eslint --fix --max-warnings=0
+        files: \.(ts|mts|cts|js|mjs|cjs|json|ya?ml)$
+        id: eslint
+        language: system
+        name: eslint
+      - entry: pnpm exec oxlint --fix
+        files: \.(ts|mts|cts|js|mjs|cjs)$
+        id: oxlint
+        language: system
+        name: oxlint
+    repo: local
   - hooks:
       - args: [--fix]
         id: markdownlint-cli2
         name: '[Markdown] Lint/Fix'
     repo: https://github.com/DavidAnson/markdownlint-cli2
     rev: v0.22.0
-  # language: system because the config packages aren't published yet.
-  # Consumers should use language: node with additional_dependencies.
-  - hooks:
-      - entry: pnpm exec eslint --max-warnings=0
-        files: \.(ts|mts|cts|js|mjs|cjs|json|ya?ml)$
-        id: eslint
-        language: system
-        name: eslint
-      - entry: pnpm exec oxfmt --write
-        files: \.(json[5c]?|md|ya?ml)$
-        id: oxfmt
-        language: system
-        name: oxfmt
-      - entry: pnpm exec oxlint
-        files: \.(ts|mts|cts|js|mjs|cjs)$
-        id: oxlint
-        language: system
-        name: oxlint
-    repo: local


### PR DESCRIPTION
## Summary

- Move oxfmt before markdownlint so tables are formatted before linting
- Add `--fix` to eslint and oxlint hooks for auto-fixing on commit

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)