### PR TITLE
Disable oxlint jsPlugins on Windows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,7 +117,8 @@ Dual-linter setup:
 
 - **oxlint** — Primary linter. All categories at `warn` + `denyWarnings`.
   Uses `@stylistic/eslint-plugin` via the jsPlugin loader for syntax-aware
-  formatting.
+  formatting. jsPlugins are disabled on Windows and Android due to upstream
+  bugs; ESLint picks up those rules as fallbacks.
 - **ESLint** — Supplementary. `@eslint/json` (JSON linting),
   `eslint-plugin-pnpm` (workspace validation), `eslint-plugin-n` (Node.js
   rules not in oxlint), `eslint-plugin-yml` (YAML linting + key sorting),
@@ -263,6 +264,10 @@ Consumer guidance:
   diagnostics stand out. CI enforces via `denyWarnings` (oxlint) and
   `--max-warnings=0` (ESLint).
 - Inline suppressions require a `--` reason suffix.
+- oxlint jsPlugins use `eslint-disable` directives (not `oxlint-disable`).
+  Always use `eslint-disable` for ESLint plugin rules regardless of whether
+  the rule runs in ESLint or oxlint. Use `oxlint-disable` only for
+  oxlint-native rules (e.g., `no-debugger`, `typescript/*`).
 - All exported functions, types, interfaces, and constants must have JSDoc comments.
 - When asserting on `CommandResult` (exit code, stdout, stderr), use
   `expect(result).toMatchObject({ exitCode: 0 })` instead of

--- a/packages/eslint-config/src/index.ts
+++ b/packages/eslint-config/src/index.ts
@@ -4,7 +4,7 @@ import {
   defaultEntryPoints,
   eslintCommentsRuleOverrides,
   importOrderRules,
-  isAndroid,
+  jsPluginsSupported,
   stylisticCustomizeDefaults,
   stylisticRuleOverrides,
   vitestE2eRuleOverrides,
@@ -145,8 +145,9 @@ const resolveNodeConfig = (options: ESLintConfigureOptions): DefineConfigArg => 
 });
 
 const resolveJsPluginFallbacks = (): Linter.Config[] =>
-  isAndroid
-    ? [
+  jsPluginsSupported
+    ? []
+    : [
         { ...stylistic.configs.customize(stylisticCustomizeDefaults), files: ['**/*.ts'] },
         { files: ['**/*.ts'], rules: stylisticRuleOverrides },
         eslintCommentsConfigs.recommended,
@@ -156,8 +157,7 @@ const resolveJsPluginFallbacks = (): Linter.Config[] =>
           plugins: { 'import-x': importPlugin },
           rules: importOrderRules,
         },
-      ]
-    : [];
+      ];
 
 const testFiles = ['**/test/**/*.ts', '**/e2e/**/*.ts'];
 
@@ -191,9 +191,10 @@ const vitestConfigs: Linter.Config[] = [
 /**
  * Creates an ESLint flat config for TypeScript projects.
  * Supplementary to oxlint — covers `@eslint/json`, `eslint-plugin-pnpm`,
- * `eslint-plugin-n`, and `@vitest/eslint-plugin`. On Android, also runs
+ * `eslint-plugin-n`, and `@vitest/eslint-plugin`. On platforms where oxlint
+ * jsPlugins are unsupported (Windows, Android), also runs
  * `@stylistic/eslint-plugin`, `@eslint-community/eslint-plugin-eslint-comments`,
- * and `eslint-plugin-import-x` as fallbacks for oxlint jsPlugins.
+ * and `eslint-plugin-import-x` as fallbacks.
  * `eslint-plugin-oxlint` is applied last to disable overlapping rules.
  */
 export const configure = async (options: ESLintConfigureOptions = {}): Promise<Linter.Config[]> => {

--- a/packages/oxlint-config/README.md
+++ b/packages/oxlint-config/README.md
@@ -49,13 +49,31 @@ const { configure } = await importModule('@gtbuchanan/oxlint-config');
 export default configure();
 ```
 
-## Android / Termux
+## Suppression comments
 
-oxlint has two known issues on Android:
+oxlint jsPlugins (`@stylistic`, `eslint-plugin-import-x`,
+`@eslint-community/eslint-plugin-eslint-comments`) use `eslint-disable`
+directives — not `oxlint-disable`. Always use `eslint-disable` for ESLint
+plugin rules regardless of whether oxlint or ESLint is running the rule.
+Use `oxlint-disable` only for oxlint-native rules (e.g., `no-debugger`,
+`typescript/*`).
 
-- **jsPlugins crash** — `@stylistic/eslint-plugin` triggers a panic in
-  `oxc_allocator` ([oxc#21045](https://github.com/oxc-project/oxc/issues/21045)).
-  `configure()` auto-detects Android and omits jsPlugins + stylistic rules.
+## Platform limitations
+
+oxlint jsPlugins (`@stylistic/eslint-plugin`, `eslint-plugin-import-x`,
+`@eslint-community/eslint-plugin-eslint-comments`) crash on certain
+platforms. `configure()` auto-detects these platforms and omits jsPlugins +
+stylistic rules. The exported ESLint fallback rules (`stylisticRuleOverrides`,
+`importOrderRules`, `eslintCommentsRuleOverrides`) can be used to restore
+coverage via ESLint on affected platforms.
+
+- **Windows** — intermittent failures
+  ([oxc#19395](https://github.com/oxc-project/oxc/issues/19395))
+- **Android / Termux** — `oxc_allocator` thread-local pool panic
+  ([oxc#21045](https://github.com/oxc-project/oxc/issues/21045))
+
+### Android / Termux additional issues
+
 - **Missing tsgolint binary** — `oxlint-tsgolint` has no `android-arm64`
   package ([tsgolint#866](https://github.com/oxc-project/tsgolint/issues/866)).
   The `linux-arm64` binary works. To use it:

--- a/packages/oxlint-config/e2e/cli.test.ts
+++ b/packages/oxlint-config/e2e/cli.test.ts
@@ -9,7 +9,9 @@ import {
 } from '@gtbuchanan/test-utils';
 import { it as baseIt, describe } from 'vitest';
 
-const isAndroid = process.platform === 'android';
+// Duplicated from src/index.ts — e2e tests must not import source directly
+const jsPluginsSupported =
+  process.platform !== 'android' && process.platform !== 'win32';
 
 const oxlintConfig = [
   "import { configure } from '@gtbuchanan/oxlint-config';",
@@ -53,8 +55,8 @@ describe('oxlint CLI', () => {
     expect(result.stdout).toContain('debugger');
   });
 
-  // JsPlugins crash on Android/Termux; stylistic rules require the plugin
-  baseIt.runIf(!isAndroid)(
+  // JsPlugins crash on certain platforms; stylistic rules require the plugin
+  baseIt.runIf(jsPluginsSupported)(
     'includes stylistic rules via @stylistic/eslint-plugin',
     ({ expect }) => {
       const fixture = createFixture();
@@ -65,6 +67,21 @@ describe('oxlint CLI', () => {
       expect(result.stdout).toContain('semi');
     },
   );
+
+  it('allows eslint-disable for jsPlugin rules', ({ fixture, expect }) => {
+    fixture.writeFile(
+      'style.js',
+      '// eslint-disable-next-line @stylistic/semi -- cross-platform\nconst _x = 0\n',
+    );
+
+    const result = fixture.run('oxlint', ['style.js']);
+
+    expect(result).toMatchObject({
+      exitCode: 0,
+      stderr: '',
+      stdout: expect.stringContaining('Found 0 warnings') as unknown,
+    });
+  });
 
   it('relaxes no-magic-numbers in test files', ({ fixture, expect }) => {
     fixture.writeFile('test/example.test.ts', 'export const answer = 42;\n');

--- a/packages/oxlint-config/src/index.ts
+++ b/packages/oxlint-config/src/index.ts
@@ -8,6 +8,7 @@ import {
   type OxlintOverride,
   defineConfig,
 } from 'oxlint';
+import { jsPluginsSupported } from './platform.ts';
 
 /** Options for the shared oxlint configuration. */
 export interface OxlintConfigureOptions {
@@ -182,11 +183,7 @@ const eslintCommentsRecommendedRules: DummyRuleMap = {
   '@eslint-community/eslint-comments/no-unused-enable': 'warn',
 };
 
-// Oxlint jsPlugins crash on Android/Termux (oxc_allocator thread-local pool panic).
-// Stylistic rules require the jsPlugin so they must be omitted together.
-// https://github.com/oxc-project/oxc/issues/21045
-/** Whether the current platform is Android (Termux). */
-export const isAndroid = process.platform === 'android';
+export { jsPluginsSupported } from './platform.ts';
 
 /** Default file patterns for entry points (bin and scripts directories). */
 export const defaultEntryPoints: readonly string[] = [
@@ -420,10 +417,10 @@ export const configure = (opts: OxlintConfigureOptions = {}): OxlintConfig => {
       ...categoryOverrides,
     },
     ignorePatterns,
-    ...(!isAndroid && { jsPlugins: resolveJsPlugins() }),
+    ...(jsPluginsSupported && { jsPlugins: resolveJsPlugins() }),
     options: { denyWarnings: true, typeAware: true, ...optionOverrides },
     overrides: [testOverride, ...targetOverrides, ...overrides],
     plugins: ['typescript', 'import', 'node', 'promise'],
-    rules: isAndroid ? ruleOverrides : resolveRules(stylisticOptions),
+    rules: jsPluginsSupported ? resolveRules(stylisticOptions) : ruleOverrides,
   });
 };

--- a/packages/oxlint-config/src/platform.ts
+++ b/packages/oxlint-config/src/platform.ts
@@ -1,0 +1,9 @@
+/*
+ * Oxlint jsPlugins crash on certain platforms. Stylistic rules require
+ * the jsPlugin so they must be omitted together.
+ * - Android/Termux: oxc_allocator thread-local pool panic (oxc#21045)
+ * - Windows: intermittent failures (oxc#19395)
+ */
+/** Whether the current platform supports oxlint jsPlugins. */
+export const jsPluginsSupported =
+  process.platform !== 'android' && process.platform !== 'win32';

--- a/packages/oxlint-config/test/configure-supported-platform.test.ts
+++ b/packages/oxlint-config/test/configure-supported-platform.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, vi } from 'vitest';
+import { configure } from '#src/index.js';
+
+vi.mock(import('#src/platform.js'), () => ({ jsPluginsSupported: true }));
+
+describe('configure on supported platforms', () => {
+  it('includes jsPlugins', ({ expect }) => {
+    const config = configure();
+
+    expect(config.jsPlugins).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('stylistic'),
+        expect.stringContaining('eslint-comments'),
+      ]),
+    );
+  });
+
+  it('includes eslint-comments rules', ({ expect }) => {
+    const config = configure();
+
+    expect(config.rules?.['@eslint-community/eslint-comments/disable-enable-pair']).toBe('warn');
+    expect(config.rules?.['@eslint-community/eslint-comments/require-description']).toBeDefined();
+  });
+
+  it('includes stylistic rules', ({ expect }) => {
+    const config = configure();
+
+    expect(config.rules?.['@stylistic/semi']).toBeDefined();
+  });
+
+  it('enforces 1tbs brace style', ({ expect }) => {
+    const config = configure();
+
+    expect(config.rules?.['@stylistic/brace-style']).toEqual([
+      'warn',
+      '1tbs',
+      { allowSingleLine: true },
+    ]);
+  });
+
+  it('allows customizing stylistic options', ({ expect }) => {
+    const withSemi = configure({ stylistic: { semi: true } });
+    const withoutSemi = configure({ stylistic: { semi: false } });
+
+    expect(withSemi.rules?.['@stylistic/semi']).toBeDefined();
+    expect(withoutSemi.rules?.['@stylistic/semi']).toBeDefined();
+    expect(withSemi.rules?.['@stylistic/semi']).not.toEqual(
+      withoutSemi.rules?.['@stylistic/semi'],
+    );
+  });
+
+  it('sets max-len to 100', ({ expect }) => {
+    const config = configure();
+    const maxLen = config.rules?.['@stylistic/max-len'];
+
+    expect(maxLen).toEqual(['warn', { code: 100, ignoreUrls: true }]);
+  });
+
+  it('enforces single quotes', ({ expect }) => {
+    const config = configure();
+    const quotes = config.rules?.['@stylistic/quotes'];
+
+    expect(quotes).toEqual([
+      'warn',
+      'single',
+      { allowTemplateLiterals: 'avoidEscape', avoidEscape: true },
+    ]);
+  });
+});

--- a/packages/oxlint-config/test/configure-unsupported-platform.test.ts
+++ b/packages/oxlint-config/test/configure-unsupported-platform.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, vi } from 'vitest';
+import { configure } from '#src/index.js';
+
+vi.mock(import('#src/platform.js'), () => ({ jsPluginsSupported: false }));
+
+describe('configure on unsupported platforms', () => {
+  it('omits jsPlugins', ({ expect }) => {
+    const config = configure();
+
+    expect(config.jsPlugins).toBeUndefined();
+  });
+
+  it('omits stylistic rules', ({ expect }) => {
+    const config = configure();
+
+    expect(config.rules?.['@stylistic/semi']).toBeUndefined();
+    expect(config.rules?.['@stylistic/max-len']).toBeUndefined();
+  });
+});

--- a/packages/oxlint-config/test/configure.test.ts
+++ b/packages/oxlint-config/test/configure.test.ts
@@ -1,26 +1,7 @@
 import { describe, it } from 'vitest';
 import { configure, defaultEntryPoints } from '#src/index.js';
 
-const isAndroid = process.platform === 'android';
-
 describe(configure, () => {
-  it.runIf(!isAndroid)('includes jsPlugins with defaults', ({ expect }) => {
-    const config = configure();
-
-    expect(config.jsPlugins).toEqual(
-      expect.arrayContaining([
-        expect.stringContaining('stylistic'),
-        expect.stringContaining('eslint-comments'),
-      ]),
-    );
-  });
-
-  it.runIf(isAndroid)('omits jsPlugins on Android', ({ expect }) => {
-    const config = configure();
-
-    expect(config.jsPlugins).toBeUndefined();
-  });
-
   it('returns a valid config with defaults', ({ expect }) => {
     const config = configure();
 
@@ -90,47 +71,6 @@ describe(configure, () => {
     expect(last).toEqual(custom);
   });
 
-  it.runIf(!isAndroid)('includes eslint-comments rules', ({ expect }) => {
-    const config = configure();
-
-    expect(config.rules?.['@eslint-community/eslint-comments/disable-enable-pair']).toBe('warn');
-    expect(config.rules?.['@eslint-community/eslint-comments/require-description']).toBeDefined();
-  });
-
-  it.runIf(!isAndroid)('includes stylistic rules', ({ expect }) => {
-    const config = configure();
-
-    expect(config.rules?.['@stylistic/semi']).toBeDefined();
-  });
-
-  it.runIf(!isAndroid)('enforces 1tbs brace style', ({ expect }) => {
-    const config = configure();
-
-    expect(config.rules?.['@stylistic/brace-style']).toEqual([
-      'warn',
-      '1tbs',
-      { allowSingleLine: true },
-    ]);
-  });
-
-  it.runIf(isAndroid)('omits stylistic rules on Android', ({ expect }) => {
-    const config = configure();
-
-    expect(config.rules?.['@stylistic/semi']).toBeUndefined();
-    expect(config.rules?.['@stylistic/max-len']).toBeUndefined();
-  });
-
-  it.runIf(!isAndroid)('allows customizing stylistic options', ({ expect }) => {
-    const withSemi = configure({ stylistic: { semi: true } });
-    const withoutSemi = configure({ stylistic: { semi: false } });
-
-    expect(withSemi.rules?.['@stylistic/semi']).toBeDefined();
-    expect(withoutSemi.rules?.['@stylistic/semi']).toBeDefined();
-    expect(withSemi.rules?.['@stylistic/semi']).not.toEqual(
-      withoutSemi.rules?.['@stylistic/semi'],
-    );
-  });
-
   it('enables no-param-reassign with props', ({ expect }) => {
     const config = configure();
 
@@ -165,24 +105,6 @@ describe(configure, () => {
     const config = configure();
 
     expect(config.rules?.['no-continue']).toBe('off');
-  });
-
-  it.runIf(!isAndroid)('sets max-len to 100', ({ expect }) => {
-    const config = configure();
-    const maxLen = config.rules?.['@stylistic/max-len'];
-
-    expect(maxLen).toEqual(['warn', { code: 100, ignoreUrls: true }]);
-  });
-
-  it.runIf(!isAndroid)('enforces single quotes', ({ expect }) => {
-    const config = configure();
-    const quotes = config.rules?.['@stylistic/quotes'];
-
-    expect(quotes).toEqual([
-      'warn',
-      'single',
-      { allowTemplateLiterals: 'avoidEscape', avoidEscape: true },
-    ]);
   });
 
   it('allows common sentinel values in no-magic-numbers', ({ expect }) => {


### PR DESCRIPTION
## Summary

- Disable oxlint jsPlugins on Windows to avoid intermittent `Insufficient memory to create fixed-size allocator pool` panics ([oxc#19395](https://github.com/oxc-project/oxc/issues/19395)). Generalizes the existing Android workaround into a capability-based `jsPluginsSupported` flag.
- On unsupported platforms, ESLint picks up `@stylistic`, `import-x`, and `eslint-comments` rules as fallbacks via `resolveJsPluginFallbacks()`.
- Extract `jsPluginsSupported` to `src/platform.ts` so both branches are tested on every platform via `vi.mock`.
- Document that `eslint-disable` (not `oxlint-disable`) is the correct directive for jsPlugin rules.

## Test plan

- [x] `pnpm check` passes (34/34 tasks)
- [x] Platform-mocked unit tests verify both supported (7 tests) and unsupported (2 tests) branches unconditionally
- [x] E2e test confirms `eslint-disable` for jsPlugin rules doesn't cause oxlint errors
- [x] Manual verification: oxlint no longer panics on Windows under normal use

🤖 Generated with [Claude Code](https://claude.com/claude-code)