### PR TITLE
Fix gtb sync stripping codecov.yml document-start marker

### DIFF
--- a/packages/cli/src/lib/file-writer.ts
+++ b/packages/cli/src/lib/file-writer.ts
@@ -88,9 +88,14 @@ export const mergePackageScripts = (
   return { added, skipped };
 };
 
-/** Writes a YAML object to a file with single-quoted strings and trailing newline. */
+/**
+ * Writes a YAML object to a file with single-quoted strings, a leading
+ * `---` document-start marker, and a trailing newline. The marker keeps
+ * generated output in sync with the `yamllint/document-start` rule, so
+ * a follow-up `eslint --fix` pass cannot reintroduce drift.
+ */
 export const writeYamlFile = (path: string, data: unknown): void => {
-  writeFileSync(path, stringifyYaml(data, { singleQuote: true }));
+  writeFileSync(path, stringifyYaml(data, { directives: true, singleQuote: true }));
 };
 
 const ExistingCodecovSchema = v.nullable(

--- a/packages/cli/test/file-writer.test.ts
+++ b/packages/cli/test/file-writer.test.ts
@@ -139,6 +139,15 @@ describe(writeYamlFile, () => {
     expect(content.endsWith('\n')).toBe(true);
   });
 
+  it('emits the document-start marker so output matches yamllint policy', ({ expect }) => {
+    const dir = createTempDir();
+    const filePath = path.join(dir, 'test.yml');
+
+    writeYamlFile(filePath, { key: 'value' });
+
+    expect(readFileSync(filePath, 'utf8').startsWith('---\n')).toBe(true);
+  });
+
   it('uses single quotes for strings that need quoting', ({ expect }) => {
     const dir = createTempDir();
     const filePath = path.join(dir, 'test.yml');


### PR DESCRIPTION
## Summary

- `writeYamlFile` now passes `directives: true` so generated YAML emits the leading `---` marker, matching the `yamllint/document-start` rule on first write
- Eliminates the ping-pong drift where `gtb sync` removed the marker and a follow-up `eslint --fix` pass added it back
- Adds a writer-level test asserting the document-start marker is present

Closes #60

## Test plan

- [x] `pnpm run check` passes (lint + fast tests, including new assertion)
- [ ] On a checkout where `codecov.yml` lacks `---`, run `pnpm run gtb sync` and confirm the file now starts with `---` (no `git diff` ping-pong)