### PR TITLE
Scope turbo task inputs to source files

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -51,6 +51,9 @@
     "@gtbuchanan/vitest-config": "workspace:*",
     "@types/cross-spawn": "catalog:"
   },
+  "peerDependencies": {
+    "typescript": ">=5.0.0"
+  },
   "engines": {
     "node": ">=22.17"
   }

--- a/packages/cli/src/lib/discovery.ts
+++ b/packages/cli/src/lib/discovery.ts
@@ -1,6 +1,7 @@
 import { existsSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import type { Manifest } from './manifest.ts';
+import { buildInclude, resolveBuildIncludes } from './tsconfig-gen.ts';
 import {
   type ResolveWorkspaceOptions,
   readParsedManifest,
@@ -9,6 +10,8 @@ import {
 
 /** Capabilities detected for a single package. */
 export interface PackageCapabilities {
+  /** Resolved `include` directories from tsconfig.build.json (published packages only). */
+  readonly buildIncludes: readonly string[];
   /** Package directory path. */
   readonly dir: string;
   /** Has a `bin/` directory. */
@@ -99,8 +102,10 @@ const buildCapabilities = (
     hasFilePrefix(files, 'vitest.config');
   const hasTest = hasDir(dir, 'test');
   const generateScripts = collectGenerateScripts(manifest);
+  const isPublished = manifest.private !== true && manifest.publishConfig?.directory !== undefined;
 
   return {
+    buildIncludes: isPublished ? resolveBuildIncludes(dir) : buildInclude,
     dir,
     generateScripts,
     hasBin: hasDir(dir, 'bin'),
@@ -114,7 +119,7 @@ const buildCapabilities = (
     hasVitest,
     hasVitestE2e: hasFilePrefix(files, 'vitest.config.e2e'),
     hasVitestTests: hasVitest && hasTest,
-    isPublished: manifest.private !== true && manifest.publishConfig?.directory !== undefined,
+    isPublished,
   };
 };
 

--- a/packages/cli/src/lib/tsconfig-gen.ts
+++ b/packages/cli/src/lib/tsconfig-gen.ts
@@ -1,4 +1,5 @@
 import { join } from 'node:path';
+import ts from 'typescript';
 import * as v from 'valibot';
 import type { PackageCapabilities } from './discovery.ts';
 import { readJsonFile } from './file-writer.ts';
@@ -7,7 +8,46 @@ import { readJsonFile } from './file-writer.ts';
 const typeCheckInclude = ['bin', 'scripts', 'src', 'test', 'e2e', '*.config.*'] as const;
 
 /** Directories included in tsconfig.build.json for compilation. */
-const buildInclude = ['bin', 'src'] as const;
+export const buildInclude = ['bin', 'src'] as const;
+
+const ReadConfigSchema = v.object({
+  config: v.unknown(),
+  error: v.optional(v.unknown()),
+});
+
+const ResolvedConfigSchema = v.object({
+  include: v.optional(v.array(v.string())),
+});
+
+const readFile = (path: string): string | undefined => ts.sys.readFile(path);
+
+/** Stub host that skips directory scanning — we only need the resolved config. */
+const parseHost: ts.ParseConfigHost = {
+  fileExists: path => ts.sys.fileExists(path),
+  readDirectory: () => [],
+  readFile,
+  useCaseSensitiveFileNames: ts.sys.useCaseSensitiveFileNames,
+};
+
+/**
+ * Resolves the effective `include` from a tsconfig.build.json using the
+ * TypeScript API. Lets `parseJsonConfigFileContent` handle extends
+ * resolution. Falls back to {@link buildInclude} if resolution fails.
+ */
+export const resolveBuildIncludes = (dir: string): readonly string[] => {
+  const configPath = join(dir, 'tsconfig.build.json');
+  const raw = v.safeParse(ReadConfigSchema, ts.readConfigFile(configPath, readFile));
+  if (!raw.success || raw.output.error !== undefined) {
+    return buildInclude;
+  }
+
+  const parsed = ts.parseJsonConfigFileContent(
+    raw.output.config, parseHost, dir, undefined, configPath,
+  );
+  const result = v.safeParse(ResolvedConfigSchema, parsed.raw);
+
+  return result.success ? result.output.include ?? buildInclude : buildInclude;
+};
 
 /** Shape of a generated tsconfig file. */
 export interface GeneratedTsconfig {

--- a/packages/cli/src/lib/turbo-config.ts
+++ b/packages/cli/src/lib/turbo-config.ts
@@ -52,6 +52,8 @@ export const collect = <Value>(
 
 /** Flags summarizing which tool categories are active across all packages. */
 export interface ToolFlags {
+  /** Union of tsconfig.build.json `include` directories across published packages. */
+  readonly compileIncludes: readonly string[];
   readonly hasCheck: boolean;
   readonly hasE2e: boolean;
   readonly hasEslint: boolean;
@@ -74,8 +76,12 @@ export const resolveToolFlags = (discovery: WorkspaceDiscovery): ToolFlags => {
   )].sort();
   const hasTypeScript = discovery.packages.some(pkg => pkg.hasTypeScript);
   const hasVitest = discovery.packages.some(pkg => pkg.hasVitestTests);
+  const compileIncludes = [...new Set(
+    discovery.packages.filter(pkg => pkg.isPublished).flatMap(pkg => pkg.buildIncludes),
+  )].sort();
 
   return {
+    compileIncludes,
     generateScripts,
     hasCheck: hasTypeScript || hasLint || hasVitest,
     hasE2e: discovery.root.hasVitestE2e || discovery.packages.some(pkg => pkg.hasVitestE2e),
@@ -91,6 +97,12 @@ export const resolveToolFlags = (discovery: WorkspaceDiscovery): ToolFlags => {
 
 /** Creates a topological (cross-package) task dependency. */
 const topo = (task: string): string => `^${task}`;
+
+const isGlob = (pattern: string): boolean => /[*?\{]/v.test(pattern);
+
+/** Converts a tsconfig `include` entry to a turbo input glob. */
+const toTurboGlob = (include: string): string =>
+  isGlob(include) ? include : `${include}/**`;
 
 const typecheckTasks = (flags: ToolFlags): readonly ConditionalEntry<TurboTask>[] => [
   {
@@ -116,7 +128,7 @@ const compileTasks = (flags: ToolFlags): readonly ConditionalEntry<TurboTask>[] 
       dependsOn: [topo(compileTs.name), ...(flags.hasGenerate ? [Aggregate.generate] : [])],
       inputs: [
         '$TURBO_ROOT$/tsconfig.base.json', '$TURBO_ROOT$/tsconfig.build.json',
-        'bin/**', 'src/**', 'scripts/**', 'tsconfig.json', 'tsconfig.*.json',
+        ...flags.compileIncludes.map(toTurboGlob), 'tsconfig.build.json',
       ],
       outputs: ['dist/source/**'],
     },
@@ -160,11 +172,17 @@ const lintTasks = (flags: ToolFlags): readonly ConditionalEntry<TurboTask>[] => 
   ];
 };
 
+/*
+ * Unlike compile inputs, test inputs can't be resolved from vitest config —
+ * vitest configs are executable TypeScript, not statically parseable.
+ * Broadening beyond test directories is intentional: tests import source.
+ */
+const testInputs = ['bin/**', 'src/**', 'test/**', 'scripts/**', 'vitest.config.ts'];
+
 const testTasks = (flags: ToolFlags): readonly ConditionalEntry<TurboTask>[] => {
   const deps = [
     ...(flags.hasPublished ? [topo(compileTs.name)] : []),
   ];
-  const testInputs = ['bin/**', 'src/**', 'test/**', 'scripts/**', 'vitest.config.*'];
 
   return [
     {

--- a/packages/cli/test/turbo-config.helpers.ts
+++ b/packages/cli/test/turbo-config.helpers.ts
@@ -1,9 +1,11 @@
 import type { PackageCapabilities, WorkspaceDiscovery } from '#src/lib/discovery.js';
+import { buildInclude } from '#src/lib/tsconfig-gen.js';
 
 export const makeCapabilities = (
   overrides: Partial<PackageCapabilities> = {},
 ): PackageCapabilities => {
   const merged = {
+    buildIncludes: [...buildInclude] as readonly string[],
     dir: '/fake/pkg',
     generateScripts: [] as readonly string[],
     hasBin: false,

--- a/packages/cli/test/turbo-json.test.ts
+++ b/packages/cli/test/turbo-json.test.ts
@@ -287,4 +287,48 @@ describe.concurrent(generateTurboJson, () => {
 
     expect(result.$schema).toBe('https://turbo.build/schema.json');
   });
+
+  it('compile:ts inputs derive from resolved buildIncludes', ({ expect }) => {
+    const discovery = makeDiscovery([
+      makeCapabilities({
+        buildIncludes: ['bin', 'src', 'generated', '*.proto.ts'],
+        isPublished: true,
+      }),
+    ]);
+
+    const result = generateTurboJson(discovery);
+    const inputs = result.tasks['compile:ts']?.inputs ?? [];
+
+    expect(inputs).toContain('bin/**');
+    expect(inputs).toContain('src/**');
+    expect(inputs).toContain('generated/**');
+    expect(inputs).toContain('*.proto.ts');
+    expect(inputs).toContain('tsconfig.build.json');
+    expect(inputs).not.toContain('tsconfig.json');
+    expect(inputs).not.toContain('scripts/**');
+  });
+
+  it('test:vitest:fast inputs use explicit vitest config filename', ({ expect }) => {
+    const discovery = makeDiscovery([
+      makeCapabilities({ hasTest: true, hasVitest: true }),
+    ]);
+
+    const result = generateTurboJson(discovery);
+    const inputs = result.tasks['test:vitest:fast']?.inputs ?? [];
+
+    expect(inputs).toContain('vitest.config.ts');
+    expect(inputs).not.toContain('vitest.config.*');
+  });
+
+  it('test:vitest:slow inputs use explicit vitest config filename', ({ expect }) => {
+    const discovery = makeDiscovery([
+      makeCapabilities({ hasTest: true, hasVitest: true }),
+    ]);
+
+    const result = generateTurboJson(discovery);
+    const inputs = result.tasks['test:vitest:slow']?.inputs ?? [];
+
+    expect(inputs).toContain('vitest.config.ts');
+    expect(inputs).not.toContain('vitest.config.*');
+  });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -191,6 +191,9 @@ importers:
       find-up-simple:
         specifier: 'catalog:'
         version: 1.0.1
+      typescript:
+        specifier: '>=5.0.0'
+        version: 5.9.3
       valibot:
         specifier: 'catalog:'
         version: 1.3.1(typescript@5.9.3)

--- a/turbo.json
+++ b/turbo.json
@@ -20,9 +20,7 @@
         "$TURBO_ROOT$/tsconfig.build.json",
         "bin/**",
         "src/**",
-        "scripts/**",
-        "tsconfig.json",
-        "tsconfig.*.json"
+        "tsconfig.build.json"
       ],
       "outputs": ["dist/source/**"]
     },
@@ -83,13 +81,13 @@
     "test:vitest:fast": {
       "dependsOn": ["^compile:ts"],
       "env": ["CI"],
-      "inputs": ["bin/**", "src/**", "test/**", "scripts/**", "vitest.config.*"],
+      "inputs": ["bin/**", "src/**", "test/**", "scripts/**", "vitest.config.ts"],
       "outputs": ["dist/coverage/vitest/fast/**", "dist/test-results/vitest/merge/blob-fast.json"]
     },
     "test:vitest:slow": {
       "dependsOn": ["^compile:ts"],
       "env": ["CI"],
-      "inputs": ["bin/**", "src/**", "test/**", "scripts/**", "vitest.config.*"],
+      "inputs": ["bin/**", "src/**", "test/**", "scripts/**", "vitest.config.ts"],
       "outputs": ["dist/coverage/vitest/slow/**", "dist/test-results/vitest/merge/blob-slow.json"]
     },
     "typecheck": {


### PR DESCRIPTION
## Summary

- Resolve `compile:ts` inputs from each package's `tsconfig.build.json` via
  the TypeScript API (`parseJsonConfigFileContent`) instead of hardcoding
  them — test/script changes no longer bust the compile cache
- Narrow `test:vitest:fast`/`test:vitest:slow` inputs from `vitest.config.*`
  to explicit `vitest.config.ts` so e2e config changes don't invalidate
  source test caches
- Add `buildIncludes` to `PackageCapabilities` during workspace discovery,
  aggregated as `ToolFlags.compileIncludes` for turbo config generation

Closes #34

## Test plan

- [x] 3 new unit tests covering resolved buildIncludes and explicit vitest config filenames
- [x] All 145 CLI tests pass including turbo-check integration tests
- [x] `turbo:check` confirms no drift
- [x] Typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)