### PR TITLE
Add per-package vitest.config.e2e.ts for E2E runs

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,10 +1,8 @@
 codecov:
   require_ci_to_pass: true
-
 comment:
   layout: condensed_header, condensed_files, condensed_footer
   require_changes: true
-
 component_management:
   default_rules:
     statuses:
@@ -12,33 +10,31 @@ component_management:
         threshold: 1%
         type: project
   individual_components:
-    - component_id: cli
-      name: cli
-      paths:
-        - packages/cli/bin/**
-        - packages/cli/scripts/**
-        - packages/cli/src/**
-    - component_id: eslint-config
-      name: eslint-config
-      paths:
-        - packages/eslint-config/src/**
-    - component_id: oxfmt-config
-      name: oxfmt-config
-      paths:
-        - packages/oxfmt-config/src/**
-    - component_id: oxlint-config
-      name: oxlint-config
-      paths:
-        - packages/oxlint-config/src/**
-    - component_id: test-utils
-      name: test-utils
-      paths:
-        - packages/test-utils/src/**
     - component_id: vitest-config
       name: vitest-config
       paths:
         - packages/vitest-config/src/**
-
+    - component_id: test-utils
+      name: test-utils
+      paths:
+        - packages/test-utils/src/**
+    - component_id: oxlint-config
+      name: oxlint-config
+      paths:
+        - packages/oxlint-config/src/**
+    - component_id: oxfmt-config
+      name: oxfmt-config
+      paths:
+        - packages/oxfmt-config/src/**
+    - component_id: eslint-config
+      name: eslint-config
+      paths:
+        - packages/eslint-config/src/**
+    - component_id: cli
+      name: cli
+      paths:
+        - packages/cli/bin/**
+        - packages/cli/src/**
 coverage:
   status:
     patch:
@@ -48,7 +44,6 @@ coverage:
       default:
         target: auto
         threshold: 1%
-
 flags:
   cli:
     carryforward: true
@@ -74,7 +69,6 @@ flags:
     carryforward: true
     paths:
       - packages/vitest-config/
-
 ignore:
   - '**/dist/**'
   - '**/e2e/**'

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -35,7 +35,8 @@
     "coverage:vitest:merge": "pnpm run gtb coverage:vitest:merge",
     "typecheck:ts": "pnpm run gtb typecheck:ts",
     "gtb": "node --experimental-strip-types ../../packages/cli/bin/gtb.ts",
-    "coverage:codecov:upload": "pnpm run gtb coverage:codecov:upload"
+    "coverage:codecov:upload": "pnpm run gtb coverage:codecov:upload",
+    "test:vitest:e2e": "pnpm run gtb test:vitest:e2e"
   },
   "dependencies": {
     "cross-spawn": "catalog:",

--- a/packages/cli/src/commands/leaf/test-vitest-e2e.ts
+++ b/packages/cli/src/commands/leaf/test-vitest-e2e.ts
@@ -2,7 +2,10 @@ import type { RunCommandDef } from '../types.ts';
 
 /** Runs end-to-end tests via Vitest with the e2e config. */
 export const def = {
-  args: ['run', '--config', 'vitest.config.e2e.ts'],
+  args: [
+    'run', '--config', 'vitest.config.e2e.ts',
+    '--outputFile.blob=dist/test-results/vitest/blob-e2e.json',
+  ],
   bin: 'vitest',
   name: 'test:vitest:e2e',
 } as const satisfies RunCommandDef;

--- a/packages/cli/src/lib/turbo-config.ts
+++ b/packages/cli/src/lib/turbo-config.ts
@@ -203,7 +203,7 @@ const testTasks = (flags: ToolFlags): readonly ConditionalEntry<TurboTask>[] => 
         dependsOn: flags.hasPublished ? [Aggregate.pack, topo(Aggregate.pack)] : [],
         env: ['CI'],
         inputs: ['e2e/**', 'vitest.config.e2e.*'],
-        outputs: [],
+        outputs: ['dist/test-results/vitest/blob-e2e.json'],
       },
     },
   ];

--- a/packages/cli/src/lib/turbo-config.ts
+++ b/packages/cli/src/lib/turbo-config.ts
@@ -78,7 +78,7 @@ export const resolveToolFlags = (discovery: WorkspaceDiscovery): ToolFlags => {
   return {
     generateScripts,
     hasCheck: hasTypeScript || hasLint || hasVitest,
-    hasE2e: discovery.root.hasVitestE2e,
+    hasE2e: discovery.root.hasVitestE2e || discovery.packages.some(pkg => pkg.hasVitestE2e),
     hasEslint,
     hasGenerate: generateScripts.length > 0,
     hasLint,

--- a/packages/cli/src/lib/turbo-scripts.ts
+++ b/packages/cli/src/lib/turbo-scripts.ts
@@ -1,8 +1,8 @@
 import { relative } from 'node:path';
 import {
   compileTs, coverageCodecovUpload, coverageVitestMerge, lintEslint,
-  lintOxlint, packNpm, prepare, testVitestFast, testVitestSlow,
-  turboCheck, typecheckTs,
+  lintOxlint, packNpm, prepare, testVitestE2e, testVitestFast,
+  testVitestSlow, turboCheck, typecheckTs,
 } from '../commands/leaf/index.ts';
 import type { PackageCapabilities, WorkspaceDiscovery } from './discovery.ts';
 import {
@@ -38,6 +38,11 @@ const packageScriptEntries = (
       condition: caps.hasVitestTests,
       key: testVitestSlow.name,
       value: cmd(testVitestSlow),
+    },
+    {
+      condition: caps.hasVitestE2e,
+      key: testVitestE2e.name,
+      value: cmd(testVitestE2e),
     },
     {
       condition: caps.hasVitestTests,

--- a/packages/cli/test/turbo-scripts.test.ts
+++ b/packages/cli/test/turbo-scripts.test.ts
@@ -40,6 +40,14 @@ describe.concurrent(generatePackageScripts, () => {
     expect(result).toHaveProperty('test:vitest:slow', 'gtb test:vitest:slow');
   });
 
+  it('generates test:vitest:e2e for packages with e2e vitest config', ({ expect }) => {
+    const caps = makeCapabilities({ hasVitestE2e: true });
+
+    const result = generatePackageScripts(caps, false);
+
+    expect(result).toHaveProperty('test:vitest:e2e', 'gtb test:vitest:e2e');
+  });
+
   it('generates gtb shim for self-hosted packages', ({ expect }) => {
     const caps = makeCapabilities({ dir: '/root/packages/app', hasTypeScript: true });
 

--- a/packages/cli/vitest.config.e2e.ts
+++ b/packages/cli/vitest.config.e2e.ts
@@ -1,0 +1,3 @@
+import { configureEndToEndPackage } from '@gtbuchanan/vitest-config/configure-e2e';
+
+export default configureEndToEndPackage();

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -26,7 +26,8 @@
     "coverage:vitest:merge": "pnpm run gtb coverage:vitest:merge",
     "typecheck:ts": "pnpm run gtb typecheck:ts",
     "gtb": "node --experimental-strip-types ../../packages/cli/bin/gtb.ts",
-    "coverage:codecov:upload": "pnpm run gtb coverage:codecov:upload"
+    "coverage:codecov:upload": "pnpm run gtb coverage:codecov:upload",
+    "test:vitest:e2e": "pnpm run gtb test:vitest:e2e"
   },
   "dependencies": {
     "@eslint-community/eslint-plugin-eslint-comments": "catalog:",

--- a/packages/eslint-config/vitest.config.e2e.ts
+++ b/packages/eslint-config/vitest.config.e2e.ts
@@ -1,0 +1,3 @@
+import { configureEndToEndPackage } from '@gtbuchanan/vitest-config/configure-e2e';
+
+export default configureEndToEndPackage();

--- a/packages/markdownlint-config/package.json
+++ b/packages/markdownlint-config/package.json
@@ -19,7 +19,8 @@
     "lint:eslint": "pnpm run gtb lint:eslint",
     "lint:oxlint": "pnpm run gtb lint:oxlint",
     "typecheck:ts": "pnpm run gtb typecheck:ts",
-    "gtb": "node --experimental-strip-types ../../packages/cli/bin/gtb.ts"
+    "gtb": "node --experimental-strip-types ../../packages/cli/bin/gtb.ts",
+    "test:vitest:e2e": "pnpm run gtb test:vitest:e2e"
   },
   "dependencies": {
     "markdownlint": "catalog:"
@@ -27,7 +28,8 @@
   "devDependencies": {
     "@gtbuchanan/eslint-config": "workspace:*",
     "@gtbuchanan/oxlint-config": "workspace:*",
-    "@gtbuchanan/test-utils": "workspace:*"
+    "@gtbuchanan/test-utils": "workspace:*",
+    "@gtbuchanan/vitest-config": "workspace:*"
   },
   "engines": {
     "node": ">=22.17"

--- a/packages/markdownlint-config/vitest.config.e2e.ts
+++ b/packages/markdownlint-config/vitest.config.e2e.ts
@@ -1,0 +1,3 @@
+import { configureEndToEndPackage } from '@gtbuchanan/vitest-config/configure-e2e';
+
+export default configureEndToEndPackage();

--- a/packages/oxfmt-config/package.json
+++ b/packages/oxfmt-config/package.json
@@ -26,7 +26,8 @@
     "coverage:vitest:merge": "pnpm run gtb coverage:vitest:merge",
     "typecheck:ts": "pnpm run gtb typecheck:ts",
     "gtb": "node --experimental-strip-types ../../packages/cli/bin/gtb.ts",
-    "coverage:codecov:upload": "pnpm run gtb coverage:codecov:upload"
+    "coverage:codecov:upload": "pnpm run gtb coverage:codecov:upload",
+    "test:vitest:e2e": "pnpm run gtb test:vitest:e2e"
   },
   "devDependencies": {
     "@gtbuchanan/eslint-config": "workspace:*",

--- a/packages/oxfmt-config/vitest.config.e2e.ts
+++ b/packages/oxfmt-config/vitest.config.e2e.ts
@@ -1,0 +1,3 @@
+import { configureEndToEndPackage } from '@gtbuchanan/vitest-config/configure-e2e';
+
+export default configureEndToEndPackage();

--- a/packages/oxlint-config/package.json
+++ b/packages/oxlint-config/package.json
@@ -26,7 +26,8 @@
     "coverage:vitest:merge": "pnpm run gtb coverage:vitest:merge",
     "typecheck:ts": "pnpm run gtb typecheck:ts",
     "gtb": "node --experimental-strip-types ../../packages/cli/bin/gtb.ts",
-    "coverage:codecov:upload": "pnpm run gtb coverage:codecov:upload"
+    "coverage:codecov:upload": "pnpm run gtb coverage:codecov:upload",
+    "test:vitest:e2e": "pnpm run gtb test:vitest:e2e"
   },
   "dependencies": {
     "@eslint-community/eslint-plugin-eslint-comments": "catalog:",

--- a/packages/oxlint-config/vitest.config.e2e.ts
+++ b/packages/oxlint-config/vitest.config.e2e.ts
@@ -1,0 +1,4 @@
+// Relative import avoids circular dependency (vitest-config depends on oxlint-config)
+import { configureEndToEndPackage } from '../vitest-config/src/configure-e2e.ts';
+
+export default configureEndToEndPackage();

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -19,12 +19,14 @@
     "lint:eslint": "pnpm run gtb lint:eslint",
     "lint:oxlint": "pnpm run gtb lint:oxlint",
     "typecheck:ts": "pnpm run gtb typecheck:ts",
-    "gtb": "node --experimental-strip-types ../../packages/cli/bin/gtb.ts"
+    "gtb": "node --experimental-strip-types ../../packages/cli/bin/gtb.ts",
+    "test:vitest:e2e": "pnpm run gtb test:vitest:e2e"
   },
   "devDependencies": {
     "@gtbuchanan/eslint-config": "workspace:*",
     "@gtbuchanan/oxlint-config": "workspace:*",
     "@gtbuchanan/test-utils": "workspace:*",
+    "@gtbuchanan/vitest-config": "workspace:*",
     "@tsconfig/strictest": "catalog:"
   },
   "engines": {

--- a/packages/tsconfig/vitest.config.e2e.ts
+++ b/packages/tsconfig/vitest.config.e2e.ts
@@ -1,0 +1,3 @@
+import { configureEndToEndPackage } from '@gtbuchanan/vitest-config/configure-e2e';
+
+export default configureEndToEndPackage();

--- a/packages/vitest-config/package.json
+++ b/packages/vitest-config/package.json
@@ -34,7 +34,8 @@
     "coverage:vitest:merge": "pnpm run gtb coverage:vitest:merge",
     "typecheck:ts": "pnpm run gtb typecheck:ts",
     "gtb": "node --experimental-strip-types ../../packages/cli/bin/gtb.ts",
-    "coverage:codecov:upload": "pnpm run gtb coverage:codecov:upload"
+    "coverage:codecov:upload": "pnpm run gtb coverage:codecov:upload",
+    "test:vitest:e2e": "pnpm run gtb test:vitest:e2e"
   },
   "dependencies": {
     "console-fail-test": "catalog:",

--- a/packages/vitest-config/src/configure-e2e.ts
+++ b/packages/vitest-config/src/configure-e2e.ts
@@ -10,6 +10,7 @@ import {
   buildGlobalConfig,
   buildProjectConfig,
   buildWorkspaceEntry,
+  findConfigFile,
   resolveProjectDirs,
 } from './configure.ts';
 
@@ -33,6 +34,8 @@ export interface VitestEndToEndConfigureGlobalOptions extends VitestConfigureGlo
 
 const e2eTestInclude = ['e2e/**/*.test.ts'] as const;
 
+const e2eConfigPrefix = 'vitest.config.e2e';
+
 /**
  * Per-project e2e configuration for use with vitest projects.
  * Sets excludes and e2e include pattern. Does not include global-only settings.
@@ -40,22 +43,31 @@ const e2eTestInclude = ['e2e/**/*.test.ts'] as const;
 export const configureEndToEndProject = (): UserWorkspaceConfig =>
   buildProjectConfig(e2eTestInclude);
 
+const buildE2eProjectEntry = (
+  dir: string,
+  testTimeout: number,
+): string | UserWorkspaceConfig => {
+  const configPath = findConfigFile(dir, e2eConfigPrefix);
+  if (configPath !== undefined) {
+    return configPath;
+  }
+  const entry = buildWorkspaceEntry(dir, configureEndToEndProject);
+  return { ...entry, test: { ...entry.test, testTimeout } };
+};
+
 const resolveEndToEndProjects = (
   patterns: readonly string[],
   testTimeout: number,
-): UserWorkspaceConfig[] =>
-  resolveProjectDirs(patterns).map((dir) => {
-    const entry = buildWorkspaceEntry(dir, configureEndToEndProject);
-    return { ...entry, test: { ...entry.test, testTimeout } };
-  });
+): (string | UserWorkspaceConfig)[] =>
+  resolveProjectDirs(patterns).map(dir =>
+    buildE2eProjectEntry(dir, testTimeout),
+  );
 
 /**
  * Global e2e configuration for use in a root vitest.config.e2e.ts of a monorepo.
  * Sets setupFiles, testTimeout, and other global-only settings. Does not include coverage.
- * When `projects` is provided, generates inline project entries for each
- * resolved directory using {@link configureEndToEndProject}. Unlike the unit
- * test variant, e2e always generates inline configs (no per-package e2e config
- * file convention).
+ * When `projects` is provided, directories with their own `vitest.config.e2e.*`
+ * are included as-is; others get inline entries via {@link configureEndToEndProject}.
  */
 export const configureEndToEndGlobal = (
   options: VitestEndToEndConfigureGlobalOptions = {},
@@ -71,6 +83,24 @@ export const configureEndToEndGlobal = (
   );
 };
 
+const buildCombinedE2eConfig = (
+  options: VitestEndToEndConfigureOptions,
+  includeTestPatterns: boolean,
+): ViteUserConfig => {
+  const project = configureEndToEndProject();
+  return mergeConfig(
+    configureEndToEndGlobal(options),
+    defineConfig({
+      test: {
+        ...(project.test?.exclude && { exclude: project.test.exclude }),
+        ...(includeTestPatterns && project.test?.include && {
+          include: project.test.include,
+        }),
+      },
+    }),
+  );
+};
+
 /**
  * Combined e2e configuration for single-project consumers.
  * Composes global e2e settings with project-level excludes.
@@ -78,14 +108,13 @@ export const configureEndToEndGlobal = (
  */
 export const configureEndToEnd = (
   options: VitestEndToEndConfigureOptions = {},
-): ViteUserConfig => {
-  const project = configureEndToEndProject();
-  return mergeConfig(
-    configureEndToEndGlobal(options),
-    defineConfig({
-      ...(project.test?.exclude && {
-        test: { exclude: project.test.exclude },
-      }),
-    }),
-  );
-};
+): ViteUserConfig => buildCombinedE2eConfig(options, false);
+
+/**
+ * Per-package e2e configuration for Turborepo-managed monorepos.
+ * Composes global e2e settings with project-level includes and excludes.
+ * Each package runs its own vitest instance via `vitest.config.e2e.ts`.
+ */
+export const configureEndToEndPackage = (
+  options: VitestEndToEndConfigureOptions = {},
+): ViteUserConfig => buildCombinedE2eConfig(options, true);

--- a/packages/vitest-config/src/configure.ts
+++ b/packages/vitest-config/src/configure.ts
@@ -111,15 +111,24 @@ export const resolveSetupFiles = (options: VitestConfigureOptions): string[] => 
   return setupFiles;
 };
 
-const vitestConfigFiles = [
-  'vitest.config.ts',
-  'vitest.config.js',
-  'vitest.config.mts',
-  'vitest.config.mjs',
-] as const;
+const configExtensions = ['.ts', '.js', '.mts', '.mjs'] as const;
+
+/**
+ * Finds a config file by prefix in a directory.
+ * Checks common extensions (.ts, .js, .mts, .mjs) and returns the first match.
+ */
+export const findConfigFile = (dir: string, prefix: string): string | undefined => {
+  for (const ext of configExtensions) {
+    const path = join(dir, `${prefix}${ext}`);
+    if (existsSync(path)) {
+      return path;
+    }
+  }
+  return undefined;
+};
 
 const hasVitestConfig = (dir: string): boolean =>
-  vitestConfigFiles.some(file => existsSync(join(dir, file)));
+  findConfigFile(dir, 'vitest.config') !== undefined;
 
 const globSuffix = '/*';
 const findGitRoot = (cwd: string): string | undefined => {

--- a/packages/vitest-config/src/index.ts
+++ b/packages/vitest-config/src/index.ts
@@ -20,6 +20,7 @@ export {
 export {
   configureEndToEnd,
   configureEndToEndGlobal,
+  configureEndToEndPackage,
   configureEndToEndProject,
   type VitestEndToEndConfigureGlobalOptions,
   type VitestEndToEndConfigureOptions,

--- a/packages/vitest-config/test/configure-e2e.test.ts
+++ b/packages/vitest-config/test/configure-e2e.test.ts
@@ -2,6 +2,7 @@ import { describe, it } from 'vitest';
 import {
   configureEndToEnd,
   configureEndToEndGlobal,
+  configureEndToEndPackage,
   configureEndToEndProject,
 } from '#src/configure-e2e.js';
 import { excludeDefault } from '#src/configure.js';
@@ -108,6 +109,45 @@ describe('vitest configureEndToEndGlobal', () => {
     const config = configureEndToEndGlobal();
 
     expect(config.test).not.toHaveProperty('projects');
+  });
+});
+
+describe('vitest configureEndToEndPackage', () => {
+  it('includes e2e test patterns', ({ expect }) => {
+    const config = configureEndToEndPackage();
+
+    expect(config.test?.include).toEqual(['e2e/**/*.test.ts']);
+  });
+
+  it('includes global settings (setupFiles, mockReset)', ({ expect }) => {
+    const config = configureEndToEndPackage();
+
+    expect(config.test?.setupFiles).toBeDefined();
+    expect(config.test?.mockReset).toBe(true);
+  });
+
+  it('does not include coverage', ({ expect }) => {
+    const config = configureEndToEndPackage();
+
+    expect(config.test?.coverage).toBeUndefined();
+  });
+
+  it('includes testTimeout', ({ expect }) => {
+    const config = configureEndToEndPackage();
+
+    expect(config.test?.testTimeout).toBe(300_000);
+  });
+
+  it('accepts custom testTimeout', ({ expect }) => {
+    const config = configureEndToEndPackage({ testTimeout: 120_000 });
+
+    expect(config.test?.testTimeout).toBe(120_000);
+  });
+
+  it('includes default excludes', ({ expect }) => {
+    const config = configureEndToEndPackage();
+
+    expect(config.test?.exclude).toContain('**/dist/**');
   });
 });
 

--- a/packages/vitest-config/vitest.config.e2e.ts
+++ b/packages/vitest-config/vitest.config.e2e.ts
@@ -1,0 +1,3 @@
+import { configureEndToEndPackage } from './src/configure-e2e.ts';
+
+export default configureEndToEndPackage();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -280,6 +280,9 @@ importers:
       '@gtbuchanan/test-utils':
         specifier: workspace:*
         version: link:../test-utils
+      '@gtbuchanan/vitest-config':
+        specifier: workspace:*
+        version: link:../vitest-config
     publishDirectory: dist/source
 
   packages/oxfmt-config:
@@ -352,6 +355,9 @@ importers:
       '@gtbuchanan/test-utils':
         specifier: workspace:*
         version: link:../test-utils
+      '@gtbuchanan/vitest-config':
+        specifier: workspace:*
+        version: link:../vitest-config
       '@tsconfig/strictest':
         specifier: 'catalog:'
         version: 2.0.8

--- a/turbo.json
+++ b/turbo.json
@@ -78,7 +78,7 @@
       "dependsOn": ["pack", "^pack"],
       "env": ["CI"],
       "inputs": ["e2e/**", "vitest.config.e2e.*"],
-      "outputs": []
+      "outputs": ["dist/test-results/vitest/blob-e2e.json"]
     },
     "test:vitest:fast": {
       "dependsOn": ["^compile:ts"],


### PR DESCRIPTION
## Summary

- Add `configureEndToEndPackage` to `@gtbuchanan/vitest-config` so each package with `e2e/` tests can run self-contained via `gtb test:vitest:e2e`
- Extract shared `findConfigFile` utility and update `configureEndToEndGlobal` to detect per-package e2e configs
- Wire `test:vitest:e2e` into per-package script generation and regenerate turbo config

## Test plan

- [x] Unit tests pass (66 vitest-config, 142 CLI — all green)
- [x] `turbo:check` — no drift detected
- [x] E2E tests pass for all packages except CLI (pre-existing `pack` command rename issue)

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)