### PR TITLE
Lint workspace root files via //#lint:eslint turbo task

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,12 @@ coverage, setupFiles, and mock reset.
 
 - **ESLint** — Per-package `eslint.config.ts` importing `configure()`
   from `@gtbuchanan/eslint-config`. ESLint caching enabled via
-  `--cache --cache-location dist/.eslintcache`.
+  `--cache --cache-location dist/.eslintcache`. In monorepos with a
+  root ESLint config, `gtb sync` also generates a `//#lint:eslint`
+  turbo task and root `lint:eslint` script that lints workspace-root
+  files (`package.json`, `pnpm-workspace.yaml`, `.github/`, etc.) which
+  per-package lint never sees. Per-package dirs are excluded via
+  `--ignore-pattern` derived from `pnpm-workspace.yaml` package globs.
 - **Vitest** — Per-package `vitest.config.ts` using `configurePackage()`
   from `@gtbuchanan/vitest-config/configure`.
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "coverage:merge": "turbo run coverage:merge",
     "deploy:skills": "turbo run deploy:skills",
     "gtb": "node --experimental-strip-types packages/cli/bin/gtb.ts",
+    "lint:eslint": "pnpm run gtb task lint:eslint . --ignore-pattern \"packages/*/**\"",
     "pack": "turbo run pack",
     "pipeline": "node --experimental-strip-types packages/cli/bin/gtb.ts pipeline",
     "prepare": "pnpm run gtb prepare",

--- a/packages/cli/src/lib/discovery.ts
+++ b/packages/cli/src/lib/discovery.ts
@@ -50,6 +50,8 @@ export interface WorkspaceDiscovery {
   readonly isSelfHosted: boolean;
   /** Capabilities per workspace package. */
   readonly packages: readonly PackageCapabilities[];
+  /** Raw `packages` globs from pnpm-workspace.yaml. Empty in single-package mode. */
+  readonly packageGlobs: readonly string[];
   /** Root-level capabilities. */
   readonly root: PackageCapabilities;
   /** Workspace root directory. */
@@ -141,6 +143,7 @@ export const discoverWorkspace = (
     isMonorepo,
     isSelfHosted: rootDeps['@gtbuchanan/cli']?.startsWith('workspace:') === true,
     packages: ctx.packageDirs.map(dir => buildCapabilities(dir, parseManifest(dir))),
+    packageGlobs: ctx.packageGlobs,
     root: buildCapabilities(ctx.rootDir, rootManifest),
     rootDir: ctx.rootDir,
   };

--- a/packages/cli/src/lib/turbo-aggregates.ts
+++ b/packages/cli/src/lib/turbo-aggregates.ts
@@ -4,6 +4,7 @@ import {
   type ConditionalEntry,
   type ToolFlags,
   type TurboTask,
+  rootTaskKey,
 } from './turbo-config.ts';
 
 const generateAggregate = (flags: ToolFlags): readonly ConditionalEntry<TurboTask>[] => [
@@ -44,12 +45,17 @@ const packAggregate = (flags: ToolFlags): readonly ConditionalEntry<TurboTask>[]
 ];
 
 const lintAggregate = (flags: ToolFlags): readonly ConditionalEntry<TurboTask>[] => [
+  /*
+   * Root tasks must be referenced explicitly — turbo does not roll them
+   * into the bare task name when resolving deps.
+   */
   {
     condition: flags.hasLint,
     key: Aggregate.lint,
     value: {
       dependsOn: [
         ...(flags.hasEslint ? [taskNames.lintEslint] : []),
+        ...(flags.hasRootEslint ? [rootTaskKey(taskNames.lintEslint)] : []),
       ],
     },
   },

--- a/packages/cli/src/lib/turbo-config.ts
+++ b/packages/cli/src/lib/turbo-config.ts
@@ -59,6 +59,12 @@ export interface ToolFlags {
   readonly generateScripts: readonly string[];
   readonly hasLint: boolean;
   readonly hasPublished: boolean;
+  /**
+   * Workspace root has its own ESLint config and is a monorepo (so root
+   * is distinct from any package). Single-package repos lint root files
+   * via the per-package task and don't need a separate root task.
+   */
+  readonly hasRootEslint: boolean;
   readonly hasSkills: boolean;
   readonly hasTypeScript: boolean;
   readonly hasVitest: boolean;
@@ -89,6 +95,7 @@ export const resolveToolFlags = (discovery: WorkspaceDiscovery): ToolFlags => {
     hasGenerate: generateScripts.length > 0,
     hasLint,
     hasPublished: discovery.packages.some(pkg => pkg.isPublished),
+    hasRootEslint: discovery.isMonorepo && discovery.root.hasEslint,
     hasSkills: discovery.packages.some(pkg => pkg.hasSkills),
     hasTypeScript,
     hasVitest,
@@ -204,6 +211,40 @@ const lintTasks = (flags: ToolFlags): readonly ConditionalEntry<TurboTask>[] => 
   ];
 };
 
+/**
+ * Converts a pnpm workspace package glob into an ESLint/turbo ignore
+ * pattern that matches files under any directory the glob resolves to.
+ * `packages/*` → `packages/*​/**` (descendants of any direct subdir).
+ */
+export const toPackageIgnore = (glob: string): string => `${glob}/**`;
+
+/** Turbo task key for tasks dispatched at the workspace root. */
+export const rootTaskKey = (name: string): string => `//#${name}`;
+
+const rootLintTasks = (
+  flags: ToolFlags,
+  packageGlobs: readonly string[],
+): readonly ConditionalEntry<TurboTask>[] => [
+  /*
+   * `$TURBO_DEFAULT$` expands to root files minus gitignored paths
+   * (dist/, node_modules/, .turbo/, .claude/worktrees/); only package
+   * dirs need explicit subtraction since they're tracked but owned by
+   * per-package lint. Cache file lives in the root cwd's dist/,
+   * distinct from per-package caches that live in each package's dist/.
+   */
+  {
+    condition: flags.hasRootEslint,
+    key: rootTaskKey(taskNames.lintEslint),
+    value: {
+      inputs: [
+        '$TURBO_DEFAULT$',
+        ...packageGlobs.map(glob => `!${toPackageIgnore(glob)}`),
+      ],
+      outputs: ['dist/.eslintcache'],
+    },
+  },
+];
+
 /*
  * Unlike compile inputs, test inputs can't be resolved from vitest config —
  * vitest configs are executable TypeScript, not statically parseable.
@@ -289,6 +330,7 @@ export const generateTurboJson = (discovery: WorkspaceDiscovery): TurboJson => {
     ...compileSkillsTasks(flags),
     ...packTasks(flags),
     ...lintTasks(flags),
+    ...rootLintTasks(flags, discovery.packageGlobs),
     ...testTasks(flags),
     ...deploySkillsTasks(flags),
     ...aggregateTasks(flags),

--- a/packages/cli/src/lib/turbo-scripts.ts
+++ b/packages/cli/src/lib/turbo-scripts.ts
@@ -8,6 +8,7 @@ import {
   type ToolFlags,
   collect,
   resolveToolFlags,
+  toPackageIgnore,
 } from './turbo-config.ts';
 
 /*
@@ -94,10 +95,41 @@ export const generatePackageScripts = (
   return scripts;
 };
 
+/**
+ * Root-leaf scripts — leaf tasks turbo dispatches at the workspace root
+ * via `//#<task>`. Distinct from alias scripts (which delegate to turbo)
+ * and from required scripts like `prepare`/`verify`. Generated at sync
+ * time so workspace-shape inputs (package globs) are baked in.
+ *
+ * Patterns use double quotes for cross-platform shell compatibility:
+ * cmd.exe treats single quotes as literal characters (Windows pnpm
+ * default), while both shells respect double quotes for arg grouping.
+ */
+const rootLeafScriptEntries = (
+  flags: ToolFlags,
+  isSelfHosted: boolean,
+  packageGlobs: readonly string[],
+): readonly ConditionalEntry<string>[] => {
+  const ignoreFlags = packageGlobs
+    .map(glob => `--ignore-pattern "${toPackageIgnore(glob)}"`)
+    .join(' ');
+  const lintCmd = `${taskCmd(isSelfHosted, taskNames.lintEslint)} . ${ignoreFlags}`;
+
+  return [
+    { condition: flags.hasRootEslint, key: taskNames.lintEslint, value: lintCmd },
+  ];
+};
+
 /** Required root scripts — validated by `gtb verify`. */
-const requiredRootScripts = (isSelfHosted: boolean): Readonly<Record<string, string>> => ({
-  [rootNames.prepare]: rootCmd(isSelfHosted, rootNames.prepare),
-  [rootNames.verify]: rootCmd(isSelfHosted, rootNames.verify),
+const requiredRootScripts = (
+  discovery: WorkspaceDiscovery,
+  flags: ToolFlags,
+): Readonly<Record<string, string>> => ({
+  [rootNames.prepare]: rootCmd(discovery.isSelfHosted, rootNames.prepare),
+  [rootNames.verify]: rootCmd(discovery.isSelfHosted, rootNames.verify),
+  ...collect(
+    rootLeafScriptEntries(flags, discovery.isSelfHosted, discovery.packageGlobs),
+  ),
 });
 
 /**
@@ -143,12 +175,15 @@ const aliasRootScriptEntries = (
 /** Generates all root-level scripts (required + optional aliases). */
 export const generateRootScripts = (
   discovery: WorkspaceDiscovery,
-): Record<string, string> => ({
-  ...collect(aliasRootScriptEntries(resolveToolFlags(discovery), discovery.isMonorepo)),
-  ...requiredRootScripts(discovery.isSelfHosted),
-});
+): Record<string, string> => {
+  const flags = resolveToolFlags(discovery);
+  return {
+    ...collect(aliasRootScriptEntries(flags, discovery.isMonorepo)),
+    ...requiredRootScripts(discovery, flags),
+  };
+};
 
 /** Generates only required root scripts for drift validation. */
 export const generateRequiredRootScripts = (
   discovery: WorkspaceDiscovery,
-): Record<string, string> => ({ ...requiredRootScripts(discovery.isSelfHosted) });
+): Record<string, string> => ({ ...requiredRootScripts(discovery, resolveToolFlags(discovery)) });

--- a/packages/cli/src/lib/workspace.ts
+++ b/packages/cli/src/lib/workspace.ts
@@ -9,6 +9,8 @@ import { type Manifest, ManifestSchema } from './manifest.ts';
 /** Resolved workspace context for pack operations. */
 export interface WorkspaceContext {
   readonly packageDirs: readonly string[];
+  /** Raw `packages` globs from pnpm-workspace.yaml. Empty in single-package mode. */
+  readonly packageGlobs: readonly string[];
   readonly rootDir: string;
 }
 
@@ -30,16 +32,16 @@ export const resolveWorkspace = (
   const workspaceFile = findUpSync('pnpm-workspace.yaml', { cwd });
   if (workspaceFile !== undefined) {
     const rootDir = path.dirname(workspaceFile);
-    const globs = parsePackageGlobs(workspaceFile);
-    const packageDirs = globs.flatMap(pattern =>
+    const packageGlobs = parsePackageGlobs(workspaceFile);
+    const packageDirs = packageGlobs.flatMap(pattern =>
       globSync(`${pattern}/`, { cwd: rootDir }).map(dir => path.resolve(rootDir, dir)),
     );
     if (packageDirs.length > 0) {
-      return { packageDirs, rootDir };
+      return { packageDirs, packageGlobs, rootDir };
     }
   }
 
-  return { packageDirs: [cwd], rootDir: cwd };
+  return { packageDirs: [cwd], packageGlobs: [], rootDir: cwd };
 };
 
 const WorkspaceSchema = v.object({

--- a/packages/cli/test/deploy-skills.test.ts
+++ b/packages/cli/test/deploy-skills.test.ts
@@ -20,6 +20,7 @@ vi.mock(import('#src/lib/workspace.js'), async (importOriginal) => {
     ...actual,
     resolveWorkspace: vi.fn<typeof actual.resolveWorkspace>(() => ({
       packageDirs: [process.cwd()],
+      packageGlobs: [],
       rootDir: process.cwd(),
     })),
   };
@@ -53,6 +54,7 @@ const createFixture = (): Fixture => {
   const mockDetected = vi.mocked(getDetectedAgents);
   mockResolveWorkspace.mockReturnValue({
     packageDirs: [process.cwd()],
+    packageGlobs: [],
     rootDir: process.cwd(),
   });
   return { mockRun, mockLoadConfigured, mockResolveWorkspace, mockDetected };
@@ -110,6 +112,7 @@ describe('gtb task deploy:skills', () => {
     const fixture = createFixture();
     fixture.mockResolveWorkspace.mockReturnValue({
       packageDirs: [process.cwd()],
+      packageGlobs: [],
       rootDir: `${process.cwd()}/..`,
     });
     fixture.mockLoadConfigured.mockResolvedValue(['claude-code']);

--- a/packages/cli/test/turbo-config.helpers.ts
+++ b/packages/cli/test/turbo-config.helpers.ts
@@ -36,6 +36,7 @@ export const makeDiscovery = (
   isMonorepo: packages.length > 1,
   isSelfHosted: false,
   packages,
+  packageGlobs: packages.length > 1 ? ['packages/*'] : [],
   root: makeCapabilities(rootOverrides),
   rootDir: '/fake/root',
 });

--- a/packages/cli/test/turbo-json-root-lint.test.ts
+++ b/packages/cli/test/turbo-json-root-lint.test.ts
@@ -1,0 +1,52 @@
+import { describe, it } from 'vitest';
+import { generateTurboJson } from '#src/lib/turbo-config.js';
+import { makeCapabilities, makeDiscovery } from './turbo-config.helpers.ts';
+
+const monorepoWithRootEslint = (): ReturnType<typeof makeDiscovery> =>
+  makeDiscovery(
+    [makeCapabilities({ hasEslint: true }), makeCapabilities({ hasEslint: true })],
+    { hasEslint: true },
+  );
+
+describe.concurrent('generateTurboJson — root lint', () => {
+  it('emits //#lint:eslint when monorepo root has ESLint', ({ expect }) => {
+    const result = generateTurboJson(monorepoWithRootEslint());
+
+    expect(result.tasks).toHaveProperty('//#lint:eslint');
+  });
+
+  it('omits //#lint:eslint in single-package repos', ({ expect }) => {
+    const discovery = makeDiscovery(
+      [makeCapabilities({ hasEslint: true })],
+      { hasEslint: true },
+    );
+
+    const result = generateTurboJson(discovery);
+
+    expect(result.tasks).not.toHaveProperty('//#lint:eslint');
+  });
+
+  it('omits //#lint:eslint when monorepo root has no ESLint', ({ expect }) => {
+    const discovery = makeDiscovery(
+      [makeCapabilities({ hasEslint: true }), makeCapabilities({ hasEslint: true })],
+    );
+
+    const result = generateTurboJson(discovery);
+
+    expect(result.tasks).not.toHaveProperty('//#lint:eslint');
+  });
+
+  it('//#lint:eslint subtracts package globs from defaults', ({ expect }) => {
+    const result = generateTurboJson(monorepoWithRootEslint());
+    const inputs = result.tasks['//#lint:eslint']?.inputs ?? [];
+
+    expect(inputs).toContain('$TURBO_DEFAULT$');
+    expect(inputs).toContain('!packages/*/**');
+  });
+
+  it('lint aggregate depends on //#lint:eslint when root has ESLint', ({ expect }) => {
+    const result = generateTurboJson(monorepoWithRootEslint());
+
+    expect(result.tasks['lint']?.dependsOn).toContain('//#lint:eslint');
+  });
+});

--- a/packages/cli/test/turbo-scripts.test.ts
+++ b/packages/cli/test/turbo-scripts.test.ts
@@ -107,7 +107,7 @@ describe.concurrent(generateRootScripts, () => {
 });
 
 describe.concurrent(generateRequiredRootScripts, () => {
-  it('returns only prepare and verify regardless of capabilities', ({ expect }) => {
+  it('returns only prepare and verify in single-package repos', ({ expect }) => {
     const discovery = makeDiscovery([
       makeCapabilities({
         hasEslint: true,
@@ -123,5 +123,28 @@ describe.concurrent(generateRequiredRootScripts, () => {
       prepare: 'gtb prepare',
       verify: 'gtb verify',
     });
+  });
+
+  it('adds root lint:eslint when monorepo root has ESLint', ({ expect }) => {
+    const discovery = makeDiscovery(
+      [makeCapabilities({ hasEslint: true }), makeCapabilities({ hasEslint: true })],
+      { hasEslint: true },
+    );
+
+    const result = generateRequiredRootScripts(discovery);
+
+    expect(result['lint:eslint']).toBe(
+      'gtb task lint:eslint . --ignore-pattern "packages/*/**"',
+    );
+  });
+
+  it('omits root lint:eslint when root has no ESLint', ({ expect }) => {
+    const discovery = makeDiscovery(
+      [makeCapabilities({ hasEslint: true }), makeCapabilities({ hasEslint: true })],
+    );
+
+    const result = generateRequiredRootScripts(discovery);
+
+    expect(result).not.toHaveProperty('lint:eslint');
   });
 });

--- a/packages/eslint-config/src/index.ts
+++ b/packages/eslint-config/src/index.ts
@@ -70,7 +70,12 @@ export const configure = async (
 ): Promise<Linter.Config[]> => {
   const resolved: ResolvedOptions = {
     entryPoints: options.entryPoints ?? [...defaultEntryPoints],
-    ignores: options.ignores ?? ['.claude/worktrees/**', '**/dist/**', '**/pnpm-lock.yaml'],
+    ignores: options.ignores ?? [
+      '.claude/worktrees/**',
+      '**/.turbo/**',
+      '**/dist/**',
+      '**/pnpm-lock.yaml',
+    ],
     onlyWarn: options.onlyWarn ?? true,
     pnpm: options.pnpm ?? true,
     target: options.target ?? 'server',

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,15 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "tasks": {
+    "//#lint:eslint": {
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "!packages/*/**"
+      ],
+      "outputs": [
+        "dist/.eslintcache"
+      ]
+    },
     "build": {
       "dependsOn": [
         "check",
@@ -95,7 +104,8 @@
     },
     "lint": {
       "dependsOn": [
-        "lint:eslint"
+        "lint:eslint",
+        "//#lint:eslint"
       ]
     },
     "lint:eslint": {


### PR DESCRIPTION
## Summary

Closes #61.

`turbo run lint:eslint` only ran in packages, so workspace-root `package.json`, `pnpm-workspace.yaml`, `codecov.yml`, and `.github/` workflows silently passed CI on any branch that didn't touch them. Pre-commit caught drift on changed files but missed merges, force-pushes, and files left in a bad state after a merge.

This PR adds a `//#lint:eslint` root task plus a paired root `lint:eslint` script in monorepos with a root ESLint config:

- Inputs: `\$TURBO_DEFAULT\$` (root files minus gitignored paths) minus `pnpm-workspace.yaml` package globs — per-package lint stays authoritative for package contents.
- Script: forwards `--ignore-pattern` for the same globs so the cwd-walking ESLint invocation matches turbo's input shape.
- Single-package repos are unaffected (per-package task already lints root since root *is* the package).

Issue #61 lays out the alternatives and trade-offs in detail.

## Test plan

- [x] Reproduced the bug: pinned `valibot` to `1.3.1` in root `package.json` → `turbo run lint:eslint` now fails the new `//#lint:eslint` task with `pnpm/json-enforce-catalog`.
- [x] Confirmed `turbo run lint:eslint --dry=json` lists `//#lint:eslint` alongside per-package tasks.
- [x] `pnpm run check` passes (33/33 turbo tasks).
- [x] `pnpm run verify` clean (no drift).
- [x] Verify CI passes on the PR build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)