### PR TITLE
Wire skills-npm into gtb prepare for consumer skill discovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 *.tsbuildinfo
+.agents/skills/
+.claude/skills/
 .claude/worktrees/
 .turbo/
 dist/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
   - hooks:
       # ESLint handles linting, formatting (via eslint-plugin-format),
       # and markdown structural checks (via eslint-plugin-markdownlint).
-      - entry: pnpm exec eslint --fix --max-warnings=0
+      - entry: pnpm exec eslint --fix --max-warnings=0 --no-warn-ignored
         id: eslint
         language: system
         name: eslint

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "find-up-simple": "catalog:",
     "jiti": "catalog:",
     "prettier": "catalog:",
+    "skills-npm": "catalog:",
     "turbo": "catalog:",
     "typescript": "catalog:",
     "valibot": "catalog:",

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -167,6 +167,27 @@ Define inputs and outputs in a per-package `turbo.json`:
 }
 ```
 
+## Agent Skills
+
+`gtb` ships opt-in support for
+[Agent Skills](https://agentskills.io/specification).
+
+### Consuming skills from installed packages
+
+Add `skills-npm` as a devDep:
+
+```sh
+pnpm add -D skills-npm
+```
+
+`gtb prepare` invokes `skills-npm --recursive --yes` on every `pnpm
+install`, symlinking skills from every installed package into the
+directories of the coding agents detected on your machine. Silently
+skipped if `skills-npm` isn't installed. See
+[`skills-npm`](https://github.com/antfu/skills-npm) for a
+`skills-npm.config.ts` if you need to pin specific agents or filter
+which packages get scanned.
+
 ## Workspace detection
 
 `pack` supports both monorepo and single-package layouts:

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -38,7 +38,13 @@
     "@types/cross-spawn": "catalog:"
   },
   "peerDependencies": {
+    "skills-npm": "^1.1.1",
     "typescript": ">=5.0.0"
+  },
+  "peerDependenciesMeta": {
+    "skills-npm": {
+      "optional": true
+    }
   },
   "engines": {
     "node": ">=22.17"

--- a/packages/cli/src/commands/root/prepare.ts
+++ b/packages/cli/src/commands/root/prepare.ts
@@ -1,33 +1,8 @@
 import { statSync } from 'node:fs';
 import { defineCommand } from 'citty';
 import crossSpawn from 'cross-spawn';
+import { trySpawn } from '../../lib/process.ts';
 import { rootNames } from './names.ts';
-
-/**
- * Tries to spawn a command. Resolves true on exit 0, false on ENOENT
- * (command not found), and rejects on other failures.
- */
-const trySpawn = async (
-  bin: string,
-  args: readonly string[],
-): Promise<boolean> =>
-  new Promise((resolve, reject) => {
-    const child = crossSpawn(bin, [...args], { stdio: 'inherit' });
-    child.on('error', (err: NodeJS.ErrnoException) => {
-      if (err.code === 'ENOENT') {
-        resolve(false);
-      } else {
-        reject(err);
-      }
-    });
-    child.on('close', (code) => {
-      if (code === 0) {
-        resolve(true);
-      } else {
-        reject(new Error(`${bin} exited with code ${String(code)}`));
-      }
-    });
-  });
 
 /**
  * Linked worktrees have a `.git` file (not directory) pointing to the
@@ -42,35 +17,52 @@ const isLinkedWorktree = (): boolean => {
   }
 };
 
+const installPreCommitHooks = async (): Promise<void> => {
+  if (isLinkedWorktree()) {
+    console.log('linked worktree, skipping hook installation');
+    return;
+  }
+
+  if (await trySpawn('prek', ['install'])) {
+    return;
+  }
+
+  console.log('prek unavailable, falling back to pre-commit');
+  crossSpawn.sync('git', ['config', '--unset-all', 'core.hooksPath']);
+
+  if (await trySpawn('pre-commit', ['install'])) {
+    return;
+  }
+
+  console.log('pre-commit unavailable, skipping hook installation');
+};
+
+const syncInstalledSkills = async (): Promise<void> => {
+  if (!await trySpawn('skills-npm', ['--recursive', '--yes'])) {
+    console.log('skills-npm unavailable, skipping skill symlinking');
+  }
+};
+
 /**
- * Installs pre-commit hooks via prek or pre-commit.
+ * Installs pre-commit hooks and symlinks skills from installed packages.
  *
- * Skips in linked worktrees (hooks inherited via shared config). In the
- * main working tree, tries prek first (Rust, fast), then falls back to
- * pre-commit (Python) when prek is unavailable (e.g., Android/Termux).
+ * Hooks: prek first (Rust, fast), falls back to pre-commit (Python) on
+ * platforms where prek is unavailable. Skipped in linked worktrees
+ * (hooks inherited via shared `core.hooksPath`).
+ *
+ * Skills: `skills-npm --recursive` discovers `skills/` in every installed
+ * package and symlinks them into agent directories per
+ * `skills-npm.config.ts`. Runs unconditionally — linked worktrees have
+ * their own `node_modules` and agent dirs. Silently skipped when
+ * `skills-npm` isn't installed (consumers opt in).
  */
 export const prepare = defineCommand({
   meta: {
-    description: 'Install pre-commit hooks via prek or pre-commit',
+    description: 'Install pre-commit hooks and sync installed skills',
     name: rootNames.prepare,
   },
   run: async () => {
-    if (isLinkedWorktree()) {
-      console.log('prepare: skipped (linked worktree)');
-      return;
-    }
-
-    if (await trySpawn('prek', ['install'])) {
-      return;
-    }
-
-    console.log('prek unavailable, falling back to pre-commit');
-    crossSpawn.sync('git', ['config', '--unset-all', 'core.hooksPath']);
-
-    if (await trySpawn('pre-commit', ['install'])) {
-      return;
-    }
-
-    console.log('pre-commit unavailable, skipping hook installation');
+    await installPreCommitHooks();
+    await syncInstalledSkills();
   },
 });

--- a/packages/cli/src/lib/process.ts
+++ b/packages/cli/src/lib/process.ts
@@ -26,3 +26,29 @@ export const run = async (
     child.on('error', reject);
   });
 };
+
+/**
+ * Spawns a command. Resolves true on exit 0, false on ENOENT
+ * (command not found), and rejects on other failures.
+ */
+export const trySpawn = async (
+  bin: string,
+  args: readonly string[],
+): Promise<boolean> =>
+  new Promise((resolve, reject) => {
+    const child = crossSpawn(bin, [...args], { stdio: 'inherit' });
+    child.on('error', (err: NodeJS.ErrnoException) => {
+      if (err.code === 'ENOENT') {
+        resolve(false);
+      } else {
+        reject(err);
+      }
+    });
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve(true);
+      } else {
+        reject(new Error(`${bin} exited with code ${String(code)}`));
+      }
+    });
+  });

--- a/packages/cli/test/prepare.test.ts
+++ b/packages/cli/test/prepare.test.ts
@@ -1,0 +1,93 @@
+import { runCommand } from 'citty';
+import { describe, it, vi } from 'vitest';
+
+const enoent = (): NodeJS.ErrnoException =>
+  Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+
+vi.mock(import('node:fs'), async importOriginal => ({
+  ...await importOriginal(),
+  statSync: vi.fn<() => never>(() => {
+    throw enoent();
+  }),
+}));
+
+vi.mock(import('#src/lib/process.js'), async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, trySpawn: vi.fn<typeof actual.trySpawn>() };
+});
+
+const { statSync } = await import('node:fs');
+const { trySpawn } = await import('#src/lib/process.js');
+const { prepare } = await import('#src/commands/root/prepare.js');
+
+interface Fixture {
+  readonly mockStatSync: ReturnType<typeof vi.mocked<typeof statSync>>;
+  readonly mockTrySpawn: ReturnType<typeof vi.mocked<typeof trySpawn>>;
+}
+
+const createFixture = (): Fixture => {
+  const mockStatSync = vi.mocked(statSync);
+  const mockTrySpawn = vi.mocked(trySpawn);
+  mockStatSync.mockImplementation(() => {
+    throw enoent();
+  });
+  vi.spyOn(console, 'log').mockReturnValue();
+  return { mockStatSync, mockTrySpawn };
+};
+
+const invoke = async (): Promise<void> => {
+  await runCommand(prepare, { rawArgs: [] });
+};
+
+const spawnedBins = (fixture: Fixture): readonly string[] =>
+  fixture.mockTrySpawn.mock.calls.map(call => call[0]);
+
+const spawnArgsFor = (fixture: Fixture, bin: string): readonly string[] => {
+  const call = fixture.mockTrySpawn.mock.calls.find(([name]) => name === bin);
+  return call?.[1] ?? [];
+};
+
+describe('gtb prepare', () => {
+  it('invokes skills-npm with --recursive --yes after hook install', async ({ expect }) => {
+    const fixture = createFixture();
+    fixture.mockTrySpawn.mockResolvedValue(true);
+
+    await invoke();
+
+    expect(spawnedBins(fixture)).toStrictEqual(['prek', 'skills-npm']);
+    expect(spawnArgsFor(fixture, 'skills-npm')).toStrictEqual(['--recursive', '--yes']);
+  });
+
+  it('logs skills-npm unavailable when trySpawn returns false', async ({ expect }) => {
+    const fixture = createFixture();
+    fixture.mockTrySpawn.mockImplementation(bin => Promise.resolve(bin !== 'skills-npm'));
+
+    await invoke();
+
+    expect(vi.mocked(console.log)).toHaveBeenCalledWith(
+      expect.stringContaining('skills-npm unavailable'),
+    );
+  });
+
+  it('propagates skills-npm failures', async ({ expect }) => {
+    const fixture = createFixture();
+    fixture.mockTrySpawn.mockImplementation((bin) => {
+      if (bin === 'skills-npm') {
+        return Promise.reject(new Error('skills-npm exited with code 1'));
+      }
+      return Promise.resolve(true);
+    });
+
+    await expect(invoke()).rejects.toThrow(/skills-npm exited with code 1/v);
+  });
+
+  it('runs skills-npm in linked worktrees (hook install skipped)', async ({ expect }) => {
+    const fixture = createFixture();
+    fixture.mockStatSync.mockReturnValueOnce({ isFile: () => true } as ReturnType<typeof statSync>);
+    fixture.mockTrySpawn.mockResolvedValue(true);
+
+    await invoke();
+
+    expect(spawnedBins(fixture)).toStrictEqual(['skills-npm']);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,9 @@ catalogs:
     prettier-plugin-sort-json:
       specifier: 4.2.0
       version: 4.2.0
+    skills-npm:
+      specifier: 1.1.1
+      version: 1.1.1
     turbo:
       specifier: ^2.5.4
       version: 2.9.5
@@ -176,6 +179,9 @@ importers:
       prettier:
         specifier: 'catalog:'
         version: 3.8.3
+      skills-npm:
+        specifier: 'catalog:'
+        version: 1.1.1
       turbo:
         specifier: 'catalog:'
         version: 2.9.5
@@ -200,6 +206,9 @@ importers:
       find-up-simple:
         specifier: 'catalog:'
         version: 1.0.1
+      skills-npm:
+        specifier: ^1.1.1
+        version: 1.1.1
       typescript:
         specifier: '>=5.0.0'
         version: 5.9.3
@@ -477,6 +486,12 @@ packages:
 
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
+
+  '@clack/core@1.2.0':
+    resolution: {integrity: sha512-qfxof/3T3t9DPU/Rj3OmcFyZInceqj/NVtO9rwIuJqCUgh32gwPjpFQQp/ben07qKlhpwq7GzfWpST4qdJ5Drg==, tarball: https://registry.npmjs.org/@clack/core/-/core-1.2.0.tgz}
+
+  '@clack/prompts@1.2.0':
+    resolution: {integrity: sha512-4jmztR9fMqPMjz6H/UZXj0zEmE43ha1euENwkckKKel4XpSfokExPo5AiVStdHSAlHekz4d0CA/r45Ok1E4D3w==, tarball: https://registry.npmjs.org/@clack/prompts/-/prompts-1.2.0.tgz}
 
   '@date-vir/duration@8.3.1':
     resolution: {integrity: sha512-IfTchf2IoyCAXpKGedi/z+s7JTnT8Mmvp4Zj82fxfSstT/bcbFyItQIf0IfJd3h/z3hG399yNUzr9fg/2mZNAA==}
@@ -759,6 +774,9 @@ packages:
     resolution: {integrity: sha512-/UyNlHfkuLXG6Ed85KB0WBF283xn2yavR+UtRibBRUcvEJId2DSLdGXwJ/cDa1X++SWDPzq3+GSFniHjkNy7yg==}
     peerDependencies:
       prettier: ^3.0.0
+
+  '@quansync/fs@1.0.0':
+    resolution: {integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==, tarball: https://registry.npmjs.org/@quansync/fs/-/fs-1.0.0.tgz}
 
   '@rolldown/binding-android-arm64@1.0.0-rc.12':
     resolution: {integrity: sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==, tarball: https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.12.tgz}
@@ -1277,6 +1295,10 @@ packages:
     resolution: {integrity: sha512-c5JxaDrzwRjq3WyJkI1AGR5xy6Gr6udlt7sQPbl09+3ckB+Zo2qqQ2KhCTBr7Q8dHB43bENGYEk4xddrFH/b7A==}
     engines: {node: '>=18.20'}
 
+  cac@7.0.0:
+    resolution: {integrity: sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==, tarball: https://registry.npmjs.org/cac/-/cac-7.0.0.tgz}
+    engines: {node: '>=20.19.0'}
+
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
@@ -1418,6 +1440,9 @@ packages:
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==, tarball: https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz}
     engines: {node: '>= 0.4'}
+
+  defu@6.1.7:
+    resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==, tarball: https://registry.npmjs.org/defu/-/defu-6.1.7.tgz}
 
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
@@ -1683,6 +1708,10 @@ packages:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
+  extend-shallow@2.0.1:
+    resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==, tarball: https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz}
+    engines: {node: '>=0.10.0'}
+
   extendable-error@0.1.7:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
 
@@ -1702,11 +1731,20 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==, tarball: https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz}
 
+  fast-string-truncated-width@1.2.1:
+    resolution: {integrity: sha512-Q9acT/+Uu3GwGj+5w/zsGuQjh9O1TyywhIwAxHudtWrgF09nHOPrvTLhQevPbttcxjr/SNN7mJmfOw/B1bXgow==, tarball: https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-1.2.1.tgz}
+
+  fast-string-width@1.1.0:
+    resolution: {integrity: sha512-O3fwIVIH5gKB38QNbdg+3760ZmGz0SZMgvwJbA1b2TGXceKE6A2cOlfogh1iw8lr049zPyd7YADHy+B7U4W9bQ==, tarball: https://registry.npmjs.org/fast-string-width/-/fast-string-width-1.1.0.tgz}
+
+  fast-wrap-ansi@0.1.6:
+    resolution: {integrity: sha512-HlUwET7a5gqjURj70D5jl7aC3Zmy4weA1SHUfM0JFI0Ptq987NH2TwbBFLoERhfwk+E+eaq4EK3jXoT+R3yp3w==, tarball: https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.1.6.tgz}
+
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
   fdir@6.5.0:
-    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==, tarball: https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz}
     engines: {node: '>=12.0.0'}
     peerDependencies:
       picomatch: ^3 || ^4
@@ -1845,6 +1883,10 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
+  gray-matter@4.0.3:
+    resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==, tarball: https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz}
+    engines: {node: '>=6.0'}
+
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==, tarball: https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz}
     engines: {node: '>= 0.4'}
@@ -1950,6 +1992,10 @@ packages:
 
   is-decimal@2.0.1:
     resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==, tarball: https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz}
+
+  is-extendable@0.1.1:
+    resolution: {integrity: sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==, tarball: https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz}
+    engines: {node: '>=0.10.0'}
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==, tarball: https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz}
@@ -2103,6 +2149,10 @@ packages:
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==, tarball: https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz}
+
+  kind-of@6.0.3:
+    resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==, tarball: https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz}
+    engines: {node: '>=0.10.0'}
 
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==, tarball: https://registry.npmjs.org/levn/-/levn-0.4.1.tgz}
@@ -2552,6 +2602,9 @@ packages:
   quansync@0.2.11:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
 
+  quansync@1.0.0:
+    resolution: {integrity: sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA==, tarball: https://registry.npmjs.org/quansync/-/quansync-1.0.0.tgz}
+
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
@@ -2638,6 +2691,10 @@ packages:
     resolution: {integrity: sha512-3A6sD0WYP7+QrjbfNA2FN3FsOaGGFoekCVgTyypy53gPxhbkCIjtO6YWgdrfM+n/8sI8JeXZOIxsHjMTNxQ4nQ==}
     engines: {node: ^14.0.0 || >=16.0.0}
 
+  section-matter@1.0.0:
+    resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==, tarball: https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz}
+    engines: {node: '>=4'}
+
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==, tarball: https://registry.npmjs.org/semver/-/semver-6.3.1.tgz}
     hasBin: true
@@ -2689,6 +2746,13 @@ packages:
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
+
+  sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==, tarball: https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz}
+
+  skills-npm@1.1.1:
+    resolution: {integrity: sha512-qbRSzorWK3fVdpKzZquehYlWzmC29/MOh8AqWoX7NAZiCSAX/RuTpyqAml7hWBe7NM9DDx472kZ0hKO7CCXRkA==, tarball: https://registry.npmjs.org/skills-npm/-/skills-npm-1.1.1.tgz}
+    hasBin: true
 
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
@@ -2759,6 +2823,10 @@ packages:
     resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==, tarball: https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz}
     engines: {node: '>=12'}
 
+  strip-bom-string@1.0.0:
+    resolution: {integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==, tarball: https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz}
+    engines: {node: '>=0.10.0'}
+
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
@@ -2799,7 +2867,7 @@ packages:
     engines: {node: '>=18'}
 
   tinyglobby@0.2.15:
-    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==, tarball: https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz}
     engines: {node: '>=12.0.0'}
 
   tinypool@2.1.0:
@@ -2883,6 +2951,12 @@ packages:
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==, tarball: https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz}
     engines: {node: '>= 0.4'}
+
+  unconfig-core@7.5.0:
+    resolution: {integrity: sha512-Su3FauozOGP44ZmKdHy2oE6LPjk51M/TRRjHv2HNCWiDvfvCoxC2lno6jevMA91MYAdCdwP05QnWdWpSbncX/w==, tarball: https://registry.npmjs.org/unconfig-core/-/unconfig-core-7.5.0.tgz}
+
+  unconfig@7.5.0:
+    resolution: {integrity: sha512-oi8Qy2JV4D3UQ0PsopR28CzdQ3S/5A1zwsUwp/rosSbfhJ5z7b90bIyTwi/F7hCLD4SGcZVjDzd4XoUQcEanvA==, tarball: https://registry.npmjs.org/unconfig/-/unconfig-7.5.0.tgz}
 
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
@@ -3021,6 +3095,10 @@ packages:
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==, tarball: https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz}
     engines: {node: '>=0.10.0'}
+
+  xdg-basedir@5.1.0:
+    resolution: {integrity: sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ==, tarball: https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-5.1.0.tgz}
+    engines: {node: '>=12'}
 
   yaml-eslint-parser@2.0.0:
     resolution: {integrity: sha512-h0uDm97wvT2bokfwwTmY6kJ1hp6YDFL0nRHwNKz8s/VD1FH/vvZjAKoMUE+un0eaYBSG7/c6h+lJTP+31tjgTw==}
@@ -3223,6 +3301,18 @@ snapshots:
       fs-extra: 7.0.1
       human-id: 4.1.3
       prettier: 2.8.8
+
+  '@clack/core@1.2.0':
+    dependencies:
+      fast-wrap-ansi: 0.1.6
+      sisteransi: 1.0.5
+
+  '@clack/prompts@1.2.0':
+    dependencies:
+      '@clack/core': 1.2.0
+      fast-string-width: 1.1.0
+      fast-wrap-ansi: 0.1.6
+      sisteransi: 1.0.5
 
   '@date-vir/duration@8.3.1':
     dependencies:
@@ -3456,6 +3546,10 @@ snapshots:
     dependencies:
       '@xml-tools/parser': 1.0.11
       prettier: 3.8.3
+
+  '@quansync/fs@1.0.0':
+    dependencies:
+      quansync: 1.0.0
 
   '@rolldown/binding-android-arm64@1.0.0-rc.12':
     optional: true
@@ -3918,6 +4012,8 @@ snapshots:
 
   builtin-modules@5.1.0: {}
 
+  cac@7.0.0: {}
+
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -4054,6 +4150,8 @@ snapshots:
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
     optional: true
+
+  defu@6.1.7: {}
 
   delayed-stream@1.0.0: {}
 
@@ -4445,6 +4543,10 @@ snapshots:
 
   expect-type@1.3.0: {}
 
+  extend-shallow@2.0.1:
+    dependencies:
+      is-extendable: 0.1.1
+
   extendable-error@0.1.7: {}
 
   fast-deep-equal@3.1.3: {}
@@ -4462,6 +4564,16 @@ snapshots:
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
+
+  fast-string-truncated-width@1.2.1: {}
+
+  fast-string-width@1.1.0:
+    dependencies:
+      fast-string-truncated-width: 1.2.1
+
+  fast-wrap-ansi@0.1.6:
+    dependencies:
+      fast-string-width: 1.1.0
 
   fastq@1.20.1:
     dependencies:
@@ -4618,6 +4730,13 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
+  gray-matter@4.0.3:
+    dependencies:
+      js-yaml: 3.14.2
+      kind-of: 6.0.3
+      section-matter: 1.0.0
+      strip-bom-string: 1.0.0
+
   has-bigints@1.1.0:
     optional: true
 
@@ -4728,6 +4847,8 @@ snapshots:
     optional: true
 
   is-decimal@2.0.1: {}
+
+  is-extendable@0.1.1: {}
 
   is-extglob@2.1.1: {}
 
@@ -4881,6 +5002,8 @@ snapshots:
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  kind-of@6.0.3: {}
 
   levn@0.4.1:
     dependencies:
@@ -5403,6 +5526,8 @@ snapshots:
 
   quansync@0.2.11: {}
 
+  quansync@1.0.0: {}
+
   queue-microtask@1.2.3: {}
 
   read-yaml-file@1.1.0:
@@ -5532,6 +5657,11 @@ snapshots:
       refa: 0.12.1
       regexp-ast-analysis: 0.7.1
 
+  section-matter@1.0.0:
+    dependencies:
+      extend-shallow: 2.0.1
+      kind-of: 6.0.3
+
   semver@6.3.1:
     optional: true
 
@@ -5603,6 +5733,19 @@ snapshots:
   siginfo@2.0.0: {}
 
   signal-exit@4.1.0: {}
+
+  sisteransi@1.0.5: {}
+
+  skills-npm@1.1.1:
+    dependencies:
+      '@clack/prompts': 1.2.0
+      cac: 7.0.0
+      gray-matter: 4.0.3
+      picocolors: 1.1.1
+      tinyglobby: 0.2.15
+      unconfig: 7.5.0
+      xdg-basedir: 5.1.0
+      yaml: 2.8.3
 
   slash@3.0.0: {}
 
@@ -5686,6 +5829,8 @@ snapshots:
   strip-ansi@7.2.0:
     dependencies:
       ansi-regex: 6.2.2
+
+  strip-bom-string@1.0.0: {}
 
   strip-bom@3.0.0: {}
 
@@ -5824,6 +5969,19 @@ snapshots:
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
     optional: true
+
+  unconfig-core@7.5.0:
+    dependencies:
+      '@quansync/fs': 1.0.0
+      quansync: 1.0.0
+
+  unconfig@7.5.0:
+    dependencies:
+      '@quansync/fs': 1.0.0
+      defu: 6.1.7
+      jiti: 2.6.1
+      quansync: 1.0.0
+      unconfig-core: 7.5.0
 
   undici-types@7.18.2: {}
 
@@ -5970,6 +6128,8 @@ snapshots:
       stackback: 0.0.2
 
   word-wrap@1.2.5: {}
+
+  xdg-basedir@5.1.0: {}
 
   yaml-eslint-parser@2.0.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -32,6 +32,7 @@ catalog:
   prettier-plugin-multiline-arrays: 4.1.5
   prettier-plugin-packagejson: 3.0.2
   prettier-plugin-sort-json: 4.2.0
+  skills-npm: 1.1.1
   turbo: ^2.5.4
   typescript: ^5.9.3
   typescript-eslint: 8.58.0


### PR DESCRIPTION
## Summary

- `gtb prepare` now invokes `skills-npm --recursive --yes` after pre-commit hook install, so consumers that install packages shipping skills get them symlinked into agent directories automatically on every `pnpm install`.
- skills-npm detects installed agents on the machine; no config file needed for the common case. A `skills-npm.config.ts` can still pin specific agents if desired (link in the CLI README).
- Declares `skills-npm` as an optional peer dep of `@gtbuchanan/cli` so pnpm surfaces the relationship and warns on version mismatch without forcing it on consumers who don't want skill discovery.
- Adds `.agents/skills/` and `.claude/skills/` to `.gitignore` since skills-npm writes symlinks there on every install.
- Pre-commit eslint hook gains `--no-warn-ignored` so dotfiles without a matching config (`.gitignore`, etc.) don't trip `--max-warnings=0` when edited.

Part of #41.

## Test plan

- [x] `pnpm run verify` passes
- [x] `pnpm exec turbo run lint:eslint test:vitest:fast typecheck:ts --filter=@gtbuchanan/cli` — 160 tests pass
- [x] `pnpm install` triggers `gtb prepare` → skills-npm runs, detects installed Claude Code, no-ops cleanly when no installed packages ship skills
- [x] Without `skills-npm` installed: trySpawn returns ENOENT, logs `skills-npm unavailable, skipping skill symlinking`, install succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)