### PR TITLE
Add Node.js module rule handling to shared lint configs

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -1,10 +1,3 @@
 import { configure } from '@gtbuchanan/oxlint-config';
 
-export default configure({
-  overrides: [{
-    files: ['**/*.ts'],
-    rules: {
-      'import/no-nodejs-modules': 'off',
-    },
-  }],
-});
+export default configure();

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "type": "module",
   "scripts": {
-    "gtb": "node --experimental-strip-types packages/cli/src/main.ts",
+    "gtb": "node --experimental-strip-types packages/cli/bin/gtb.ts",
     "prepare": "pnpm run gtb prepare",
     "build:ci": "pnpm run gtb build:ci",
     "test:e2e": "pnpm run gtb test:e2e",

--- a/packages/cli/bin/gtb.ts
+++ b/packages/cli/bin/gtb.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { commands } from './commands/index.ts';
+import { commands } from '#src/commands/index.ts';
 
 const argvOffset = 2;
 const [name, ...args] = process.argv.slice(argvOffset);

--- a/packages/cli/bin/tsconfig.json
+++ b/packages/cli/bin/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "outDir": "../dist/source/bin",
+    "rootDir": ".",
+    "sourceMap": true
+  },
+  "extends": "../../../tsconfig.base.json",
+  "include": ["."],
+  "references": [{ "path": "../src" }]
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "Shared build CLI",
   "bin": {
-    "gtb": "./dist/source/main.js"
+    "gtb": "./dist/source/bin/gtb.js"
   },
   "type": "module",
   "imports": {
@@ -14,11 +14,14 @@
   },
   "publishConfig": {
     "bin": {
-      "gtb": "./main.js"
+      "gtb": "./bin/gtb.js"
     },
     "directory": "dist/source",
     "exports": {
       ".": "./index.js"
+    },
+    "imports": {
+      "#src/*.ts": "./*.js"
     },
     "linkDirectory": false
   },

--- a/packages/cli/src/lib/manifest.ts
+++ b/packages/cli/src/lib/manifest.ts
@@ -5,6 +5,7 @@ export const PublishConfigSchema = v.object({
   bin: v.optional(v.record(v.string(), v.string())),
   directory: v.optional(v.string()),
   exports: v.optional(v.record(v.string(), v.string())),
+  imports: v.optional(v.record(v.string(), v.string())),
   linkDirectory: v.optional(v.boolean()),
   scripts: v.optional(v.record(v.string(), v.string())),
 });
@@ -56,8 +57,8 @@ export const buildRepoFields = (
 
 /**
  * Strips `devDependencies` and `scripts`, then promotes `publishConfig.bin`,
- * `publishConfig.exports`, and `publishConfig.scripts` to top-level fields
- * for publishing.
+ * `publishConfig.exports`, `publishConfig.imports`, and
+ * `publishConfig.scripts` to top-level fields for publishing.
  */
 export const buildOutput = (manifest: Manifest): Manifest => {
   const {
@@ -74,6 +75,16 @@ export const buildOutput = (manifest: Manifest): Manifest => {
     }),
     ...(publishConfig?.exports && {
       exports: publishConfig.exports,
+    }),
+    /*
+     * Pnpm doesn't natively promote publishConfig.imports. Needed because
+     * rewriteRelativeImportExtensions only rewrites relative imports, not
+     * subpath imports (#src/*). Dev uses .ts extensions resolved via the
+     * source imports map; published packages need .ts → .js rewriting
+     * via a separate imports map (e.g. "#src/*.ts": "./*.js").
+     */
+    ...(publishConfig?.imports && {
+      imports: publishConfig.imports,
     }),
     ...(publishConfig?.scripts && {
       scripts: publishConfig.scripts,

--- a/packages/cli/test/manifest.test.ts
+++ b/packages/cli/test/manifest.test.ts
@@ -46,6 +46,17 @@ describe(buildOutput, () => {
     expect(result['bin']).toEqual({ gtb: './bin.js' });
   });
 
+  it('remaps publishConfig.imports to top-level imports', ({ expect }) => {
+    const result = buildOutput({
+      imports: { '#src/*': './src/*' },
+      publishConfig: {
+        imports: { '#src/*.ts': './*.js' },
+      },
+    });
+
+    expect(result['imports']).toEqual({ '#src/*.ts': './*.js' });
+  });
+
   it('strips publishConfig from output', ({ expect }) => {
     const result = buildOutput({
       publishConfig: {

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "files": [],
-  "references": [{ "path": "src" }, { "path": "test" }, { "path": "e2e" }]
+  "references": [{ "path": "bin" }, { "path": "src" }, { "path": "test" }, { "path": "e2e" }]
 }

--- a/packages/eslint-config/src/index.ts
+++ b/packages/eslint-config/src/index.ts
@@ -1,6 +1,7 @@
 import json from '@eslint/json';
 import eslintCommentsConfigs from '@eslint-community/eslint-plugin-eslint-comments/configs';
 import {
+  defaultEntryPoints,
   eslintCommentsRuleOverrides,
   importOrderRules,
   isAndroid,
@@ -31,8 +32,9 @@ export interface ESLintConfigureOptions {
    */
   readonly ignores?: string[];
   /**
-   * File patterns where `process.exit` and hashbang are allowed.
-   * @defaultValue Bin directories and main entry points
+   * File patterns for entry points exempt from `process.exit` and hashbang
+   * restrictions.
+   * @defaultValue {@link defaultEntryPoints}
    */
   readonly entryPoints?: string[];
   /**
@@ -196,7 +198,7 @@ const vitestConfigs: Linter.Config[] = [
  */
 export const configure = async (options: ESLintConfigureOptions = {}): Promise<Linter.Config[]> => {
   const {
-    entryPoints = ['**/bin/**/*.ts', '**/main.ts'],
+    entryPoints = [...defaultEntryPoints],
     extraConfigs = [],
     ignores = ['.claude/worktrees/**', '**/dist/**', '**/pnpm-lock.yaml'],
     onlyWarn = true,

--- a/packages/oxlint-config/src/index.ts
+++ b/packages/oxlint-config/src/index.ts
@@ -27,6 +27,12 @@ export interface OxlintConfigureOptions {
    */
   readonly options?: Partial<OxlintConfig['options']>;
   /**
+   * File patterns for entry points exempt from browser-only restrictions
+   * (e.g. `import/no-nodejs-modules`, `no-console`).
+   * @defaultValue Bin directories, scripts directories, and main entry points
+   */
+  readonly entryPoints?: string[];
+  /**
    * Additional rule overrides appended after the built-in vitest overrides.
    * @defaultValue []
    */
@@ -37,8 +43,9 @@ export interface OxlintConfigureOptions {
    */
   readonly stylistic?: StylisticCustomizeOptions;
   /**
-   * Target environment. Browser targets enable `no-console` and `no-alert`.
-   * Scripts and bin directories are always exempt from `no-console`.
+   * Target environment. Server targets disable `import/no-nodejs-modules`.
+   * Browser targets enable `no-console` and `no-alert`; entry points are
+   * exempt from both `no-console` and `import/no-nodejs-modules`.
    * @defaultValue 'server'
    */
   readonly target?: 'browser' | 'server';
@@ -180,6 +187,12 @@ const eslintCommentsRecommendedRules: DummyRuleMap = {
 // https://github.com/oxc-project/oxc/issues/21045
 /** Whether the current platform is Android (Termux). */
 export const isAndroid = process.platform === 'android';
+
+/** Default file patterns for entry points (bin and scripts directories). */
+export const defaultEntryPoints: readonly string[] = [
+  '**/bin/**/*.ts',
+  '**/scripts/**/*.ts',
+];
 
 /** Default stylistic customize options for `@stylistic/eslint-plugin`. */
 export const stylisticCustomizeDefaults: StylisticCustomizeOptions = {
@@ -355,11 +368,11 @@ const browserOverride: OxlintOverride = {
   },
 };
 
-const browserConsoleExemption: OxlintOverride = {
-  files: ['**/scripts/**/*.ts', '**/bin/**/*.ts'],
+const serverOverride: OxlintOverride = {
+  files: ['**/*.ts'],
   rules: {
-    // Justification: Scripts and CLIs use console as their interface
-    'no-console': 'off',
+    // Justification: Server code uses Node.js built-in modules
+    'import/no-nodejs-modules': 'off',
   },
 };
 
@@ -372,6 +385,7 @@ const browserConsoleExemption: OxlintOverride = {
 export const configure = (opts: OxlintConfigureOptions = {}): OxlintConfig => {
   const {
     categories: categoryOverrides,
+    entryPoints = [...defaultEntryPoints],
     ignorePatterns = ['.claude/worktrees/**', '**/dist/**'],
     options: optionOverrides,
     overrides = [],
@@ -379,9 +393,19 @@ export const configure = (opts: OxlintConfigureOptions = {}): OxlintConfig => {
     target = 'server',
   } = opts;
 
+  const browserEntryPointExemption: OxlintOverride = {
+    files: entryPoints,
+    rules: {
+      // Justification: Entry points and scripts are Node.js by nature
+      'import/no-nodejs-modules': 'off',
+      // Justification: Scripts and CLIs use console as their interface
+      'no-console': 'off',
+    },
+  };
+
   const targetOverrides = target === 'browser'
-    ? [browserOverride, browserConsoleExemption]
-    : [];
+    ? [browserOverride, browserEntryPointExemption]
+    : [serverOverride];
 
   return defineConfig({
     categories: {

--- a/packages/oxlint-config/test/configure.test.ts
+++ b/packages/oxlint-config/test/configure.test.ts
@@ -1,5 +1,5 @@
 import { describe, it } from 'vitest';
-import { configure } from '#src/index.js';
+import { configure, defaultEntryPoints } from '#src/index.js';
 
 const isAndroid = process.platform === 'android';
 
@@ -240,5 +240,54 @@ describe('oxlint configure', () => {
     const config = configure();
 
     expect(config.rules?.['class-methods-use-this']).toBe('warn');
+  });
+
+  it('exports defaultEntryPoints with bin and scripts', ({ expect }) => {
+    expect(defaultEntryPoints).toEqual([
+      '**/bin/**/*.ts',
+      '**/scripts/**/*.ts',
+    ]);
+  });
+
+  it('disables import/no-nodejs-modules for server target', ({ expect }) => {
+    const config = configure();
+    const nodeModulesOverride = config.overrides?.find(
+      override => override.rules?.['import/no-nodejs-modules'] === 'off' &&
+        override.files.includes('**/*.ts'),
+    );
+
+    expect(nodeModulesOverride).toBeDefined();
+  });
+
+  it('does not disable import/no-nodejs-modules globally for browser target', ({ expect }) => {
+    const config = configure({ target: 'browser' });
+    const globalDisable = config.overrides?.find(
+      override => override.rules?.['import/no-nodejs-modules'] === 'off' &&
+        override.files.includes('**/*.ts') &&
+        !override.rules['no-console'],
+    );
+
+    expect(globalDisable).toBeUndefined();
+  });
+
+  it('exempts entry points from import/no-nodejs-modules in browser target', ({ expect }) => {
+    const config = configure({ target: 'browser' });
+    const exemption = config.overrides?.find(
+      override => override.rules?.['import/no-nodejs-modules'] === 'off' &&
+        override.rules['no-console'] === 'off',
+    );
+
+    expect(exemption?.files).toContain('**/bin/**/*.ts');
+    expect(exemption?.files).toContain('**/scripts/**/*.ts');
+  });
+
+  it('uses custom entryPoints for browser exemptions', ({ expect }) => {
+    const custom = ['**/cli/**/*.ts'];
+    const config = configure({ entryPoints: custom, target: 'browser' });
+    const exemption = config.overrides?.find(
+      override => override.rules?.['import/no-nodejs-modules'] === 'off',
+    );
+
+    expect(exemption?.files).toEqual(custom);
   });
 });


### PR DESCRIPTION
## Summary

- Move `import/no-nodejs-modules` management into `@gtbuchanan/oxlint-config` via the `target` option: server disables the rule globally, browser exempts `entryPoints`
- Export `defaultEntryPoints` from oxlint-config and share it with eslint-config
- Add `**/scripts/**/*.ts` to ESLint entry points default, remove `**/main.ts` (ambiguous in browser frameworks like Angular)

## Test plan

- [x] Unit tests added for server/browser target behavior, custom entry points, and `defaultEntryPoints` export
- [x] Existing tests pass (oxlint-config: 33 tests, eslint-config: 11 tests)
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)