### PR TITLE
Add unit tests for markdownlint-config

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -26,6 +26,10 @@ component_management:
       name: oxfmt-config
       paths:
         - packages/oxfmt-config/src/**
+    - component_id: markdownlint-config
+      name: markdownlint-config
+      paths:
+        - packages/markdownlint-config/src/**
     - component_id: eslint-config
       name: eslint-config
       paths:
@@ -53,6 +57,10 @@ flags:
     carryforward: true
     paths:
       - packages/eslint-config/
+  markdownlint-config:
+    carryforward: true
+    paths:
+      - packages/markdownlint-config/
   oxfmt-config:
     carryforward: true
     paths:

--- a/packages/markdownlint-config/package.json
+++ b/packages/markdownlint-config/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "description": "Shared markdownlint configuration",
   "type": "module",
+  "imports": {
+    "#src/*": "./src/*"
+  },
   "exports": {
     ".": "./src/index.mjs"
   },
@@ -20,7 +23,11 @@
     "lint:oxlint": "pnpm run gtb lint:oxlint",
     "typecheck:ts": "pnpm run gtb typecheck:ts",
     "gtb": "node --experimental-strip-types ../../packages/cli/bin/gtb.ts",
-    "test:vitest:e2e": "pnpm run gtb test:vitest:e2e"
+    "test:vitest:e2e": "pnpm run gtb test:vitest:e2e",
+    "test:vitest:fast": "pnpm run gtb test:vitest:fast",
+    "test:vitest:slow": "pnpm run gtb test:vitest:slow",
+    "coverage:codecov:upload": "pnpm run gtb coverage:codecov:upload",
+    "coverage:vitest:merge": "pnpm run gtb coverage:vitest:merge"
   },
   "dependencies": {
     "markdownlint": "catalog:"

--- a/packages/markdownlint-config/src/index.mjs
+++ b/packages/markdownlint-config/src/index.mjs
@@ -21,7 +21,7 @@ const identity = val => val;
  * @param {(defaults: Readonly<Configuration>) => Configuration} [fn]
  * @returns {Configuration}
  */
-export const configure = (fn = identity) => fn(defaults);
+export const configure = (fn = identity) => fn({ ...defaults });
 
 /** @typedef {{ ignores?: string[] }} Cli2Options */
 
@@ -37,4 +37,5 @@ const cli2Defaults = Object.freeze({
  * @param {(defaults: Readonly<Cli2Options>) => Cli2Options} [fn]
  * @returns {Cli2Options}
  */
-export const configureCli2 = (fn = identity) => fn(cli2Defaults);
+export const configureCli2 = (fn = identity) =>
+  fn({ ...cli2Defaults, ignores: [...(cli2Defaults.ignores ?? [])] });

--- a/packages/markdownlint-config/test/configure.test.ts
+++ b/packages/markdownlint-config/test/configure.test.ts
@@ -1,0 +1,70 @@
+import { describe, it } from 'vitest';
+import { configure, configureCli2 } from '#src/index.mjs';
+
+describe('markdownlint configure', () => {
+  it('disables single-trailing-newline by default', ({ expect }) => {
+    const config = configure();
+
+    expect(config['single-trailing-newline']).toBe(false);
+  });
+
+  it('passes defaults to transform function', ({ expect }) => {
+    const config = configure(defaults => ({
+      ...defaults,
+      'line-length': false,
+    }));
+
+    expect(config['line-length']).toBe(false);
+    expect(config['single-trailing-newline']).toBe(false);
+  });
+
+  it('allows replacing defaults via transform', ({ expect }) => {
+    const config = configure(() => ({
+      'line-length': false,
+    }));
+
+    expect(config['line-length']).toBe(false);
+    expect(config['single-trailing-newline']).toBeUndefined();
+  });
+
+  it('does not share state between calls', ({ expect }) => {
+    const first = configure();
+    first['custom-rule'] = true;
+    const second = configure();
+
+    expect(second).not.toHaveProperty('custom-rule');
+  });
+});
+
+describe('markdownlint configureCli2', () => {
+  it('ignores .changeset by default', ({ expect }) => {
+    const config = configureCli2();
+
+    expect(config.ignores).toEqual(['.changeset/**']);
+  });
+
+  it('passes defaults to transform function', ({ expect }) => {
+    const config = configureCli2(defaults => ({
+      ...defaults,
+      ignores: [...(defaults.ignores ?? []), 'vendor/**'],
+    }));
+
+    expect(config.ignores).toEqual(['.changeset/**', 'vendor/**']);
+  });
+
+  it('allows replacing defaults via transform', ({ expect }) => {
+    const config = configureCli2(() => ({
+      ignores: ['custom/**'],
+    }));
+
+    expect(config.ignores).toEqual(['custom/**']);
+  });
+
+  it('does not share state between calls', ({ expect }) => {
+    const first = configureCli2();
+    first.ignores?.push('leaked/**');
+    const second = configureCli2();
+
+    expect(second.ignores).not.toContain('leaked/**');
+  });
+});

--- a/packages/markdownlint-config/vitest.config.ts
+++ b/packages/markdownlint-config/vitest.config.ts
@@ -1,0 +1,3 @@
+import { configurePackage } from '@gtbuchanan/vitest-config/configure';
+
+export default configurePackage();


### PR DESCRIPTION
Closes #26

## Summary

- Add unit tests for `configure()` and `configureCli2()` with vitest config using `configurePackage()`
- Fix shallow-freeze bug where `configureCli2()` shared its `ignores` array across calls (defensive copy, matching `oxfmt-config` pattern)
- Wire up test scripts via `turbo:init` and restore Codecov flag/component for `markdownlint-config`

## Test plan

- [x] `pnpm -C packages/markdownlint-config run test:vitest:fast` — 8 tests pass
- [x] `pnpm -C packages/markdownlint-config run typecheck:ts` — clean
- [x] `pnpm -C packages/markdownlint-config run lint:oxlint` — clean
- [x] `pnpm -C packages/markdownlint-config run lint:eslint` — clean
- [x] `pnpm run gtb turbo:check` — no drift detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)