### PR TITLE
Disable init-declarations in eslint-config

### DIFF
--- a/packages/eslint-config/src/plugins/core.ts
+++ b/packages/eslint-config/src/plugins/core.ts
@@ -14,8 +14,6 @@ const coreRuleConfig: Linter.Config = {
     'complexity': ['warn', { max: 10 }],
     // Justification: Single-letter namespace aliases are idiomatic for schema libraries
     'id-length': ['warn', { exceptions: ['v'] }],
-    // Justification: Pushes toward const and expressions over statements
-    'init-declarations': 'warn',
     // Justification: Enforces modern JS idiom (x ??= y over x = x ?? y)
     'logical-assignment-operators': [
       'warn', 'always', { enforceForIfStatements: true },

--- a/packages/eslint-config/test/configure.test.ts
+++ b/packages/eslint-config/test/configure.test.ts
@@ -169,6 +169,16 @@ describe(configure, () => {
     }
   });
 
+  it('leaves init-declarations disabled', async ({ expect }) => {
+    // Conflicts with unicorn/no-useless-undefined on `let x: T | undefined`
+    const configs = await configure({ onlyWarn: false });
+    const initConfig = configs.find(
+      cfg => cfg.rules?.['init-declarations'] !== undefined,
+    );
+
+    expect(initConfig).toBeUndefined();
+  });
+
   it('applies import ordering to all script file extensions', async ({ expect }) => {
     const configs = await configure({ onlyWarn: false });
     const importConfig = configs.find(


### PR DESCRIPTION
## Summary

- Drops `init-declarations` from `@gtbuchanan/eslint-config` because it conflicts with `unicorn/no-useless-undefined` for the common `let x: T | undefined;` pattern — one rule warns on the missing initializer, the other on the explicit `= undefined`.
- Hoisting bugs remain covered by `no-var` + `prefer-const`; TypeScript's strict null checks flag genuine use-before-assign for non-optional types.
- Adds a config-shape test asserting no config enables `init-declarations`.

Closes #53

## Test plan

- [x] `pnpm build:ci` passes (32/32 tasks)
- [x] `packages/eslint-config` fast tests pass (22/22)
- [x] Repo continues to lint clean under the new config

🤖 Generated with [Claude Code](https://claude.com/claude-code)