### PR TITLE
Fix oxlint @stylistic/brace-style to enforce 1TBS

### DIFF
--- a/packages/cli/src/lib/process.ts
+++ b/packages/cli/src/lib/process.ts
@@ -21,8 +21,7 @@ export const run = async (
     child.on('close', (code) => {
       if (code === 0) {
         resolve();
-      }
-      else {
+      } else {
         reject(new Error(`${command} exited with code ${String(code)}`));
       }
     });
@@ -48,8 +47,7 @@ export const runParallel = async (
         killOthersOn: ['failure'],
       },
     ).result;
-  }
-  catch {
+  } catch {
     const names = commands.map(cmd => cmd.name).join(', ');
     throw new Error(`Parallel execution failed: ${names}`);
   }

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -7,8 +7,7 @@ const [name, ...args] = process.argv.slice(argvOffset);
 if (name === undefined || name === '--help' || name === '-h') {
   const available = Object.keys(commands).join(', ');
   console.log(`Usage: gtb <command> [...args]\n\nCommands: ${available}`);
-}
-else {
+} else {
   const command = commands[name];
   if (command === undefined) {
     throw new Error(`Unknown command: ${name}`);

--- a/packages/oxlint-config/src/index.ts
+++ b/packages/oxlint-config/src/index.ts
@@ -183,6 +183,7 @@ export const isAndroid = process.platform === 'android';
 
 /** Default stylistic customize options for `@stylistic/eslint-plugin`. */
 export const stylisticCustomizeDefaults: StylisticCustomizeOptions = {
+  braceStyle: '1tbs',
   semi: true,
   severity: 'warn',
 };

--- a/packages/oxlint-config/test/configure.test.ts
+++ b/packages/oxlint-config/test/configure.test.ts
@@ -103,6 +103,16 @@ describe('oxlint configure', () => {
     expect(config.rules?.['@stylistic/semi']).toBeDefined();
   });
 
+  it.runIf(!isAndroid)('enforces 1tbs brace style', ({ expect }) => {
+    const config = configure();
+
+    expect(config.rules?.['@stylistic/brace-style']).toEqual([
+      'warn',
+      '1tbs',
+      { allowSingleLine: true },
+    ]);
+  });
+
   it.runIf(isAndroid)('omits stylistic rules on Android', ({ expect }) => {
     const config = configure();
 


### PR DESCRIPTION
## Summary

- Add explicit `braceStyle: '1tbs'` to `stylisticCustomizeDefaults` — the `@stylistic/eslint-plugin` `customize()` function defaults to `stroustrup`, not `1tbs`
- Fix 3 existing Stroustrup-style violations in `@gtbuchanan/cli`
- Add test asserting `@stylistic/brace-style` enforces 1TBS

Fixes #12

## Test plan

- [x] `pnpm run gtb build` passes (lint, unit tests, pack, e2e)

🤖 Generated with [Claude Code](https://claude.com/claude-code)