### PR TITLE
Add ESLint plugins for Agent Skills frontmatter validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,9 @@ packages/
   cli/                          — @gtbuchanan/cli (gtb build CLI for consumers)
     skills/                     — Authored Agent Skills deployed by `gtb task deploy:skills`
   eslint-config/                — @gtbuchanan/eslint-config (ESLint configure())
+  eslint-plugin-agent-skills/   — @gtbuchanan/eslint-plugin-agent-skills (Agent Skills schema + name-matches-dir rule)
   eslint-plugin-markdownlint/   — @gtbuchanan/eslint-plugin-markdownlint (markdownlint via ESLint)
+  eslint-plugin-md-frontmatter/ — @gtbuchanan/eslint-plugin-md-frontmatter (Markdown frontmatter validation via JSON Schema)
   eslint-plugin-yamllint/       — @gtbuchanan/eslint-plugin-yamllint (yamllint gap rules via ESLint)
   tsconfig/                     — @gtbuchanan/tsconfig (shared base tsconfig.json)
   vitest-config/                — @gtbuchanan/vitest-config (configurePackage, configureGlobal, + e2e variants)
@@ -82,6 +84,11 @@ coverage, setupFiles, and mock reset.
   `eslint-plugin-yamllint` (yamllint gap rules: truthy, octal-values,
   anchors, document-start/end),
   `eslint-plugin-markdownlint` (Markdown structural linting),
+  `eslint-plugin-md-frontmatter` (generic Markdown frontmatter
+  validation via JSON Schema, ajv-backed),
+  `eslint-plugin-agent-skills` (Agent Skills JSON Schema + the
+  `name-matches-dir` rule; the schema plugs into
+  `eslint-plugin-md-frontmatter`. File length via core `max-lines`),
   `@vitest/eslint-plugin` (test rules), and `eslint-plugin-only-warn`
   (downgrades errors to warnings).
 

--- a/README.md
+++ b/README.md
@@ -4,14 +4,16 @@ Shared build configuration monorepo for JavaScript/TypeScript projects.
 
 ## Packages
 
-| Package                                                                       | Description                          |
-| ----------------------------------------------------------------------------- | ------------------------------------ |
-| [@gtbuchanan/cli](packages/cli)                                               | Shared build CLI (`gtb`)             |
-| [@gtbuchanan/eslint-config](packages/eslint-config)                           | Shared ESLint configuration          |
-| [@gtbuchanan/eslint-plugin-markdownlint](packages/eslint-plugin-markdownlint) | ESLint plugin wrapping markdownlint  |
-| [@gtbuchanan/eslint-plugin-yamllint](packages/eslint-plugin-yamllint)         | ESLint plugin for yamllint gap rules |
-| [@gtbuchanan/tsconfig](packages/tsconfig)                                     | Shared TypeScript base configuration |
-| [@gtbuchanan/vitest-config](packages/vitest-config)                           | Shared Vitest configuration          |
+| Package                                                                           | Description                                                   |
+| --------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| [@gtbuchanan/cli](packages/cli)                                                   | Shared build CLI (`gtb`)                                      |
+| [@gtbuchanan/eslint-config](packages/eslint-config)                               | Shared ESLint configuration                                   |
+| [@gtbuchanan/eslint-plugin-agent-skills](packages/eslint-plugin-agent-skills)     | Agent Skills schema + spec-specific rule                      |
+| [@gtbuchanan/eslint-plugin-markdownlint](packages/eslint-plugin-markdownlint)     | ESLint plugin wrapping markdownlint                           |
+| [@gtbuchanan/eslint-plugin-md-frontmatter](packages/eslint-plugin-md-frontmatter) | ESLint plugin validating Markdown frontmatter via JSON Schema |
+| [@gtbuchanan/eslint-plugin-yamllint](packages/eslint-plugin-yamllint)             | ESLint plugin for yamllint gap rules                          |
+| [@gtbuchanan/tsconfig](packages/tsconfig)                                         | Shared TypeScript base configuration                          |
+| [@gtbuchanan/vitest-config](packages/vitest-config)                               | Shared Vitest configuration                                   |
 
 ## Reusable Workflows
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -23,10 +23,18 @@ component_management:
       name: eslint-plugin-yamllint
       paths:
         - packages/eslint-plugin-yamllint/src/**
+    - component_id: eslint-plugin-md-frontmatter
+      name: eslint-plugin-md-frontmatter
+      paths:
+        - packages/eslint-plugin-md-frontmatter/src/**
     - component_id: eslint-plugin-markdownlint
       name: eslint-plugin-markdownlint
       paths:
         - packages/eslint-plugin-markdownlint/src/**
+    - component_id: eslint-plugin-agent-skills
+      name: eslint-plugin-agent-skills
+      paths:
+        - packages/eslint-plugin-agent-skills/src/**
     - component_id: eslint-config
       name: eslint-config
       paths:
@@ -54,10 +62,18 @@ flags:
     carryforward: true
     paths:
       - packages/eslint-config/
+  eslint-plugin-agent-skills:
+    carryforward: true
+    paths:
+      - packages/eslint-plugin-agent-skills/
   eslint-plugin-markdownlint:
     carryforward: true
     paths:
       - packages/eslint-plugin-markdownlint/
+  eslint-plugin-md-frontmatter:
+    carryforward: true
+    paths:
+      - packages/eslint-plugin-md-frontmatter/
   eslint-plugin-yamllint:
     carryforward: true
     paths:

--- a/packages/eslint-config/e2e/cli.test.ts
+++ b/packages/eslint-config/e2e/cli.test.ts
@@ -1,102 +1,12 @@
-import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
-import { createIsolatedFixture, runCommand } from '@gtbuchanan/test-utils';
+import { runCommand } from '@gtbuchanan/test-utils';
 import { it as base, describe } from 'vitest';
-
-const createRequireConfig = [
-  'import { createRequire } from "node:module";',
-  'import { pathToFileURL } from "node:url";',
-  'const { resolve } = createRequire(import.meta.url);',
-  'const { href } = pathToFileURL(resolve("@gtbuchanan/eslint-config"));',
-  'const { configure } = await import(href);',
-  'export default configure({',
-  '  onlyWarn: false,',
-  '  tsconfigRootDir: import.meta.dirname,',
-  '});',
-].join('\n');
-
-const createRequireOnlyWarnConfig = [
-  'import { createRequire } from "node:module";',
-  'import { pathToFileURL } from "node:url";',
-  'const { resolve } = createRequire(import.meta.url);',
-  'const { href } = pathToFileURL(resolve("@gtbuchanan/eslint-config"));',
-  'const { configure } = await import(href);',
-  'export default configure({',
-  '  onlyWarn: true,',
-  '  tsconfigRootDir: import.meta.dirname,',
-  '});',
-].join('\n');
-
-const tsconfigRoot = `${JSON.stringify({
-  compilerOptions: {
-    module: 'ESNext',
-    moduleResolution: 'bundler',
-    strict: true,
-    target: 'ESNext',
-  },
-})}\n`;
-
-const tsconfig = `${JSON.stringify({
-  extends: './tsconfig.root.json',
-  include: ['**/*.ts', '**/*.mts', '**/*.cts'],
-})}\n`;
-
-interface RunOptions {
-  config?: string;
-  env?: Record<string, string | undefined>;
-  files: Record<string, string>;
-  flags?: readonly string[];
-}
-
-const createFixture = () => {
-  const fixture = createIsolatedFixture({
-    depsPackages: ['typescript'],
-    hookPackages: ['eslint', 'jiti'],
-    packageName: '@gtbuchanan/eslint-config',
-  });
-
-  const eslint = path.join(fixture.hookDir, 'node_modules/.bin/eslint');
-
-  const run = async ({ config, env, files, flags = [] }: RunOptions) => {
-    const runDir = mkdtempSync(path.join(fixture.projectDir, 'run-'));
-    writeFileSync(path.join(runDir, 'eslint.config.ts'), config ?? createRequireConfig);
-    writeFileSync(path.join(runDir, 'tsconfig.json'), tsconfig);
-    writeFileSync(path.join(runDir, 'tsconfig.root.json'), tsconfigRoot);
-
-    const fileNames = Object.keys(files);
-    for (const [name, content] of Object.entries(files)) {
-      const filePath = path.join(runDir, name);
-      mkdirSync(path.join(filePath, '..'), { recursive: true });
-      writeFileSync(filePath, content);
-    }
-
-    const result = await runCommand(eslint, [...flags, ...fileNames], {
-      cwd: runDir,
-      env: {
-        ...process.env,
-        NODE_PATH: fixture.nodePath,
-        ...env,
-      },
-    });
-
-    return {
-      ...result,
-      readFile: (name: string) => readFileSync(path.join(runDir, name), 'utf8'),
-    };
-  };
-
-  return {
-    eslint,
-    nodePath: fixture.nodePath,
-    projectDir: fixture.projectDir,
-    run,
-    [Symbol.dispose]() {
-      fixture[Symbol.dispose]();
-    },
-  };
-};
-
-type Fixture = ReturnType<typeof createFixture>;
+import {
+  type Fixture,
+  createFixture,
+  createRequireOnlyWarnConfig,
+} from './fixture.ts';
 
 /* eslint-disable-next-line vitest/consistent-test-it --
    False positive on .extend() factory:

--- a/packages/eslint-config/e2e/fixture.ts
+++ b/packages/eslint-config/e2e/fixture.ts
@@ -1,0 +1,98 @@
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { createIsolatedFixture, runCommand } from '@gtbuchanan/test-utils';
+
+export const createRequireConfig = [
+  'import { createRequire } from "node:module";',
+  'import { pathToFileURL } from "node:url";',
+  'const { resolve } = createRequire(import.meta.url);',
+  'const { href } = pathToFileURL(resolve("@gtbuchanan/eslint-config"));',
+  'const { configure } = await import(href);',
+  'export default configure({',
+  '  onlyWarn: false,',
+  '  tsconfigRootDir: import.meta.dirname,',
+  '});',
+].join('\n');
+
+export const createRequireOnlyWarnConfig = [
+  'import { createRequire } from "node:module";',
+  'import { pathToFileURL } from "node:url";',
+  'const { resolve } = createRequire(import.meta.url);',
+  'const { href } = pathToFileURL(resolve("@gtbuchanan/eslint-config"));',
+  'const { configure } = await import(href);',
+  'export default configure({',
+  '  onlyWarn: true,',
+  '  tsconfigRootDir: import.meta.dirname,',
+  '});',
+].join('\n');
+
+const tsconfigRoot = `${JSON.stringify({
+  compilerOptions: {
+    module: 'ESNext',
+    moduleResolution: 'bundler',
+    strict: true,
+    target: 'ESNext',
+  },
+})}\n`;
+
+const tsconfig = `${JSON.stringify({
+  extends: './tsconfig.root.json',
+  include: ['**/*.ts', '**/*.mts', '**/*.cts'],
+})}\n`;
+
+interface RunOptions {
+  config?: string;
+  env?: Record<string, string | undefined>;
+  files: Record<string, string>;
+  flags?: readonly string[];
+}
+
+export const createFixture = () => {
+  const fixture = createIsolatedFixture({
+    depsPackages: ['typescript'],
+    hookPackages: ['eslint', 'jiti'],
+    packageName: '@gtbuchanan/eslint-config',
+  });
+
+  const eslint = path.join(fixture.hookDir, 'node_modules/.bin/eslint');
+
+  const run = async ({ config, env, files, flags = [] }: RunOptions) => {
+    const runDir = mkdtempSync(path.join(fixture.projectDir, 'run-'));
+    writeFileSync(path.join(runDir, 'eslint.config.ts'), config ?? createRequireConfig);
+    writeFileSync(path.join(runDir, 'tsconfig.json'), tsconfig);
+    writeFileSync(path.join(runDir, 'tsconfig.root.json'), tsconfigRoot);
+
+    const fileNames = Object.keys(files);
+    for (const [name, content] of Object.entries(files)) {
+      const filePath = path.join(runDir, name);
+      mkdirSync(path.join(filePath, '..'), { recursive: true });
+      writeFileSync(filePath, content);
+    }
+
+    const result = await runCommand(eslint, [...flags, ...fileNames], {
+      cwd: runDir,
+      env: {
+        ...process.env,
+        NODE_PATH: fixture.nodePath,
+        ...env,
+      },
+    });
+
+    return {
+      ...result,
+      readFile: (name: string) => readFileSync(path.join(runDir, name), 'utf8'),
+    };
+  };
+
+  return {
+    eslint,
+    nodePath: fixture.nodePath,
+    projectDir: fixture.projectDir,
+    run,
+    [Symbol.dispose]() {
+      fixture[Symbol.dispose]();
+    },
+  };
+};
+
+export type Fixture = ReturnType<typeof createFixture>;

--- a/packages/eslint-config/e2e/skill.test.ts
+++ b/packages/eslint-config/e2e/skill.test.ts
@@ -1,0 +1,110 @@
+import { it as base, describe } from 'vitest';
+import { type Fixture, createFixture } from './fixture.ts';
+
+/* eslint-disable-next-line vitest/consistent-test-it --
+   False positive on .extend() factory:
+   https://github.com/vitest-dev/eslint-plugin-vitest/issues/884 */
+const it = base.extend<{ fixture: Fixture }>({
+
+  fixture: [async ({}, use) => {
+    using fixture = createFixture();
+    await use(fixture);
+  }, { scope: 'file' }],
+});
+
+const skill = (frontmatter: readonly string[], body: readonly string[] = ['# Body', '']) =>
+  ['---', ...frontmatter, '---', '', ...body].join('\n');
+
+describe.concurrent('SKILL.md validation', () => {
+  it('passes for a valid SKILL.md', async ({ fixture, expect }) => {
+    const result = await fixture.run({
+      files: {
+        'skills/example-skill/SKILL.md': skill(
+          [
+            'name: example-skill',
+            'description: A description that is descriptive enough.',
+          ],
+          ['# Example skill', '', 'Body content.', ''],
+        ),
+      },
+    });
+
+    expect(result).toMatchObject({ exitCode: 0 });
+    expect(result.stdout).not.toMatch(/md-frontmatter|agent-skills/v);
+  });
+
+  it('flags missing required frontmatter fields', async ({ fixture, expect }) => {
+    const result = await fixture.run({
+      files: {
+        'skills/example-skill/SKILL.md': skill(['name: example-skill']),
+      },
+    });
+
+    expect(result.stdout).toMatch(/md-frontmatter\/schema/v);
+    expect(result.stdout).toMatch(/required property 'description'/v);
+  });
+
+  it('flags non-kebab-case name', async ({ fixture, expect }) => {
+    const result = await fixture.run({
+      files: {
+        'skills/example-skill/SKILL.md': skill([
+          'name: ExampleSkill',
+          'description: A description that is descriptive enough.',
+        ]),
+      },
+    });
+
+    expect(result.stdout).toMatch(/md-frontmatter\/schema/v);
+    expect(result.stdout).toMatch(/must match pattern/v);
+  });
+
+  it('flags unknown frontmatter fields', async ({ fixture, expect }) => {
+    const result = await fixture.run({
+      files: {
+        'skills/example-skill/SKILL.md': skill([
+          'name: example-skill',
+          'description: A description that is descriptive enough.',
+          'unknown: value',
+        ]),
+      },
+    });
+
+    expect(result.stdout).toMatch(/md-frontmatter\/schema/v);
+    expect(result.stdout).toMatch(/additional properties/v);
+  });
+
+  it('flags name not matching parent directory', async ({ fixture, expect }) => {
+    const result = await fixture.run({
+      files: {
+        'skills/example-skill/SKILL.md': skill([
+          'name: wrong-name',
+          'description: A description that is descriptive enough.',
+        ]),
+      },
+    });
+
+    expect(result.stdout).toMatch(/agent-skills\/name-matches-dir/v);
+    expect(result.stdout).toMatch(/expected `example-skill`, got `wrong-name`/v);
+  });
+
+  it('caps file at 500 lines per the spec', async ({ fixture, expect }) => {
+    const lines = Array.from(
+      { length: 600 },
+      (_unused, index) => `Line ${String(index + 1)}`,
+    );
+    const result = await fixture.run({
+      files: {
+        'skills/example-skill/SKILL.md': skill(
+          [
+            'name: example-skill',
+            'description: A description that is descriptive enough.',
+          ],
+          [...lines, ''],
+        ),
+      },
+    });
+
+    expect(result.stdout).toMatch(/max-lines/v);
+    expect(result.stdout).toMatch(/Maximum allowed is 500/v);
+  });
+});

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -24,7 +24,9 @@
   "dependencies": {
     "@eslint-community/eslint-plugin-eslint-comments": "catalog:",
     "@eslint/json": "catalog:",
+    "@gtbuchanan/eslint-plugin-agent-skills": "workspace:*",
     "@gtbuchanan/eslint-plugin-markdownlint": "workspace:*",
+    "@gtbuchanan/eslint-plugin-md-frontmatter": "workspace:*",
     "@gtbuchanan/eslint-plugin-yamllint": "workspace:*",
     "@prettier/plugin-xml": "catalog:",
     "@stylistic/eslint-plugin": "catalog:",

--- a/packages/eslint-config/src/plugins/agent-skills.ts
+++ b/packages/eslint-config/src/plugins/agent-skills.ts
@@ -1,0 +1,11 @@
+import { configs } from '@gtbuchanan/eslint-plugin-agent-skills';
+import type { PluginFactory } from '../index.ts';
+
+/**
+ * Agent Skills `SKILL.md` validation. Delegates the entire wiring
+ * (frontmatter schema rule, name-matches-dir rule, file-length cap)
+ * to the plugin's recommended flat-config block.
+ */
+const plugin: PluginFactory = () => [...configs.recommended];
+
+export default plugin;

--- a/packages/eslint-config/src/plugins/index.ts
+++ b/packages/eslint-config/src/plugins/index.ts
@@ -1,4 +1,5 @@
 import type { PluginFactory } from '../index.ts';
+import agentSkills from './agent-skills.ts';
 import core from './core.ts';
 import eslintComments from './eslint-comments.ts';
 import format from './format.ts';
@@ -20,6 +21,6 @@ import yamllint from './yamllint.ts';
 /** Ordered plugin factories. Later entries override earlier ones for the same file. */
 export const plugins: readonly PluginFactory[] = [
   typescript, unicorn, promise, regexp, jsdoc, json, yaml, yamllint, pnpm, node,
-  format, markdownlint, stylistic, eslintComments, importX,
+  format, markdownlint, agentSkills, stylistic, eslintComments, importX,
   core, vitest,
 ];

--- a/packages/eslint-plugin-agent-skills/CHANGELOG.md
+++ b/packages/eslint-plugin-agent-skills/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @gtbuchanan/eslint-plugin-agent-skills
+
+## 0.1.0
+
+### Minor Changes
+
+- Initial release

--- a/packages/eslint-plugin-agent-skills/README.md
+++ b/packages/eslint-plugin-agent-skills/README.md
@@ -1,0 +1,83 @@
+# @gtbuchanan/eslint-plugin-agent-skills
+
+Agent Skills-specific ESLint rules and the canonical
+[Agent Skills frontmatter JSON Schema](./src/schema.json).
+
+Most validation is expressed in the schema and runs via
+`@gtbuchanan/eslint-plugin-md-frontmatter`'s `schema` rule. This package
+ships:
+
+- The Agent Skills frontmatter JSON Schema (exported as
+  `skillFrontmatterSchema`).
+- One rule, `agent-skills/name-matches-dir`, covering the one
+  [spec](https://agentskills.io/specification) constraint that pure
+  schemas can't express: `name` must equal the parent directory name.
+- A `configs.recommended` flat-config block that wires both plugins
+  plus core `max-lines: 500` for `**/skills/*/SKILL.md`.
+
+## Install
+
+```sh
+pnpm add -D \
+  @gtbuchanan/eslint-plugin-md-frontmatter \
+  @gtbuchanan/eslint-plugin-agent-skills \
+  eslint
+```
+
+## Usage
+
+The recommended config wires everything in one line:
+
+```typescript
+// eslint.config.ts
+import { configs } from '@gtbuchanan/eslint-plugin-agent-skills';
+
+export default [...configs.recommended];
+```
+
+The plugin needs a parser that exposes the file source as text. If you
+also use `@gtbuchanan/eslint-plugin-markdownlint`, its parser is already
+wired up for `*.md` files. Otherwise, register a plain-text parser
+(e.g. `eslint-plugin-format`'s `parserPlain`).
+
+To customize the wiring (different file glob, different rule severity,
+extra rules), reference the schema and rule directly:
+
+```typescript
+// eslint.config.ts
+import frontmatter from '@gtbuchanan/eslint-plugin-md-frontmatter';
+import agentSkills, {
+  skillFrontmatterSchema,
+} from '@gtbuchanan/eslint-plugin-agent-skills';
+
+export default [
+  {
+    files: ['custom/path/*/SKILL.md'],
+    plugins: {
+      'agent-skills': agentSkills,
+      'md-frontmatter': frontmatter,
+    },
+    rules: {
+      'agent-skills/name-matches-dir': 'error',
+      'md-frontmatter/schema': ['error', { schema: skillFrontmatterSchema }],
+      'max-lines': ['error', { max: 500 }],
+    },
+  },
+];
+```
+
+## What's covered
+
+- **Schema-driven** (via `md-frontmatter/schema` + `skillFrontmatterSchema`):
+  required `name`/`description`, length limits, kebab-case `name`,
+  `metadata` map of strings, optional `license`/`compatibility`/`allowed-tools`,
+  no unknown top-level fields.
+- **Rule-driven** (this plugin): `name === parent directory name`.
+- **File length** via core `max-lines` (≤ 500 lines per the spec).
+
+## Rules
+
+### `agent-skills/name-matches-dir`
+
+Flags when `name` in `SKILL.md` frontmatter doesn't match the parent
+directory name. No options.

--- a/packages/eslint-plugin-agent-skills/eslint.config.ts
+++ b/packages/eslint-plugin-agent-skills/eslint.config.ts
@@ -1,0 +1,5 @@
+import { configure } from '../eslint-config/src/index.ts';
+
+export default configure({
+  tsconfigRootDir: import.meta.dirname,
+});

--- a/packages/eslint-plugin-agent-skills/package.json
+++ b/packages/eslint-plugin-agent-skills/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@gtbuchanan/eslint-plugin-agent-skills",
+  "version": "0.1.0",
+  "description": "ESLint plugin: Agent Skills JSON Schema + name-matches-dir rule",
+  "type": "module",
+  "imports": {
+    "#src/*": "./src/*"
+  },
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "compile:ts": "pnpm run gtb task compile:ts",
+    "coverage:codecov:upload": "pnpm run gtb task coverage:codecov:upload",
+    "coverage:vitest:merge": "pnpm run gtb task coverage:vitest:merge",
+    "gtb": "node --experimental-strip-types ../../packages/cli/bin/gtb.ts",
+    "lint:eslint": "pnpm run gtb task lint:eslint",
+    "pack:npm": "pnpm run gtb task pack:npm",
+    "test:vitest:fast": "pnpm run gtb task test:vitest:fast",
+    "test:vitest:slow": "pnpm run gtb task test:vitest:slow",
+    "typecheck:ts": "pnpm run gtb task typecheck:ts"
+  },
+  "dependencies": {
+    "@gtbuchanan/eslint-plugin-md-frontmatter": "workspace:*",
+    "yaml": "catalog:"
+  },
+  "devDependencies": {
+    "@gtbuchanan/vitest-config": "workspace:*"
+  },
+  "peerDependencies": {
+    "eslint": "^10.0.0"
+  },
+  "engines": {
+    "node": ">=24.0.0"
+  },
+  "publishConfig": {
+    "directory": "dist/source",
+    "exports": {
+      ".": "./src/index.js"
+    },
+    "linkDirectory": false
+  }
+}

--- a/packages/eslint-plugin-agent-skills/src/index.ts
+++ b/packages/eslint-plugin-agent-skills/src/index.ts
@@ -1,0 +1,55 @@
+import frontmatter from '@gtbuchanan/eslint-plugin-md-frontmatter';
+import type { ESLint, Linter } from 'eslint';
+import { nameMatchesDir } from './rules/name-matches-dir.ts';
+import schema from './schema.json' with { type: 'json' };
+
+/**
+ * JSON Schema for Agent Skills `SKILL.md` frontmatter, per the
+ * [Agent Skills specification](https://agentskills.io/specification).
+ * Pair with `@gtbuchanan/eslint-plugin-md-frontmatter`'s `schema` rule
+ * to validate frontmatter at lint time. `$id` is set to a
+ * forward-looking canonical URL — the schema is not yet published at
+ * that location.
+ */
+export { default as skillFrontmatterSchema }
+  from './schema.json' with { type: 'json' };
+
+/**
+ * ESLint plugin for Agent Skills-specific lint checks. Most validation
+ * lives in the JSON Schema (see `skillFrontmatterSchema`); this plugin
+ * only ships the `name-matches-dir` rule for the one spec constraint
+ * that schemas can't express.
+ */
+const plugin: ESLint.Plugin = {
+  rules: {
+    'name-matches-dir': nameMatchesDir,
+  },
+};
+
+/**
+ * Ready-to-spread flat-config blocks for SKILL.md files.
+ *
+ * - `recommended` — wires `md-frontmatter/schema` (with the canonical
+ *   schema), `agent-skills/name-matches-dir`, and core `max-lines: 500`
+ *   for file-length enforcement, scoped to `**\/skills/*\/SKILL.md`.
+ */
+export const configs: {
+  readonly recommended: readonly Linter.Config[];
+} = {
+  recommended: [
+    {
+      files: ['**/skills/*/SKILL.md'],
+      plugins: {
+        'agent-skills': plugin,
+        'md-frontmatter': frontmatter,
+      },
+      rules: {
+        'agent-skills/name-matches-dir': 'warn',
+        'max-lines': ['warn', { max: 500 }],
+        'md-frontmatter/schema': ['warn', { schema }],
+      },
+    },
+  ],
+};
+
+export default plugin;

--- a/packages/eslint-plugin-agent-skills/src/rules/name-matches-dir.ts
+++ b/packages/eslint-plugin-agent-skills/src/rules/name-matches-dir.ts
@@ -1,0 +1,59 @@
+import path from 'node:path';
+import {
+  parseMarkdown,
+  toEslintLoc,
+} from '@gtbuchanan/eslint-plugin-md-frontmatter/parse';
+import type { Rule } from 'eslint';
+import { isMap, isScalar } from 'yaml';
+
+/**
+ * Validates that the Agent Skills SKILL.md `name` frontmatter field
+ * matches the parent directory name, per the spec. Other field-level
+ * checks (length, kebab-case, required) are expressed in the
+ * frontmatter JSON Schema and run via `md-frontmatter/schema` — this
+ * rule covers the one constraint a pure schema can't express.
+ */
+export const nameMatchesDir: Rule.RuleModule = {
+  meta: {
+    schema: [],
+    type: 'problem',
+  },
+
+  create(context) {
+    return {
+      Program() {
+        const { filename } = context;
+        if (!filename) return;
+        const text = context.sourceCode.getText();
+        const { frontmatter, lineCounter } = parseMarkdown(
+          context.sourceCode,
+          text,
+        );
+        if (!frontmatter) return;
+
+        const root = frontmatter.document.contents;
+        if (!isMap(root)) return;
+        const pair = root.items.find(
+          item => isScalar(item.key) && item.key.value === 'name',
+        );
+        if (!pair || !isScalar(pair.value)) return;
+        const { range, value } = pair.value;
+        if (typeof value !== 'string') return;
+
+        const parentDir = path.basename(path.dirname(filename));
+        if (value === parentDir) return;
+
+        const [start, end] = range;
+        context.report({
+          loc: {
+            end: toEslintLoc(lineCounter, frontmatter.contentOffset + end),
+            start: toEslintLoc(lineCounter, frontmatter.contentOffset + start),
+          },
+          message:
+            '`name` must match the parent directory name ' +
+            `(expected \`${parentDir}\`, got \`${value}\`)`,
+        });
+      },
+    };
+  },
+};

--- a/packages/eslint-plugin-agent-skills/src/schema.json
+++ b/packages/eslint-plugin-agent-skills/src/schema.json
@@ -1,0 +1,41 @@
+{
+  "$id": "https://gtbuchanan.github.io/tooling/schemas/agent-skills/skill-frontmatter.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "properties": {
+    "allowed-tools": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "compatibility": {
+      "maxLength": 500,
+      "minLength": 1,
+      "type": "string"
+    },
+    "description": {
+      "maxLength": 1024,
+      "minLength": 1,
+      "type": "string"
+    },
+    "license": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "metadata": {
+      "additionalProperties": { "type": "string" },
+      "type": "object"
+    },
+    "name": {
+      "maxLength": 64,
+      "minLength": 1,
+      "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$",
+      "type": "string"
+    }
+  },
+  "required": [
+    "name",
+    "description"
+  ],
+  "title": "Agent Skills SKILL.md frontmatter",
+  "type": "object"
+}

--- a/packages/eslint-plugin-agent-skills/test/name-matches-dir.test.ts
+++ b/packages/eslint-plugin-agent-skills/test/name-matches-dir.test.ts
@@ -1,0 +1,69 @@
+import { RuleTester } from 'eslint';
+import { describe, it } from 'vitest';
+import { nameMatchesDir } from '#src/rules/name-matches-dir.js';
+import * as parser from './parser.js';
+
+const ruleTester = new RuleTester({
+  languageOptions: { parser },
+});
+
+describe('agent-skills/name-matches-dir', () => {
+  it('passes when name matches the parent directory', ({ expect }) => {
+    expect(() => {
+      ruleTester.run('agent-skills/name-matches-dir', nameMatchesDir, {
+        invalid: [],
+        valid: [
+          {
+            code: '---\nname: my-skill\ndescription: ok.\n---\n',
+            filename: '/repo/skills/my-skill/SKILL.md',
+          },
+        ],
+      });
+    }).not.toThrow();
+  });
+
+  it('flags when name differs from the parent directory', ({ expect }) => {
+    expect(() => {
+      ruleTester.run('agent-skills/name-matches-dir', nameMatchesDir, {
+        invalid: [
+          {
+            code: '---\nname: wrong-name\ndescription: ok.\n---\n',
+            errors: [{
+              message: /expected `my-skill`, got `wrong-name`/v,
+            }],
+            filename: '/repo/skills/my-skill/SKILL.md',
+          },
+        ],
+        valid: [],
+      });
+    }).not.toThrow();
+  });
+
+  it('skips when there is no frontmatter', ({ expect }) => {
+    expect(() => {
+      ruleTester.run('agent-skills/name-matches-dir', nameMatchesDir, {
+        invalid: [],
+        valid: [
+          {
+            code: '# No frontmatter\n',
+            filename: '/repo/skills/foo/SKILL.md',
+          },
+        ],
+      });
+    }).not.toThrow();
+  });
+
+  it('skips when name field is absent', ({ expect }) => {
+    expect(() => {
+      ruleTester.run('agent-skills/name-matches-dir', nameMatchesDir, {
+        invalid: [],
+        valid: [
+          {
+            code: '---\ndescription: ok.\n---\n',
+            filename: '/repo/skills/foo/SKILL.md',
+          },
+        ],
+      });
+    }).not.toThrow();
+  });
+});

--- a/packages/eslint-plugin-agent-skills/test/parser.ts
+++ b/packages/eslint-plugin-agent-skills/test/parser.ts
@@ -1,0 +1,32 @@
+import type { Linter } from 'eslint';
+
+/**
+ * Minimal ESLint parser for SKILL.md test files. Produces a `Program`
+ * AST node with the raw source text accessible via `context.sourceCode`.
+ */
+export const parseForESLint = (code: string): Linter.ESLintParseResult => {
+  const lines = code.split(/\r\n?|\n/v);
+  const lastLine = lines.at(-1) ?? '';
+
+  return {
+    ast: {
+      body: [],
+      comments: [],
+      loc: {
+        end: { column: lastLine.length, line: lines.length },
+        start: { column: 0, line: 1 },
+      },
+      range: [0, code.length] as [number, number],
+      sourceType: 'module',
+      tokens: [],
+      type: 'Program' as const,
+    },
+    scopeManager: undefined,
+    visitorKeys: {},
+  };
+};
+
+/** Parser metadata. */
+export const meta = {
+  name: '@gtbuchanan/eslint-plugin-agent-skills/test-parser',
+};

--- a/packages/eslint-plugin-agent-skills/tsconfig.build.json
+++ b/packages/eslint-plugin-agent-skills/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "outDir": "dist/source",
+    "rootDir": "."
+  },
+  "extends": "../../tsconfig.build.json",
+  "include": [
+    "bin",
+    "src"
+  ]
+}

--- a/packages/eslint-plugin-agent-skills/tsconfig.json
+++ b/packages/eslint-plugin-agent-skills/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "extends": "../../tsconfig.base.json",
+  "include": [
+    "bin",
+    "scripts",
+    "src",
+    "test",
+    "e2e",
+    "*",
+    ".*"
+  ]
+}

--- a/packages/eslint-plugin-agent-skills/vitest.config.ts
+++ b/packages/eslint-plugin-agent-skills/vitest.config.ts
@@ -1,0 +1,3 @@
+import { configurePackage } from '../vitest-config/src/configure.ts';
+
+export default configurePackage();

--- a/packages/eslint-plugin-md-frontmatter/CHANGELOG.md
+++ b/packages/eslint-plugin-md-frontmatter/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @gtbuchanan/eslint-plugin-md-frontmatter
+
+## 0.1.0
+
+### Minor Changes
+
+- Initial release

--- a/packages/eslint-plugin-md-frontmatter/README.md
+++ b/packages/eslint-plugin-md-frontmatter/README.md
@@ -1,0 +1,68 @@
+# @gtbuchanan/eslint-plugin-md-frontmatter
+
+ESLint plugin validating Markdown YAML frontmatter against a JSON Schema.
+Generic — knows nothing about specific schemas. Consumers supply the schema
+via the rule option.
+
+## Why?
+
+Markdown frontmatter often follows a strict shape (Agent Skills, blog posts,
+docusaurus pages, changesets, etc.). JSON Schema is the standard way to
+describe that shape. This plugin runs the same kind of structural check as
+[`remark-lint-frontmatter-schema`](https://github.com/JulianCataldo/remark-lint-frontmatter-schema)
+but inside ESLint, so problems surface inline in the editor and inside the
+existing `lint:eslint` task.
+
+## Install
+
+```sh
+pnpm add -D @gtbuchanan/eslint-plugin-md-frontmatter eslint
+```
+
+## Usage
+
+```typescript
+// eslint.config.ts
+import frontmatter from '@gtbuchanan/eslint-plugin-md-frontmatter';
+
+const blogPostSchema = {
+  type: 'object',
+  required: ['title', 'date'],
+  additionalProperties: false,
+  properties: {
+    title: { type: 'string', minLength: 1, maxLength: 100 },
+    date: { type: 'string', format: 'date' },
+    tags: { type: 'array', items: { type: 'string' } },
+  },
+};
+
+export default [
+  {
+    files: ['content/posts/**/*.md'],
+    plugins: { 'md-frontmatter': frontmatter },
+    rules: {
+      'md-frontmatter/schema': ['warn', { schema: blogPostSchema }],
+    },
+  },
+];
+```
+
+The plugin needs a parser that exposes the source as text. Pair it with
+`@gtbuchanan/eslint-plugin-markdownlint`'s parser (already wired for `*.md`
+files in `@gtbuchanan/eslint-config`), or any plain-text parser like
+`eslint-plugin-format`'s `parserPlain`.
+
+## Rules
+
+### `md-frontmatter/schema`
+
+Validates frontmatter against a JSON Schema. Each Ajv error is reported
+with a source location pointing at the offending YAML node.
+
+| Option   | Type     | Required | Description                      |
+| -------- | -------- | -------- | -------------------------------- |
+| `schema` | `object` | Yes      | JSON Schema (Draft-07 supported) |
+
+The rule also reports when frontmatter is missing entirely. If you only
+want to validate frontmatter when present, gate the rule's `files` glob
+to files that should have frontmatter.

--- a/packages/eslint-plugin-md-frontmatter/eslint.config.ts
+++ b/packages/eslint-plugin-md-frontmatter/eslint.config.ts
@@ -1,0 +1,5 @@
+import { configure } from '../eslint-config/src/index.ts';
+
+export default configure({
+  tsconfigRootDir: import.meta.dirname,
+});

--- a/packages/eslint-plugin-md-frontmatter/package.json
+++ b/packages/eslint-plugin-md-frontmatter/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@gtbuchanan/eslint-plugin-md-frontmatter",
+  "version": "0.1.0",
+  "description": "ESLint plugin validating Markdown YAML frontmatter against a JSON Schema",
+  "type": "module",
+  "imports": {
+    "#src/*": "./src/*"
+  },
+  "exports": {
+    ".": "./src/index.ts",
+    "./parse": "./src/parse.ts"
+  },
+  "scripts": {
+    "compile:ts": "pnpm run gtb task compile:ts",
+    "coverage:codecov:upload": "pnpm run gtb task coverage:codecov:upload",
+    "coverage:vitest:merge": "pnpm run gtb task coverage:vitest:merge",
+    "gtb": "node --experimental-strip-types ../../packages/cli/bin/gtb.ts",
+    "lint:eslint": "pnpm run gtb task lint:eslint",
+    "pack:npm": "pnpm run gtb task pack:npm",
+    "test:vitest:fast": "pnpm run gtb task test:vitest:fast",
+    "test:vitest:slow": "pnpm run gtb task test:vitest:slow",
+    "typecheck:ts": "pnpm run gtb task typecheck:ts"
+  },
+  "dependencies": {
+    "ajv": "catalog:",
+    "yaml": "catalog:"
+  },
+  "devDependencies": {
+    "@gtbuchanan/vitest-config": "workspace:*"
+  },
+  "peerDependencies": {
+    "eslint": "^10.0.0"
+  },
+  "engines": {
+    "node": ">=24.0.0"
+  },
+  "publishConfig": {
+    "directory": "dist/source",
+    "exports": {
+      ".": "./src/index.js",
+      "./parse": "./src/parse.js"
+    },
+    "linkDirectory": false
+  }
+}

--- a/packages/eslint-plugin-md-frontmatter/src/index.ts
+++ b/packages/eslint-plugin-md-frontmatter/src/index.ts
@@ -1,0 +1,16 @@
+import type { ESLint } from 'eslint';
+import { schema } from './rules/schema.ts';
+
+/**
+ * ESLint plugin validating Markdown YAML frontmatter against a
+ * user-supplied JSON Schema. Generic — knows nothing about specific
+ * schemas (Agent Skills, changesets, etc.); consumers supply the
+ * schema via the rule option.
+ */
+const plugin: ESLint.Plugin = {
+  rules: {
+    schema,
+  },
+};
+
+export default plugin;

--- a/packages/eslint-plugin-md-frontmatter/src/parse.ts
+++ b/packages/eslint-plugin-md-frontmatter/src/parse.ts
@@ -1,0 +1,79 @@
+import { LineCounter, parseDocument } from 'yaml';
+import type { Document } from 'yaml';
+
+const frontmatterPattern =
+  /^(?<opener>---\r?\n)(?<content>[\s\S]*?)\r?\n---(?:\r?\n|$)/v;
+
+/** Position info for a parsed YAML frontmatter block. */
+export interface ParsedFrontmatter {
+  readonly document: Document.Parsed;
+  /** Offset in the source where the frontmatter content begins (after opening `---`). */
+  readonly contentOffset: number;
+  /** Offset in the source where the closing `---` line ends. */
+  readonly endOffset: number;
+}
+
+/** Result of parsing a Markdown file with optional YAML frontmatter. */
+export interface ParsedMarkdown {
+  readonly lineCounter: LineCounter;
+  readonly frontmatter: ParsedFrontmatter | undefined;
+}
+
+const cache = new WeakMap<object, ParsedMarkdown>();
+
+const buildLineCounter = (text: string): LineCounter => {
+  /* yaml's LineCounter expects each call to register the first
+     character of a new line (one past the `\n`), with line 1 seeded
+     at offset 0 — matches what yaml's own Parser does internally. */
+  const lc = new LineCounter();
+  lc.addNewLine(0);
+  let offset = text.indexOf('\n');
+  while (offset !== -1) {
+    lc.addNewLine(offset + 1);
+    offset = text.indexOf('\n', offset + 1);
+  }
+  return lc;
+};
+
+/**
+ * Parses Markdown frontmatter, cached per ESLint source scope. Uses
+ * `context.sourceCode` as the cache key so multiple rules share a
+ * single parse per file.
+ */
+export const parseMarkdown = (
+  cacheKey: object,
+  text: string,
+): ParsedMarkdown => {
+  const cached = cache.get(cacheKey);
+  if (cached) return cached;
+
+  const lineCounter = buildLineCounter(text);
+  const match = frontmatterPattern.exec(text);
+
+  let frontmatter: ParsedFrontmatter | undefined;
+  if (match) {
+    const opener = match.groups?.['opener'] ?? '';
+    const content = match.groups?.['content'] ?? '';
+    frontmatter = {
+      contentOffset: opener.length,
+      document: parseDocument(content),
+      endOffset: match[0].length,
+    };
+  }
+
+  const result: ParsedMarkdown = { frontmatter, lineCounter };
+  cache.set(cacheKey, result);
+  return result;
+};
+
+/**
+ * Converts a yaml `LineCounter` offset to an ESLint source location.
+ * The yaml package uses 1-based columns; ESLint uses 0-based.
+ */
+export const toEslintLoc = (
+  lineCounter: LineCounter,
+  offset: number,
+): { column: number; line: number } => {
+  const pos = lineCounter.linePos(offset);
+  return { column: pos.col - 1, line: pos.line };
+};

--- a/packages/eslint-plugin-md-frontmatter/src/rules/schema.ts
+++ b/packages/eslint-plugin-md-frontmatter/src/rules/schema.ts
@@ -1,0 +1,209 @@
+import { Ajv } from 'ajv';
+import type {
+  ErrorObject,
+  SchemaObject,
+  ValidateFunction,
+} from 'ajv';
+import type { AST, Rule } from 'eslint';
+import { isMap, isNode, isScalar, isSeq } from 'yaml';
+import type { Document, LineCounter, Node, Pair, YAMLMap } from 'yaml';
+import { parseMarkdown, toEslintLoc } from '#src/parse.js';
+
+interface SchemaRuleOptions {
+  readonly schema: SchemaObject;
+}
+
+const ruleOptionsSchema = [
+  {
+    additionalProperties: false,
+    properties: {
+      schema: { additionalProperties: true, type: 'object' },
+    },
+    required: ['schema'],
+    type: 'object',
+  },
+];
+
+/*
+ * Single Ajv instance reused across rule invocations. Compiled validators
+ * are cached by schema-object identity so a stable rule config compiles
+ * once per ESLint run. `validateSchema: false` skips the meta-schema
+ * lookup so user schemas can reference any `$schema` URL (or omit it)
+ * without forcing us to register the corresponding meta-schema.
+ */
+const ajv = new Ajv({
+  allErrors: true,
+  strict: false,
+  validateSchema: false,
+});
+const compileCache = new WeakMap<object, ValidateFunction>();
+
+const compile = (schema: SchemaObject): ValidateFunction => {
+  const cached = compileCache.get(schema);
+  if (cached) return cached;
+  const validate = ajv.compile(schema);
+  compileCache.set(schema, validate);
+  return validate;
+};
+
+const decodeJsonPointer = (segment: string): string =>
+  segment.replaceAll('~1', '/').replaceAll('~0', '~');
+
+const splitInstancePath = (path: string): readonly string[] => {
+  if (path === '') return [];
+  return path.split('/').slice(1).map(decodeJsonPointer);
+};
+
+const findPairByKey = (
+  map: YAMLMap,
+  key: string,
+): Pair | undefined =>
+  map.items.find(
+    item => isScalar(item.key) && String(item.key.value) === key,
+  );
+
+const findNode = (
+  root: Node | undefined,
+  segments: readonly string[],
+): Node | undefined => {
+  let current: Node | undefined = root;
+  for (const seg of segments) {
+    if (!current) return undefined;
+    if (isMap(current)) {
+      const next = findPairByKey(current, seg)?.value;
+      current = isNode(next) ? next : undefined;
+    } else if (isSeq(current)) {
+      const index = Number(seg);
+      if (!Number.isInteger(index)) return undefined;
+      const next = current.items[index];
+      current = isNode(next) ? next : undefined;
+    } else {
+      return undefined;
+    }
+  }
+  return current;
+};
+
+const findChildKeyInMap = (
+  root: Node | undefined,
+  segments: readonly string[],
+  childKey: string,
+): Node | undefined => {
+  const parent = findNode(root, segments);
+  if (!parent || !isMap(parent)) return undefined;
+  const keyNode = findPairByKey(parent, childKey)?.key;
+  return isNode(keyNode) ? keyNode : undefined;
+};
+
+const locateNode = (
+  lineCounter: LineCounter,
+  contentOffset: number,
+  node: Node | undefined,
+  fallback: AST.SourceLocation,
+): AST.SourceLocation => {
+  if (!node?.range) return fallback;
+  const [start, end] = node.range;
+  return {
+    end: toEslintLoc(lineCounter, contentOffset + end),
+    start: toEslintLoc(lineCounter, contentOffset + start),
+  };
+};
+
+const pathLabel = (segments: readonly string[]): string =>
+  ['frontmatter', ...segments].join('.');
+
+interface ReportContext {
+  readonly contentOffset: number;
+  readonly context: Rule.RuleContext;
+  readonly document: Document.Parsed;
+  readonly fallbackLoc: AST.SourceLocation;
+  readonly lineCounter: LineCounter;
+}
+
+const reportError = (ctx: ReportContext, error: ErrorObject): void => {
+  const root = ctx.document.contents ?? undefined;
+  const segments = splitInstancePath(error.instancePath);
+
+  let target: Node | undefined;
+  let label: string;
+
+  if (error.keyword === 'additionalProperties') {
+    /* ajv types `error.params` as `Record<string, any>`; the
+       `additionalProperties` keyword always populates this shape. */
+    const additionalProperty = String(
+      (error.params as { additionalProperty: unknown }).additionalProperty,
+    );
+    target = findChildKeyInMap(root, segments, additionalProperty);
+    label = pathLabel([...segments, additionalProperty]);
+  } else {
+    target = findNode(root, segments);
+    label = pathLabel(segments);
+  }
+
+  ctx.context.report({
+    loc: locateNode(ctx.lineCounter, ctx.contentOffset, target, ctx.fallbackLoc),
+    message: `\`${label}\` ${error.message ?? 'is invalid'}`,
+  });
+};
+
+/**
+ * Validates Markdown YAML frontmatter against a JSON Schema provided in
+ * the rule options. Reports each Ajv error with a source location
+ * pointing at the offending YAML node.
+ */
+export const schema: Rule.RuleModule = {
+  meta: {
+    schema: ruleOptionsSchema,
+    type: 'problem',
+  },
+
+  create(context) {
+    return {
+      Program() {
+        const options = context.options[0] as SchemaRuleOptions | undefined;
+        if (!options) return;
+
+        const validate = compile(options.schema);
+        const text = context.sourceCode.getText();
+        const { frontmatter, lineCounter } = parseMarkdown(
+          context.sourceCode,
+          text,
+        );
+
+        if (!frontmatter) {
+          context.report({
+            loc: {
+              end: { column: 0, line: 1 },
+              start: { column: 0, line: 1 },
+            },
+            message:
+              'Markdown file must begin with YAML frontmatter delimited by `---`',
+          });
+          return;
+        }
+
+        const data: unknown = frontmatter.document.toJS();
+        if (validate(data)) return;
+
+        const errors = validate.errors ?? [];
+        const fallbackLoc: AST.SourceLocation = {
+          end: toEslintLoc(lineCounter, frontmatter.endOffset),
+          start: toEslintLoc(lineCounter, frontmatter.contentOffset),
+        };
+
+        for (const error of errors) {
+          reportError(
+            {
+              context,
+              contentOffset: frontmatter.contentOffset,
+              document: frontmatter.document,
+              fallbackLoc,
+              lineCounter,
+            },
+            error,
+          );
+        }
+      },
+    };
+  },
+};

--- a/packages/eslint-plugin-md-frontmatter/test/parser.ts
+++ b/packages/eslint-plugin-md-frontmatter/test/parser.ts
@@ -1,0 +1,32 @@
+import type { Linter } from 'eslint';
+
+/**
+ * Minimal ESLint parser for Markdown test files. Produces a `Program`
+ * AST node with the raw source text accessible via `context.sourceCode`.
+ */
+export const parseForESLint = (code: string): Linter.ESLintParseResult => {
+  const lines = code.split(/\r\n?|\n/v);
+  const lastLine = lines.at(-1) ?? '';
+
+  return {
+    ast: {
+      body: [],
+      comments: [],
+      loc: {
+        end: { column: lastLine.length, line: lines.length },
+        start: { column: 0, line: 1 },
+      },
+      range: [0, code.length] as [number, number],
+      sourceType: 'module',
+      tokens: [],
+      type: 'Program' as const,
+    },
+    scopeManager: undefined,
+    visitorKeys: {},
+  };
+};
+
+/** Parser metadata. */
+export const meta = {
+  name: '@gtbuchanan/eslint-plugin-md-frontmatter/test-parser',
+};

--- a/packages/eslint-plugin-md-frontmatter/test/schema.test.ts
+++ b/packages/eslint-plugin-md-frontmatter/test/schema.test.ts
@@ -1,0 +1,170 @@
+import { RuleTester } from 'eslint';
+import { describe, it } from 'vitest';
+import { schema } from '#src/rules/schema.js';
+import * as parser from './parser.js';
+
+const ruleTester = new RuleTester({
+  languageOptions: { parser },
+});
+
+const testSchema = {
+  $schema: 'https://json-schema.org/draft-07/schema',
+  additionalProperties: false,
+  properties: {
+    description: { maxLength: 100, minLength: 1, type: 'string' },
+    metadata: {
+      additionalProperties: { type: 'string' },
+      type: 'object',
+    },
+    name: {
+      maxLength: 64,
+      minLength: 1,
+      pattern: '^[a-z0-9]+(?:-[a-z0-9]+)*$',
+      type: 'string',
+    },
+  },
+  required: ['name', 'description'],
+  type: 'object',
+} as const;
+
+describe('md-frontmatter/schema', () => {
+  it('passes for frontmatter that satisfies the schema', ({ expect }) => {
+    expect(() => {
+      ruleTester.run('md-frontmatter/schema', schema, {
+        invalid: [],
+        valid: [
+          {
+            code: '---\nname: example\ndescription: A description.\n---\n# Body\n',
+            options: [{ schema: testSchema }],
+          },
+        ],
+      });
+    }).not.toThrow();
+  });
+
+  it('flags missing frontmatter', ({ expect }) => {
+    expect(() => {
+      ruleTester.run('md-frontmatter/schema', schema, {
+        invalid: [
+          {
+            code: '# No frontmatter\n',
+            errors: [{ message: /must begin with YAML frontmatter/v }],
+            options: [{ schema: testSchema }],
+          },
+        ],
+        valid: [],
+      });
+    }).not.toThrow();
+  });
+
+  it('flags missing required property at root', ({ expect }) => {
+    expect(() => {
+      ruleTester.run('md-frontmatter/schema', schema, {
+        invalid: [
+          {
+            code: '---\nname: example\n---\n# Body\n',
+            errors: [
+              {
+                message: /`frontmatter` must have required property 'description'/v,
+              },
+            ],
+            options: [{ schema: testSchema }],
+          },
+        ],
+        valid: [],
+      });
+    }).not.toThrow();
+  });
+
+  it('flags pattern violation on a scalar value', ({ expect }) => {
+    expect(() => {
+      ruleTester.run('md-frontmatter/schema', schema, {
+        invalid: [
+          {
+            code: '---\nname: BadName\ndescription: ok.\n---\n',
+            errors: [{ message: /`frontmatter\.name` must match pattern/v }],
+            options: [{ schema: testSchema }],
+          },
+        ],
+        valid: [],
+      });
+    }).not.toThrow();
+  });
+
+  it('flags maxLength violation', ({ expect }) => {
+    const description = 'a'.repeat(101);
+
+    expect(() => {
+      ruleTester.run('md-frontmatter/schema', schema, {
+        invalid: [
+          {
+            code: `---\nname: ok\ndescription: ${description}\n---\n`,
+            errors: [{
+              message: /`frontmatter\.description`.*more than 100 characters/v,
+            }],
+            options: [{ schema: testSchema }],
+          },
+        ],
+        valid: [],
+      });
+    }).not.toThrow();
+  });
+
+  it('flags additionalProperties at root', ({ expect }) => {
+    expect(() => {
+      ruleTester.run('md-frontmatter/schema', schema, {
+        invalid: [
+          {
+            code: '---\nname: ok\ndescription: ok.\nunknown: 42\n---\n',
+            errors: [
+              {
+                message: /`frontmatter\.unknown`.*NOT have additional properties/v,
+              },
+            ],
+            options: [{ schema: testSchema }],
+          },
+        ],
+        valid: [],
+      });
+    }).not.toThrow();
+  });
+
+  it('flags wrong type for nested property', ({ expect }) => {
+    expect(() => {
+      ruleTester.run('md-frontmatter/schema', schema, {
+        invalid: [
+          {
+            code: '---\nname: ok\ndescription: ok.\nmetadata:\n  version: 1\n---\n',
+            errors: [{
+              message: /`frontmatter\.metadata\.version` must be string/v,
+            }],
+            options: [{ schema: testSchema }],
+          },
+        ],
+        valid: [],
+      });
+    }).not.toThrow();
+  });
+
+  it('reports each violating constraint separately', ({ expect }) => {
+    /*
+     * `name: ""` violates both minLength (1) and pattern. With
+     * `allErrors: true`, ajv reports both — verify both reach ESLint.
+     */
+    expect(() => {
+      ruleTester.run('md-frontmatter/schema', schema, {
+        invalid: [
+          {
+            code: '---\nname: ""\ndescription: ok.\n---\n',
+            errors: [
+              { message: /`frontmatter\.name`.*fewer than 1 characters/v },
+              { message: /`frontmatter\.name` must match pattern/v },
+            ],
+            options: [{ schema: testSchema }],
+          },
+        ],
+        valid: [],
+      });
+    }).not.toThrow();
+  });
+});

--- a/packages/eslint-plugin-md-frontmatter/tsconfig.build.json
+++ b/packages/eslint-plugin-md-frontmatter/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "outDir": "dist/source",
+    "rootDir": "."
+  },
+  "extends": "../../tsconfig.build.json",
+  "include": [
+    "bin",
+    "src"
+  ]
+}

--- a/packages/eslint-plugin-md-frontmatter/tsconfig.json
+++ b/packages/eslint-plugin-md-frontmatter/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "extends": "../../tsconfig.base.json",
+  "include": [
+    "bin",
+    "scripts",
+    "src",
+    "test",
+    "e2e",
+    "*",
+    ".*"
+  ]
+}

--- a/packages/eslint-plugin-md-frontmatter/vitest.config.ts
+++ b/packages/eslint-plugin-md-frontmatter/vitest.config.ts
@@ -1,0 +1,3 @@
+import { configurePackage } from '../vitest-config/src/configure.ts';
+
+export default configurePackage();

--- a/packages/tsconfig/node.json
+++ b/packages/tsconfig/node.json
@@ -7,6 +7,7 @@
     ],
     "module": "nodenext",
     "moduleResolution": "nodenext",
+    "resolveJsonModule": true,
     "target": "ES2024",
     "types": [
       "node"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,9 @@ catalogs:
     '@vitest/eslint-plugin':
       specifier: 1.6.14
       version: 1.6.14
+    ajv:
+      specifier: ^8.20.0
+      version: 8.20.0
     citty:
       specifier: ^0.2.2
       version: 0.2.2
@@ -250,9 +253,15 @@ importers:
       '@eslint/json':
         specifier: 'catalog:'
         version: 1.2.0
+      '@gtbuchanan/eslint-plugin-agent-skills':
+        specifier: workspace:*
+        version: link:../eslint-plugin-agent-skills
       '@gtbuchanan/eslint-plugin-markdownlint':
         specifier: workspace:*
         version: link:../eslint-plugin-markdownlint
+      '@gtbuchanan/eslint-plugin-md-frontmatter':
+        specifier: workspace:*
+        version: link:../eslint-plugin-md-frontmatter
       '@gtbuchanan/eslint-plugin-yamllint':
         specifier: workspace:*
         version: link:../eslint-plugin-yamllint
@@ -325,6 +334,23 @@ importers:
         version: link:../vitest-config
     publishDirectory: dist/source
 
+  packages/eslint-plugin-agent-skills:
+    dependencies:
+      '@gtbuchanan/eslint-plugin-md-frontmatter':
+        specifier: workspace:*
+        version: link:../eslint-plugin-md-frontmatter
+      eslint:
+        specifier: ^10.0.0
+        version: 10.1.0(jiti@2.6.1)
+      yaml:
+        specifier: 'catalog:'
+        version: 2.8.3
+    devDependencies:
+      '@gtbuchanan/vitest-config':
+        specifier: workspace:*
+        version: link:../vitest-config
+    publishDirectory: dist/source
+
   packages/eslint-plugin-markdownlint:
     dependencies:
       eslint:
@@ -333,6 +359,23 @@ importers:
       markdownlint:
         specifier: 'catalog:'
         version: 0.40.0
+    devDependencies:
+      '@gtbuchanan/vitest-config':
+        specifier: workspace:*
+        version: link:../vitest-config
+    publishDirectory: dist/source
+
+  packages/eslint-plugin-md-frontmatter:
+    dependencies:
+      ajv:
+        specifier: 'catalog:'
+        version: 8.20.0
+      eslint:
+        specifier: ^10.0.0
+        version: 10.1.0(jiti@2.6.1)
+      yaml:
+        specifier: 'catalog:'
+        version: 2.8.3
     devDependencies:
       '@gtbuchanan/vitest-config':
         specifier: workspace:*
@@ -1205,6 +1248,9 @@ packages:
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==, tarball: https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz}
 
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==, tarball: https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz}
+
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==, tarball: https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz}
     engines: {node: '>=6'}
@@ -1746,6 +1792,9 @@ packages:
   fast-string-width@1.1.0:
     resolution: {integrity: sha512-O3fwIVIH5gKB38QNbdg+3760ZmGz0SZMgvwJbA1b2TGXceKE6A2cOlfogh1iw8lr049zPyd7YADHy+B7U4W9bQ==, tarball: https://registry.npmjs.org/fast-string-width/-/fast-string-width-1.1.0.tgz}
 
+  fast-uri@3.1.0:
+    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==, tarball: https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz}
+
   fast-wrap-ansi@0.1.6:
     resolution: {integrity: sha512-HlUwET7a5gqjURj70D5jl7aC3Zmy4weA1SHUfM0JFI0Ptq987NH2TwbBFLoERhfwk+E+eaq4EK3jXoT+R3yp3w==, tarball: https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.1.6.tgz}
 
@@ -2136,6 +2185,9 @@ packages:
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==, tarball: https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==, tarball: https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==, tarball: https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz}
@@ -2647,6 +2699,10 @@ packages:
   regjsparser@0.13.1:
     resolution: {integrity: sha512-dLsljMd9sqwRkby8zhO1gSg3PnJIBFid8f4CQj/sXx+7cKx+E7u0PKhZ+U4wmhx7EfmtvnA318oVaIkAB1lRJw==, tarball: https://registry.npmjs.org/regjsparser/-/regjsparser-0.13.1.tgz}
     hasBin: true
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==, tarball: https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz}
+    engines: {node: '>=0.10.0'}
 
   reserved-identifiers@1.2.0:
     resolution: {integrity: sha512-yE7KUfFvaBFzGPs5H3Ops1RevfUEsDc5Iz65rOwWg4lE8HJSYtle77uul3+573457oHvBKuHYDl/xqUkKpEEdw==, tarball: https://registry.npmjs.org/reserved-identifiers/-/reserved-identifiers-1.2.0.tgz}
@@ -3925,6 +3981,13 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
   ansi-colors@4.1.3: {}
 
   ansi-regex@5.0.1: {}
@@ -4585,6 +4648,8 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 1.2.1
 
+  fast-uri@3.1.0: {}
+
   fast-wrap-ansi@0.1.6:
     dependencies:
       fast-string-width: 1.1.0
@@ -4994,6 +5059,8 @@ snapshots:
   json-buffer@3.0.1: {}
 
   json-schema-traverse@0.4.1: {}
+
+  json-schema-traverse@1.0.0: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -5589,6 +5656,8 @@ snapshots:
   regjsparser@0.13.1:
     dependencies:
       jsesc: 3.1.0
+
+  require-from-string@2.0.2: {}
 
   reserved-identifiers@1.2.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,6 +10,7 @@ catalog:
   '@types/node': ^25.5.0
   '@vitest/coverage-v8': ^4.1.2
   '@vitest/eslint-plugin': 1.6.14
+  ajv: ^8.20.0
   citty: ^0.2.2
   console-fail-test: 0.6.1
   cross-spawn: ^7.0.6


### PR DESCRIPTION
## Summary

Adds two new packages that compose to validate `SKILL.md` files at lint time:

- **`@gtbuchanan/eslint-plugin-md-frontmatter`** — generic. One rule, `md-frontmatter/schema`, validates Markdown YAML frontmatter against any JSON Schema via ajv. Each error is mapped back to the offending YAML node range for inline reporting.
- **`@gtbuchanan/eslint-plugin-agent-skills`** — focused. Ships:
  - `skillFrontmatterSchema` — the [Agent Skills](https://agentskills.io/specification) JSON Schema as a real `.json` file with `$id` set to a future canonical URL.
  - `agent-skills/name-matches-dir` — the one spec constraint pure schemas can't express.
  - `configs.recommended` — a ready-to-spread flat-config block that wires both plugins plus core `max-lines: 500` for `**/skills/*/SKILL.md`. One-line setup for consumers: `[...configs.recommended]`.

`eslint-config` delegates to `configs.recommended`. `ajv ^8.20.0` added to the workspace catalog. `resolveJsonModule: true` moved to the shared `@gtbuchanan/tsconfig/node.json` so consumers get JSON imports by default.

Plugin-level `RuleTester` unit tests (`test/*.test.ts` per package) cover rule behavior. End-to-end coverage in `eslint-config/e2e/skill.test.ts` exercises the fully-wired pipeline against synthetic SKILL.md fixtures.

`CHANGELOG.md` stubs added to both new packages matching the existing format. No changeset — these will land as initial 0.1.0 entries on first release.

Relates to #41 — sets up the lint-side validation that #41 calls out as a CI checklist item. Follow-up rules tracked in #68.

## Test plan

- [x] `pnpm install && pnpm check` — 32/32 turbo tasks green
- [x] `pnpm test:e2e` — 24 e2e tests pass (18 existing + 6 new SKILL.md cases)
- [x] Rules fire on a synthetic bad SKILL.md (uppercase name, missing `description`, unknown extra field, mismatched parent dir):
  ```sh
  mkdir -p packages/cli/skills/test-bad
  printf -- '---\nname: WrongName\nunknown: foo\n---\n# Body\n' \
    > packages/cli/skills/test-bad/SKILL.md
  pnpm -C packages/cli exec eslint --no-cache skills/test-bad/SKILL.md
  rm -rf packages/cli/skills/test-bad
  ```
  Confirmed: 4 plugin warnings + 1 Prettier warning at 2:1 (missing description), 2:7 (name pattern + dir mismatch), 3:1 (unknown field), 5:1 (no trailing newline).
- [x] Existing `packages/cli/skills/gtb-build-pipeline/SKILL.md` lints clean
- [x] `src/schema.json` is shipped in the `eslint-plugin-agent-skills` tarball (verified via `tar -tzf`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)