### PR TITLE
Use function references in describe blocks

### DIFF
--- a/packages/cli/test/turbo-check.test.ts
+++ b/packages/cli/test/turbo-check.test.ts
@@ -115,7 +115,7 @@ describe('turbo:check drift detection', () => {
   });
 });
 
-describe('turbo:check command', () => {
+describe(turboCheck, () => {
   const runInDir = (dir: string, fn: () => void): void => {
     const origCwd = process.cwd();
     const origExitCode = process.exitCode;

--- a/packages/cli/test/turbo-init.test.ts
+++ b/packages/cli/test/turbo-init.test.ts
@@ -68,7 +68,7 @@ const createConsumerProject = (): string => {
   return root;
 };
 
-describe('turbo:init integration', () => {
+describe(turboInit, () => {
   it('generates turbo.json with correct tasks for consumer project', ({ expect }) => {
     const root = createConsumerProject();
     const discovery = discoverWorkspace({ cwd: root });

--- a/packages/eslint-config/test/configure.test.ts
+++ b/packages/eslint-config/test/configure.test.ts
@@ -9,7 +9,7 @@ vi.mock(import('eslint-plugin-only-warn'), () => {
   return {};
 });
 
-describe('ESLint configure', () => {
+describe(configure, () => {
   it('imports eslint-plugin-only-warn when onlyWarn is true', async ({ expect }) => {
     onlyWarnImport.mockClear();
 

--- a/packages/markdownlint-config/test/configure.test.ts
+++ b/packages/markdownlint-config/test/configure.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from 'vitest';
 import { configure, configureCli2 } from '#src/index.mjs';
 
-describe('markdownlint configure', () => {
+describe(configure, () => {
   it('disables single-trailing-newline by default', ({ expect }) => {
     const config = configure();
 
@@ -36,7 +36,7 @@ describe('markdownlint configure', () => {
   });
 });
 
-describe('markdownlint configureCli2', () => {
+describe(configureCli2, () => {
   it('ignores .changeset by default', ({ expect }) => {
     const config = configureCli2();
 

--- a/packages/oxfmt-config/test/configure.test.ts
+++ b/packages/oxfmt-config/test/configure.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from 'vitest';
 import { configure } from '#src/index.js';
 
-describe('oxfmt configure', () => {
+describe(configure, () => {
   it('enables singleQuote by default', ({ expect }) => {
     const config = configure();
 

--- a/packages/oxlint-config/test/configure.test.ts
+++ b/packages/oxlint-config/test/configure.test.ts
@@ -3,7 +3,7 @@ import { configure, defaultEntryPoints } from '#src/index.js';
 
 const isAndroid = process.platform === 'android';
 
-describe('oxlint configure', () => {
+describe(configure, () => {
   it.runIf(!isAndroid)('includes jsPlugins with defaults', ({ expect }) => {
     const config = configure();
 

--- a/packages/vitest-config/test/configure-e2e.test.ts
+++ b/packages/vitest-config/test/configure-e2e.test.ts
@@ -9,7 +9,7 @@ import { excludeDefault } from '#src/configure.js';
 
 const packageName = '@gtbuchanan/vitest-config';
 
-describe('vitest configureEndToEndProject', () => {
+describe(configureEndToEndProject, () => {
   it('does not include resolve alias', ({ expect }) => {
     const config = configureEndToEndProject();
 
@@ -41,7 +41,7 @@ describe('vitest configureEndToEndProject', () => {
   });
 });
 
-describe('vitest configureEndToEndGlobal', () => {
+describe(configureEndToEndGlobal, () => {
   it('does not include coverage', ({ expect }) => {
     const config = configureEndToEndGlobal();
 
@@ -112,7 +112,7 @@ describe('vitest configureEndToEndGlobal', () => {
   });
 });
 
-describe('vitest configureEndToEndPackage', () => {
+describe(configureEndToEndPackage, () => {
   it('includes e2e test patterns', ({ expect }) => {
     const config = configureEndToEndPackage();
 
@@ -151,7 +151,7 @@ describe('vitest configureEndToEndPackage', () => {
   });
 });
 
-describe('vitest configureEndToEnd', () => {
+describe(configureEndToEnd, () => {
   it('merges global and project settings', ({ expect }) => {
     const config = configureEndToEnd();
 

--- a/packages/vitest-config/test/configure.test.ts
+++ b/packages/vitest-config/test/configure.test.ts
@@ -13,7 +13,7 @@ import {
 
 const packageName = '@gtbuchanan/vitest-config';
 
-describe('vitest configure', () => {
+describe(configure, () => {
   it('enables mockReset by default', ({ expect }) => {
     const config = configure();
 
@@ -113,7 +113,7 @@ describe('vitest configure', () => {
   });
 });
 
-describe('vitest configureGlobal', () => {
+describe(configureGlobal, () => {
   it('includes setup files', ({ expect }) => {
     const config = configureGlobal();
 
@@ -266,7 +266,7 @@ describe(buildWorkspaceEntry, () => {
   });
 });
 
-describe('vitest configureProject', () => {
+describe(configureProject, () => {
   it('does not include resolve alias', ({ expect }) => {
     const config = configureProject();
 
@@ -286,7 +286,7 @@ describe('vitest configureProject', () => {
   });
 });
 
-describe('vitest configurePackage', () => {
+describe(configurePackage, () => {
   it('includes test patterns', ({ expect }) => {
     const config = configurePackage();
 


### PR DESCRIPTION
## Summary

- Replace string literals with function references in `describe()` calls across 7 test files (13 occurrences)
- Keeps test names in sync with source code automatically

## Test plan

- [x] Typecheck passes (`turbo run typecheck:ts`)
- [x] All 237 fast tests pass (`turbo run test:vitest:fast`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)