### PR TITLE
Stabilize pack:npm cache key across worktrees

### DIFF
--- a/packages/cli/src/lib/turbo-config.ts
+++ b/packages/cli/src/lib/turbo-config.ts
@@ -167,7 +167,18 @@ const packTasks = (flags: ToolFlags): readonly ConditionalEntry<TurboTask>[] => 
         taskNames.compileTs,
         ...(flags.hasSkills ? [taskNames.compileSkills] : []),
       ],
-      inputs: ['$TURBO_ROOT$/package.json', 'dist/source/**', 'package.json'],
+      /*
+       * Exclude the generated manifest from inputs: pack:npm writes
+       * `dist/source/package.json` as one of its outputs, and including it
+       * in the input glob makes the task's hash depend on whether a prior
+       * run left the file on disk. That prevents cache hits across fresh
+       * worktrees even when the source inputs are identical.
+       */
+      inputs: [
+        '$TURBO_ROOT$/package.json',
+        'dist/source/**', '!dist/source/package.json',
+        'package.json',
+      ],
       outputs: ['dist/packages/npm/**', 'dist/source/package.json'],
     },
   },

--- a/packages/cli/test/turbo-json.test.ts
+++ b/packages/cli/test/turbo-json.test.ts
@@ -220,6 +220,16 @@ describe.concurrent(generateTurboJson, () => {
     ]);
   });
 
+  it('excludes the generated manifest from pack:npm inputs', ({ expect }) => {
+    const discovery = makeDiscovery([
+      makeCapabilities({ isPublished: true }),
+    ]);
+
+    const result = generateTurboJson(discovery);
+
+    expect(result.tasks['pack:npm']?.inputs).toContain('!dist/source/package.json');
+  });
+
   it('omits lint:eslint from deploy:skills dependsOn when no package has ESLint', ({ expect }) => {
     const discovery = makeDiscovery([
       makeCapabilities({ hasSkills: true }),

--- a/turbo.json
+++ b/turbo.json
@@ -129,6 +129,7 @@
       "inputs": [
         "$TURBO_ROOT$/package.json",
         "dist/source/**",
+        "!dist/source/package.json",
         "package.json"
       ],
       "outputs": [


### PR DESCRIPTION
## Summary

- Exclude the generated `dist/source/package.json` manifest from `pack:npm`'s input glob so the task's hash no longer depends on whether a prior run left the file on disk.
- Fresh worktrees (or any clean checkout) now produce the same `pack:npm` hash as worktrees that have packed before, restoring cache reuse across the publish/e2e branch of the graph (`pack:npm` → `pack` → `test:vitest:e2e` → `test:e2e` → `build`).
- Locks the exclusion in via a `generateTurboJson` test.

## Background

`pack:npm` declared `dist/source/**` as input and `dist/source/package.json` as one of its outputs. The overlap meant turbo's input hash differed depending on filesystem state: the worktree that originally ran pack had the manifest on disk and contributed it to the hash; a fresh worktree did not. With Turbo 2.9's worktree-shared cache, this surfaced as `pack:npm` (and every aggregator above it) MISSing across worktrees even when source inputs were identical.

The fix excludes the file from the input glob with `!dist/source/package.json`. The output declaration is unchanged, so cache replay still restores the manifest on disk.

## Test plan

- [x] `vitest run packages/cli/test/turbo-json.test.ts` — new assertion passes
- [x] `turbo run pack:npm --filter=@gtbuchanan/cli` twice in a fresh worktree — second run reports `Cached: 6 cached, 7 total` (was `0 cached, 7 total` previously); `@gtbuchanan/cli#pack:npm` hash is stable (`b669b0c73e58f15a`)
- [ ] CI green