### PR TITLE
Auto-resolve workspace deps in e2e fixtures

### DIFF
--- a/packages/eslint-config/e2e/cli.test.ts
+++ b/packages/eslint-config/e2e/cli.test.ts
@@ -53,10 +53,6 @@ const createFixture = () => {
     depsPackages: ['typescript'],
     hookPackages: ['eslint', 'jiti'],
     packageName: '@gtbuchanan/eslint-config',
-    workspaceDeps: [
-      '@gtbuchanan/eslint-plugin-markdownlint',
-      '@gtbuchanan/eslint-plugin-yamllint',
-    ],
   });
 
   const eslint = path.join(fixture.hookDir, 'node_modules/.bin/eslint');

--- a/packages/test-utils/src/fixture.ts
+++ b/packages/test-utils/src/fixture.ts
@@ -21,7 +21,13 @@ const exec = (command: string, args: readonly string[], options: SpawnSyncOption
   }
 };
 
-const PackageJson = v.object({ version: v.string() });
+const PackageJson = v.object({
+  dependencies: v.optional(v.record(v.string(), v.string())),
+  name: v.optional(v.string()),
+  version: v.string(),
+});
+
+type PackageJson = v.InferOutput<typeof PackageJson>;
 
 const require = createRequire(import.meta.url);
 
@@ -82,7 +88,7 @@ const findWorkspaceRoot = (): string => {
  * Memoize the derived values so each additional fixture is O(1).
  */
 const cache: {
-  index?: ReadonlyMap<string, PkgJson>;
+  index?: ReadonlyMap<string, PackageJson>;
   root?: string;
   tarballs?: readonly TarballEntry[];
 } = {};
@@ -93,7 +99,7 @@ const getWorkspaceRoot = (): string =>
 const getTarballs = (): readonly TarballEntry[] =>
   cache.tarballs ??= collectTarballs();
 
-const getIndex = (): ReadonlyMap<string, PkgJson> =>
+const getIndex = (): ReadonlyMap<string, PackageJson> =>
   cache.index ??= buildWorkspaceIndex();
 
 const collectTarballs = (): readonly TarballEntry[] => {
@@ -217,20 +223,13 @@ const createSubdir = (parent: string, name: string): string => {
   return dir;
 };
 
-const PkgJsonSchema = v.object({
-  dependencies: v.optional(v.record(v.string(), v.string())),
-  name: v.optional(v.string()),
-});
-
-type PkgJson = v.InferOutput<typeof PkgJsonSchema>;
-
-const buildWorkspaceIndex = (): ReadonlyMap<string, PkgJson> => {
+const buildWorkspaceIndex = (): ReadonlyMap<string, PackageJson> => {
   const wsRoot = getWorkspaceRoot();
-  const index = new Map<string, PkgJson>();
+  const index = new Map<string, PackageJson>();
 
   for (const pkgJsonPath of globSync('packages/*/package.json', { cwd: wsRoot })) {
     const abs = path.join(wsRoot, pkgJsonPath);
-    const pkg = v.parse(PkgJsonSchema, JSON.parse(readFileSync(abs, 'utf8')));
+    const pkg = v.parse(PackageJson, JSON.parse(readFileSync(abs, 'utf8')));
     if (pkg.name !== undefined) index.set(pkg.name, pkg);
   }
 
@@ -246,7 +245,7 @@ const buildWorkspaceIndex = (): ReadonlyMap<string, PkgJson> => {
  */
 const resolveWorkspaceDeps = (
   packageName: string,
-  index: ReadonlyMap<string, PkgJson>,
+  index: ReadonlyMap<string, PackageJson>,
   visited = new Set<string>(),
 ): readonly string[] => {
   if (visited.has(packageName)) return [];

--- a/packages/test-utils/src/fixture.ts
+++ b/packages/test-utils/src/fixture.ts
@@ -67,9 +67,37 @@ interface TarballEntry {
   readonly name: string;
 }
 
-const collectTarballs = (): readonly TarballEntry[] => {
+/*
+ * Workspace layout is coupled to the `packages/*` convention documented in
+ * AGENTS.md. If the layout ever changes, update both this helper and
+ * `buildWorkspaceIndex` — or drive them from `pnpm-workspace.yaml` globs.
+ */
+const findWorkspaceRoot = (): string => {
   const wsFile = findUpSync('pnpm-workspace.yaml', { cwd: process.cwd() });
-  const wsRoot = wsFile === undefined ? process.cwd() : path.dirname(wsFile);
+  return wsFile === undefined ? process.cwd() : path.dirname(wsFile);
+};
+
+/*
+ * Workspace state is stable across test fixtures within a single worker.
+ * Memoize the derived values so each additional fixture is O(1).
+ */
+const cache: {
+  index?: ReadonlyMap<string, PkgJson>;
+  root?: string;
+  tarballs?: readonly TarballEntry[];
+} = {};
+
+const getWorkspaceRoot = (): string =>
+  cache.root ??= findWorkspaceRoot();
+
+const getTarballs = (): readonly TarballEntry[] =>
+  cache.tarballs ??= collectTarballs();
+
+const getIndex = (): ReadonlyMap<string, PkgJson> =>
+  cache.index ??= buildWorkspaceIndex();
+
+const collectTarballs = (): readonly TarballEntry[] => {
+  const wsRoot = getWorkspaceRoot();
   const packDirs = [
     // Monorepo: per-package tarballs
     ...globSync('packages/*/dist/packages/npm', { cwd: wsRoot }),
@@ -164,11 +192,6 @@ interface IsolatedFixtureOptions {
   readonly depsPackages?: readonly string[];
   readonly hookPackages: readonly string[];
   readonly packageName: string;
-  /**
-   * Additional workspace package names whose tarballs should be installed
-   * alongside the primary package (e.g. unpublished workspace dependencies).
-   */
-  readonly workspaceDeps?: readonly string[];
 }
 
 /**
@@ -194,11 +217,58 @@ const createSubdir = (parent: string, name: string): string => {
   return dir;
 };
 
-const resolveTarballs = (
-  options: Pick<ProjectFixtureOptions, 'packageName' | 'workspaceDeps'>,
+const PkgJsonSchema = v.object({
+  dependencies: v.optional(v.record(v.string(), v.string())),
+  name: v.optional(v.string()),
+});
+
+type PkgJson = v.InferOutput<typeof PkgJsonSchema>;
+
+const buildWorkspaceIndex = (): ReadonlyMap<string, PkgJson> => {
+  const wsRoot = getWorkspaceRoot();
+  const index = new Map<string, PkgJson>();
+
+  for (const pkgJsonPath of globSync('packages/*/package.json', { cwd: wsRoot })) {
+    const abs = path.join(wsRoot, pkgJsonPath);
+    const pkg = v.parse(PkgJsonSchema, JSON.parse(readFileSync(abs, 'utf8')));
+    if (pkg.name !== undefined) index.set(pkg.name, pkg);
+  }
+
+  return index;
+};
+
+/**
+ * Recursively collects all transitive `workspace:` dependencies from
+ * a package's `dependencies` field. These are co-published workspace
+ * packages whose tarballs must be installed alongside the primary package.
+ * `devDependencies` and `peerDependencies` are intentionally excluded —
+ * they are not co-published.
+ */
+const resolveWorkspaceDeps = (
+  packageName: string,
+  index: ReadonlyMap<string, PkgJson>,
+  visited = new Set<string>(),
 ): readonly string[] => {
-  const entries = collectTarballs();
-  const names = [options.packageName, ...(options.workspaceDeps ?? [])];
+  if (visited.has(packageName)) return [];
+  visited.add(packageName);
+
+  const pkg = index.get(packageName);
+  if (pkg === undefined) return [];
+
+  const direct = Object.entries(pkg.dependencies ?? {})
+    .filter(([, spec]) => spec.startsWith('workspace:'))
+    .map(([name]) => name);
+
+  return [
+    ...direct,
+    ...direct.flatMap(dep => resolveWorkspaceDeps(dep, index, visited)),
+  ];
+};
+
+const resolveTarballs = (packageName: string): readonly string[] => {
+  const entries = getTarballs();
+  const index = getIndex();
+  const names = [...new Set([packageName, ...resolveWorkspaceDeps(packageName, index)])];
   return names.map(name => locateTarballFrom(entries, name));
 };
 
@@ -207,7 +277,7 @@ const resolveTarballs = (
  * packages into separate directories so `NODE_PATH` controls resolution order.
  */
 export const createIsolatedFixture = (options: IsolatedFixtureOptions): IsolatedFixture => {
-  const tarballs = resolveTarballs(options);
+  const tarballs = resolveTarballs(options.packageName);
   const baseDir = mkdtempSync(path.join(tmpdir(), 'e2e-isolated-'));
   const projectDir = mkdtempSync(path.join(tmpdir(), 'e2e-project-'));
 
@@ -239,11 +309,6 @@ export const createIsolatedFixture = (options: IsolatedFixtureOptions): Isolated
 interface ProjectFixtureOptions {
   readonly packages?: readonly string[];
   readonly packageName: string;
-  /**
-   * Additional workspace package names whose tarballs should be installed
-   * alongside the primary package (e.g. unpublished workspace dependencies).
-   */
-  readonly workspaceDeps?: readonly string[];
 }
 
 /**
@@ -264,7 +329,7 @@ export interface ProjectFixture {
 export const createProjectFixture = (
   options: ProjectFixtureOptions,
 ): ProjectFixture => {
-  const tarballs = resolveTarballs(options);
+  const tarballs = resolveTarballs(options.packageName);
   const projectDir = mkdtempSync(path.join(tmpdir(), 'e2e-build-'));
 
   const pinnedPkgs = (options.packages ?? []).map(pinned);


### PR DESCRIPTION
## Summary

- `createIsolatedFixture` / `createProjectFixture` now walk the primary package's `dependencies` for `workspace:` specs and install those tarballs automatically, replacing the manual `workspaceDeps` option
- Shared `findWorkspaceRoot()` + module-scope memoization of workspace root, tarball listing, and parsed `package.json` index — each additional fixture in a worker is O(1)
- Parsed `package.json` is validated via valibot (matches the existing `pinned()` pattern) instead of a type assertion; resolved tarball list is deduped

## Test plan

- [x] `pnpm -C packages/test-utils typecheck:ts` passes
- [x] `pnpm -C packages/test-utils lint:eslint` passes (zero warnings)
- [x] `pnpm -C packages/test-utils test:vitest:fast` — 13/13 tests pass
- [x] `pnpm -C packages/eslint-config typecheck:ts` / `lint:eslint` pass
- [x] `pnpm -C packages/eslint-config test:vitest:e2e` — 17/17 tests pass (auto-resolver picks up `@gtbuchanan/eslint-plugin-markdownlint` from the primary package's `dependencies`)
- [x] `pnpm build:ci` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)