### PR TITLE
Document expected turbo cache miss on workspace edits

### DIFF
--- a/.github/actions/turbo-run/action.yml
+++ b/.github/actions/turbo-run/action.yml
@@ -31,6 +31,9 @@ runs:
         TURBO_VERSION: ${{ steps.turbo-version.outputs.version }}
       id: cache-check
       name: Check turbo cache
+      # Workspace edits fully invalidate the cache — see "Turbo cache
+      # miss on workspace edits" in AGENTS.md. The check still pays off
+      # on root-only edits and re-runs.
       run: |
         hit=false
         if dry=$(pnpm dlx "turbo@${TURBO_VERSION}" run "$TURBO_TASK" --dry=json); then

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,6 +151,22 @@ Composite actions:
   lockfile without install. Used to pin `pnpm dlx` invocations to the
   locked version.
 
+### Turbo cache miss on workspace edits
+
+Source changes in any `packages/*` workspace fully invalidate every
+task's cache across all packages — `Cached: 0 cached, N total` is
+expected. Turbo 2.x mixes every file in every workspace package
+reachable from root `package.json` deps/devDeps into
+`hashOfInternalDependencies`, which salts every task hash. Our root
+devDeps (`@gtbuchanan/cli`, `eslint-config`, `tsconfig`, `vitest-config`)
+transitively reach all seven packages. Root-only edits (this doc,
+`.github/`) still hit cache.
+
+Consumers see our packages as external npm deps (lockfile-keyed), so
+they're unaffected. See
+[vercel/turborepo#8202](https://github.com/vercel/turborepo/pull/8202);
+no config scopes this hash.
+
 ### Vitest usage specifics
 
 Slow tests use Vitest's native tag system (`test('name', { tags: ['slow'] }, ...)`


### PR DESCRIPTION
## Summary

- Document why CI shows `Cached: 0 cached, N total` on every PR that touches `packages/*` — turbo 2.x folds every workspace-package file reachable from root devDeps into `hashOfInternalDependencies`, salting every task hash.
- Note that consumers are unaffected (our packages reach them as external, lockfile-keyed deps).
- Add a pointer comment in `turbo-run/action.yml` so the next person debugging a full miss lands on the AGENTS.md section.

## Background

Reproduced via `turbo run build:ci --dry=json` on PR #65 (changed only 2 cli files) vs its base. `globalCacheInputs.hashOfInternalDependencies` differs (`39c66e6f3c5adaa0` → `c755c85836b34844`), and the leaf task `@gtbuchanan/test-utils#compile:ts` — with no internal deps and byte-identical inputs — gets a different task hash purely from that global salt. This is by design per [vercel/turborepo#8202](https://github.com/vercel/turborepo/pull/8202); no config scopes the hash. Removing root devDeps would fix it but would break the root `eslint.config.ts` / `tsconfig.base.json` / `vitest.config.ts` imports and `cli`'s `isSelfHosted` detection. Not worth it for a dogfooding repo — accept the miss, document it.

## Test plan

- [x] `turbo run build:ci --dry=json` on this commit matches dcc5c23 — docs-only edits don't touch any task's cache (this PR's CI should hit, modulo cache eviction)
- [x] CI green