### PR TITLE
Cap agent-skills references/ files at 300 lines

### DIFF
--- a/packages/eslint-plugin-agent-skills/README.md
+++ b/packages/eslint-plugin-agent-skills/README.md
@@ -18,8 +18,9 @@ ships:
     spec's "one level deep" depth guidance.
   - `agent-skills/max-lines` — markdown-aware version of core's
     `max-lines` that fires under any markdown parser/language.
-- A `configs.recommended` flat-config block that wires the plugin's
-  rules plus the schema rule for `**/skills/*/SKILL.md`.
+- A `configs.recommended` flat-config that wires the plugin's rules
+  plus the schema rule for `**/skills/*/SKILL.md`, and applies a
+  smaller `max-lines` cap (300) to `**/skills/*/references/**/*.md`.
 
 ## Install
 
@@ -119,12 +120,22 @@ Options:
 
 ### `agent-skills/max-lines`
 
-Caps `SKILL.md` at a maximum line count, defaulting to 500 per the
-spec's [Progressive disclosure](https://agentskills.io/specification#progressive-disclosure)
-guidance ("Keep your main `SKILL.md` under 500 lines."). Mirrors core
-ESLint's `max-lines` but fires under any markdown parser or language
-(the core rule's `Program` visitor never runs against
-`@eslint/markdown`'s `root` mdast node).
+Caps a markdown file at a maximum line count. Mirrors core ESLint's
+`max-lines` but fires under any markdown parser or language (the core
+rule's `Program` visitor never runs against `@eslint/markdown`'s
+`root` mdast node).
+
+The recommended config applies it twice, with different caps for
+different file roles per the spec's
+[Progressive disclosure](https://agentskills.io/specification#progressive-disclosure)
+guidance:
+
+- `**/skills/*/SKILL.md` — 500 lines ("Keep your main `SKILL.md` under
+  500 lines.").
+- `**/skills/*/references/**/*.md` — 300 lines, since the spec calls
+  for ancillary reference files to be focused and smaller than
+  `SKILL.md`. 300 sits just above the p90 line count observed across
+  popular published skills.
 
 Options:
 

--- a/packages/eslint-plugin-agent-skills/src/index.ts
+++ b/packages/eslint-plugin-agent-skills/src/index.ts
@@ -31,11 +31,14 @@ const plugin: ESLint.Plugin = {
 };
 
 /**
- * Ready-to-spread flat-config blocks for SKILL.md files.
- *
- * - `recommended` — wires the schema rule and every plugin rule for
- *   `**\/skills/*\/SKILL.md`. Sets `language: 'markdown/commonmark'`
- *   so `file-references` can walk the markdown AST.
+ * Ready-to-spread flat-config blocks for Agent Skills files. The
+ * `markdown/commonmark` language is required so `file-references`
+ * can walk the markdown AST. The 300-line cap on `references/**` is
+ * tighter than the 500-line `SKILL.md` cap to mirror the spec's
+ * [Progressive disclosure](https://agentskills.io/specification#progressive-disclosure)
+ * guidance that ancillary reference files stay focused and smaller
+ * than `SKILL.md`; 300 sits just above the p90 line count of files
+ * in popular published skills.
  */
 export const configs: {
   readonly recommended: readonly Linter.Config[];
@@ -54,6 +57,14 @@ export const configs: {
         'agent-skills/max-lines': ['warn', { max: 500 }],
         'agent-skills/name-matches-dir': 'warn',
         'md-frontmatter/schema': ['warn', { schema }],
+      },
+    },
+    {
+      files: ['**/skills/*/references/**/*.md'],
+      language: 'markdown/commonmark',
+      plugins: { 'agent-skills': plugin, markdown },
+      rules: {
+        'agent-skills/max-lines': ['warn', { max: 300 }],
       },
     },
   ],

--- a/packages/eslint-plugin-agent-skills/test/recommended.test.ts
+++ b/packages/eslint-plugin-agent-skills/test/recommended.test.ts
@@ -1,0 +1,59 @@
+import path from 'node:path';
+import { Linter } from 'eslint';
+import { describe, it } from 'vitest';
+import { configs } from '#src/index.js';
+
+const cwd = path.resolve('/repo');
+const referencesFile = path.join(
+  cwd, 'skills', 'my-skill', 'references', 'REFERENCE.md',
+);
+const skillFile = path.join(cwd, 'skills', 'my-skill', 'SKILL.md');
+
+const linter = new Linter({ cwd });
+const recommended = [...configs.recommended];
+
+const buildBody = (lineCount: number): string => Array
+  .from({ length: lineCount }, (_unused, index) => `Line ${(index + 1).toString()}.`)
+  .join('\n');
+
+const lint = (
+  code: string,
+  filename = referencesFile,
+): Linter.LintMessage[] => linter.verify(code, recommended, filename);
+
+const maxLinesMessages = (
+  messages: readonly Linter.LintMessage[],
+): readonly Linter.LintMessage[] =>
+  messages.filter(message => message.ruleId === 'agent-skills/max-lines');
+
+describe('configs.recommended references/ max-lines', () => {
+  it('passes when the file is at the 300-line limit', ({ expect }) => {
+    const messages = maxLinesMessages(lint(buildBody(300)));
+
+    expect(messages).toStrictEqual([]);
+  });
+
+  it('flags when the file exceeds the 300-line limit', ({ expect }) => {
+    const [message, ...rest] = maxLinesMessages(lint(buildBody(301)));
+
+    expect(rest).toStrictEqual([]);
+    expect(message?.message).toMatch(/301.*Maximum allowed is 300/v);
+    expect(message?.severity).toBe(1);
+  });
+
+  it('honors a top-of-file eslint-disable HTML comment', ({ expect }) => {
+    const code =
+      '<!-- eslint-disable agent-skills/max-lines -->\n' +
+      buildBody(500);
+
+    const messages = maxLinesMessages(lint(code));
+
+    expect(messages).toStrictEqual([]);
+  });
+
+  it('does not apply the 300-line cap to SKILL.md', ({ expect }) => {
+    const messages = maxLinesMessages(lint(buildBody(400), skillFile));
+
+    expect(messages).toStrictEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a second `configs.recommended` block applying `agent-skills/max-lines` with `max: 300` to `**/skills/*/references/**/*.md`, mirroring the spec's progressive-disclosure guidance that ancillary reference files stay focused and smaller than `SKILL.md`.
- 300 sits just above the p90 line count (290) observed across 89 reference files in popular published Agent Skills repos. Survey: anthropics/skills, TerminalSkills/skills, deepskyai/agent-tools, Agents365-ai/drawio-skill. Largest outliers (430–506 lines) trip the cap as warnings — including Anthropic's own `skill-creator/references/schemas.md`, which is arguably the right behavior given the spec's "focused, smaller files" wording.
- The new config block sets `language: 'markdown/commonmark'` so HTML-comment disable directives (`<!-- eslint-disable agent-skills/max-lines -->`) are honored.

Closes the second of issue #68's candidate rules. The remaining candidates aren't worth shipping — body-token-limit is proxied by the line cap, the frontmatter schema covers description shape, and the rest are heuristic with high false-positive rates.

## Test plan

- [x] `pnpm build` — 57/57 turbo tasks pass, all 20 agent-skills tests green
- [x] New `test/recommended.test.ts` covers: at-limit (300) passes, over-limit (301) flags with expected message and severity, top-of-file `<!-- eslint-disable agent-skills/max-lines -->` suppresses the warning, 300-line cap does not bleed onto SKILL.md
- [x] Lint clean (`gtb task lint:eslint`)