### PR TITLE
Plumb cwd + logger into sync/verify commands

### DIFF
--- a/packages/cli/src/commands/root/sync.ts
+++ b/packages/cli/src/commands/root/sync.ts
@@ -104,7 +104,27 @@ export const runSync = (options: RunSyncOptions = {}): void => {
   writeCodecovConfig(logger, discovery);
 };
 
-/** Citty command wrapper for {@link runSync}. */
+/** Parsed citty args for {@link sync}. */
+export interface SyncCommandArgs {
+  readonly cwd?: string | undefined;
+  readonly force?: boolean | undefined;
+}
+
+/**
+ * Translates citty args into {@link RunSyncOptions} and invokes
+ * {@link runSync}. Lives between the citty wrapper and the pure
+ * function so the args translation is testable without going through
+ * citty's `runCommand`.
+ */
+export const syncCommand = (args: SyncCommandArgs, logger: Logger): void => {
+  runSync({
+    ...(args.cwd !== undefined && { cwd: args.cwd }),
+    force: args.force ?? false,
+    logger,
+  });
+};
+
+/** Citty command wrapper for {@link syncCommand}. */
 export const sync = defineCommand({
   args: {
     cwd: {
@@ -122,9 +142,6 @@ export const sync = defineCommand({
     name: rootNames.sync,
   },
   run: ({ args }) => {
-    runSync({
-      ...(args.cwd !== undefined && { cwd: args.cwd }),
-      force: args.force ?? false,
-    });
+    syncCommand(args, createLogger());
   },
 });

--- a/packages/cli/src/commands/root/sync.ts
+++ b/packages/cli/src/commands/root/sync.ts
@@ -7,6 +7,7 @@ import {
 import {
   type MergeResult, mergeCodecovSections, mergePackageScripts, sortKeysDeep, writeJsonFile,
 } from '../../lib/file-writer.ts';
+import { type Logger, createLogger } from '../../lib/logger.ts';
 import { planTsconfigs, readUserCompilerOptions } from '../../lib/tsconfig-gen.ts';
 import {
   generatePackageScripts,
@@ -15,53 +16,102 @@ import {
 } from '../../lib/turbo-config.ts';
 import { rootNames } from './names.ts';
 
-const logMergeResult = (label: string, result: MergeResult): void => {
+const logMergeResult = (logger: Logger, label: string, result: MergeResult): void => {
   if (result.added.length > 0) {
-    console.log(`${label}: added ${result.added.join(', ')}`);
+    logger.info(`${label}: added ${result.added.join(', ')}`);
   }
   if (result.skipped.length > 0) {
-    console.log(`${label}: skipped ${result.skipped.join(', ')}`);
+    logger.info(`${label}: skipped ${result.skipped.join(', ')}`);
   }
 };
 
-const writeSortedAndLog = (filePath: string, data: object): void => {
+const writeSortedAndLog = (logger: Logger, filePath: string, data: object): void => {
   writeJsonFile(filePath, sortKeysDeep(data));
-  console.log(`wrote ${filePath}`);
+  logger.info(`wrote ${filePath}`);
 };
 
-const writeRootScripts = (discovery: WorkspaceDiscovery, force: boolean): void => {
+const writeRootScripts = (
+  logger: Logger, discovery: WorkspaceDiscovery, force: boolean,
+): void => {
   const rootPkgPath = path.join(discovery.rootDir, 'package.json');
-  logMergeResult('root', mergePackageScripts(rootPkgPath, generateRootScripts(discovery), force));
+  logMergeResult(
+    logger,
+    'root',
+    mergePackageScripts(rootPkgPath, generateRootScripts(discovery), force),
+  );
 };
 
 const writePackageScripts = (
-  pkg: PackageCapabilities, force: boolean, isSelfHosted: boolean, rootDir: string,
+  logger: Logger,
+  pkg: PackageCapabilities,
+  discovery: WorkspaceDiscovery,
+  force: boolean,
 ): void => {
-  const scripts = generatePackageScripts(pkg, isSelfHosted, rootDir);
+  const scripts = generatePackageScripts(pkg, discovery.isSelfHosted, discovery.rootDir);
   if (Object.keys(scripts).length === 0) {
     return;
   }
-  logMergeResult(pkg.dir, mergePackageScripts(path.join(pkg.dir, 'package.json'), scripts, force));
+  logMergeResult(
+    logger,
+    pkg.dir,
+    mergePackageScripts(path.join(pkg.dir, 'package.json'), scripts, force),
+  );
 };
 
-const writeCodecovConfig = (discovery: WorkspaceDiscovery): void => {
+const writeCodecovConfig = (logger: Logger, discovery: WorkspaceDiscovery): void => {
   if (!discovery.packages.some(pkg => pkg.hasVitestTests)) {
     return;
   }
   const filePath = path.join(discovery.rootDir, 'codecov.yml');
   mergeCodecovSections(filePath, generateCodecovSections(discovery));
-  console.log(`wrote ${filePath}`);
+  logger.info(`wrote ${filePath}`);
 };
+
+/** Options for {@link runSync}. */
+export interface RunSyncOptions {
+  readonly cwd?: string;
+  readonly force?: boolean;
+  readonly logger?: Logger;
+}
 
 /**
  * Reconciles generated config with the current workspace state.
  *
  * Writes `turbo.json`, per-package tsconfigs, `package.json` scripts,
- * and `codecov.yml` from discovery. Without `--force`, existing script
- * values are preserved; pass `--force` to overwrite them.
+ * and `codecov.yml` from discovery. With `force: false` (default),
+ * existing script values are preserved; with `force: true`, they're
+ * overwritten.
  */
+export const runSync = (options: RunSyncOptions = {}): void => {
+  const cwd = options.cwd ?? process.cwd();
+  const force = options.force ?? false;
+  const logger = options.logger ?? createLogger();
+  const discovery = discoverWorkspace({ cwd });
+
+  writeSortedAndLog(
+    logger, path.join(discovery.rootDir, 'turbo.json'), generateTurboJson(discovery),
+  );
+
+  for (const descriptor of planTsconfigs(discovery.rootDir, discovery.packages)) {
+    const userOpts = readUserCompilerOptions(descriptor.path);
+    writeSortedAndLog(logger, descriptor.path, descriptor.generate(userOpts));
+  }
+
+  for (const pkg of discovery.packages) {
+    writePackageScripts(logger, pkg, discovery, force);
+  }
+  writeRootScripts(logger, discovery, force);
+  writeCodecovConfig(logger, discovery);
+};
+
+/** Citty command wrapper for {@link runSync}. */
 export const sync = defineCommand({
   args: {
+    cwd: {
+      alias: 'C',
+      description: 'Workspace root directory (defaults to current working directory)',
+      type: 'string',
+    },
     force: {
       description: 'Overwrite existing package.json scripts',
       type: 'boolean',
@@ -72,20 +122,9 @@ export const sync = defineCommand({
     name: rootNames.sync,
   },
   run: ({ args }) => {
-    const force = args.force === true;
-    const discovery = discoverWorkspace();
-
-    writeSortedAndLog(path.join(discovery.rootDir, 'turbo.json'), generateTurboJson(discovery));
-
-    for (const descriptor of planTsconfigs(discovery.rootDir, discovery.packages)) {
-      const userOpts = readUserCompilerOptions(descriptor.path);
-      writeSortedAndLog(descriptor.path, descriptor.generate(userOpts));
-    }
-
-    for (const pkg of discovery.packages) {
-      writePackageScripts(pkg, force, discovery.isSelfHosted, discovery.rootDir);
-    }
-    writeRootScripts(discovery, force);
-    writeCodecovConfig(discovery);
+    runSync({
+      ...(args.cwd !== undefined && { cwd: args.cwd }),
+      force: args.force ?? false,
+    });
   },
 });

--- a/packages/cli/src/commands/root/verify.ts
+++ b/packages/cli/src/commands/root/verify.ts
@@ -250,7 +250,41 @@ export const runVerify = (options: RunVerifyOptions = {}): readonly string[] => 
   ];
 };
 
-/** Citty command wrapper for {@link runVerify}. */
+/** Parsed citty args for {@link verify}. */
+export interface VerifyCommandArgs {
+  readonly cwd?: string | undefined;
+}
+
+/**
+ * Translates citty args into {@link RunVerifyOptions}, invokes
+ * {@link runVerify}, and reports the drift through the given logger.
+ * Returns the exit code so the citty wrapper can set
+ * `process.exitCode` and tests can assert on the result without
+ * mutating process state.
+ */
+export const verifyCommand = (
+  rawArgs: readonly string[],
+  args: VerifyCommandArgs,
+  logger: Logger,
+): number => {
+  const drift = runVerify({
+    ...(args.cwd !== undefined && { cwd: args.cwd }),
+    ignored: parseIgnoreArgs(rawArgs),
+  });
+
+  if (drift.length === 0) {
+    logger.info('verify passed — no drift detected');
+    return 0;
+  }
+
+  for (const message of drift) {
+    logger.error(message);
+  }
+
+  return 1;
+};
+
+/** Citty command wrapper for {@link verifyCommand}. */
 export const verify = defineCommand({
   args: {
     cwd: {
@@ -268,21 +302,9 @@ export const verify = defineCommand({
     name: rootNames.verify,
   },
   run: ({ rawArgs, args }) => {
-    const logger: Logger = createLogger();
-    const drift = runVerify({
-      ...(args.cwd !== undefined && { cwd: args.cwd }),
-      ignored: parseIgnoreArgs(rawArgs),
-    });
-
-    if (drift.length === 0) {
-      logger.info('verify passed — no drift detected');
-      return;
+    const exitCode = verifyCommand(rawArgs, args, createLogger());
+    if (exitCode !== 0) {
+      process.exitCode = exitCode;
     }
-
-    for (const message of drift) {
-      logger.error(message);
-    }
-
-    process.exitCode = 1;
   },
 });

--- a/packages/cli/src/commands/root/verify.ts
+++ b/packages/cli/src/commands/root/verify.ts
@@ -6,6 +6,7 @@ import { parse as parseYaml } from 'yaml';
 import { type CodecovSections, generateCodecovSections } from '../../lib/codecov-config.ts';
 import { type WorkspaceDiscovery, discoverWorkspace } from '../../lib/discovery.ts';
 import { readJsonFile } from '../../lib/file-writer.ts';
+import { type Logger, createLogger } from '../../lib/logger.ts';
 import {
   type GeneratedTsconfig,
   planTsconfigs,
@@ -216,15 +217,47 @@ const checkCodecovSections = (
   ];
 };
 
+/** Options for {@link runVerify}. */
+export interface RunVerifyOptions {
+  readonly cwd?: string;
+  readonly ignored?: ReadonlySet<string>;
+}
+
 /**
  * Validates project config against the expected baseline from discovery.
- *
- * Checks turbo.json tasks, package.json scripts, tsconfig structure, and
- * codecov.yml flags/components. Use `--ignore <name>` to skip specific
- * tasks/scripts. Exits non-zero on drift.
+ * Returns drift messages — empty array means no drift.
  */
+export const runVerify = (options: RunVerifyOptions = {}): readonly string[] => {
+  const cwd = options.cwd ?? process.cwd();
+  const ignored = options.ignored ?? new Set<string>();
+  const discovery = discoverWorkspace({ cwd });
+  const expected = generateTurboJson(discovery);
+
+  return [
+    ...checkTurboTasks(discovery.rootDir, expected, ignored),
+    ...checkTsconfigs(discovery),
+    ...checkScripts(discovery.rootDir, generateRequiredRootScripts(discovery), ignored),
+    ...discovery.packages.flatMap(
+      pkg => checkScripts(
+        pkg.dir,
+        generatePackageScripts(pkg, discovery.isSelfHosted, discovery.rootDir),
+        ignored,
+      ),
+    ),
+    ...(discovery.packages.some(pkg => pkg.hasVitestTests)
+      ? checkCodecovSections(discovery.rootDir, discovery, ignored)
+      : []),
+  ];
+};
+
+/** Citty command wrapper for {@link runVerify}. */
 export const verify = defineCommand({
   args: {
+    cwd: {
+      alias: 'C',
+      description: 'Workspace root directory (defaults to current working directory)',
+      type: 'string',
+    },
     ignore: {
       description: 'Skip drift detection for a specific task or script',
       type: 'string',
@@ -234,34 +267,20 @@ export const verify = defineCommand({
     description: 'Verify generated config matches the expected baseline',
     name: rootNames.verify,
   },
-  run: ({ rawArgs }) => {
-    const ignored = parseIgnoreArgs(rawArgs);
-    const discovery = discoverWorkspace();
-    const expected = generateTurboJson(discovery);
-
-    const drift = [
-      ...checkTurboTasks(discovery.rootDir, expected, ignored),
-      ...checkTsconfigs(discovery),
-      ...checkScripts(discovery.rootDir, generateRequiredRootScripts(discovery), ignored),
-      ...discovery.packages.flatMap(
-        pkg => checkScripts(
-          pkg.dir,
-          generatePackageScripts(pkg, discovery.isSelfHosted, discovery.rootDir),
-          ignored,
-        ),
-      ),
-      ...(discovery.packages.some(pkg => pkg.hasVitestTests)
-        ? checkCodecovSections(discovery.rootDir, discovery, ignored)
-        : []),
-    ];
+  run: ({ rawArgs, args }) => {
+    const logger: Logger = createLogger();
+    const drift = runVerify({
+      ...(args.cwd !== undefined && { cwd: args.cwd }),
+      ignored: parseIgnoreArgs(rawArgs),
+    });
 
     if (drift.length === 0) {
-      console.log('verify passed — no drift detected');
+      logger.info('verify passed — no drift detected');
       return;
     }
 
     for (const message of drift) {
-      console.error(message);
+      logger.error(message);
     }
 
     process.exitCode = 1;

--- a/packages/cli/src/lib/logger.ts
+++ b/packages/cli/src/lib/logger.ts
@@ -1,0 +1,18 @@
+/** Stream-injectable logger for CLI commands so tests can capture output. */
+export interface Logger {
+  readonly info: (...args: unknown[]) => void;
+  readonly error: (...args: unknown[]) => void;
+}
+
+/** Creates a Logger that writes to the given streams. */
+export const createLogger = (
+  stdout: NodeJS.WritableStream = process.stdout,
+  stderr: NodeJS.WritableStream = process.stderr,
+): Logger => ({
+  info: (...args) => {
+    stdout.write(`${args.join(' ')}\n`);
+  },
+  error: (...args) => {
+    stderr.write(`${args.join(' ')}\n`);
+  },
+});

--- a/packages/cli/test/helpers.ts
+++ b/packages/cli/test/helpers.ts
@@ -1,12 +1,14 @@
 import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
+import { Writable } from 'node:stream';
 import * as v from 'valibot';
 import { generateCodecovSections } from '#src/lib/codecov-config.js';
 import { type PackageCapabilities, discoverWorkspace } from '#src/lib/discovery.js';
 import {
   mergeCodecovSections, mergePackageScripts, writeJsonFile,
 } from '#src/lib/file-writer.js';
+import { type Logger, createLogger } from '#src/lib/logger.js';
 import { ManifestSchema } from '#src/lib/manifest.js';
 import { planTsconfigs } from '#src/lib/tsconfig-gen.js';
 import {
@@ -16,6 +18,35 @@ import {
 /** Creates an isolated temp directory for test fixtures. */
 export const createTempDir = (): string =>
   mkdtempSync(path.join(tmpdir(), 'gtb-test-'));
+
+/** A capturing logger plus accessors for the buffered stdout/stderr text. */
+export interface CapturedLogger {
+  readonly logger: Logger;
+  readonly out: () => string;
+  readonly err: () => string;
+}
+
+const captureSink = (chunks: string[]): NodeJS.WritableStream =>
+  new Writable({
+    write: (chunk, _enc, cb) => {
+      chunks.push(String(chunk));
+      cb();
+    },
+  });
+
+/**
+ * Buffers everything written through the Logger so concurrent tests can
+ * assert on the output without sharing console state.
+ */
+export const captureLogger = (): CapturedLogger => {
+  const stdoutChunks: string[] = [];
+  const stderrChunks: string[] = [];
+  return {
+    logger: createLogger(captureSink(stdoutChunks), captureSink(stderrChunks)),
+    out: () => stdoutChunks.join(''),
+    err: () => stderrChunks.join(''),
+  };
+};
 
 /** Writes generated tsconfigs for a discovered workspace. */
 export const writeTsconfigs = (

--- a/packages/cli/test/sync.test.ts
+++ b/packages/cli/test/sync.test.ts
@@ -1,38 +1,34 @@
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
-import { runCommand } from 'citty';
+import { Writable } from 'node:stream';
 import * as v from 'valibot';
-import { describe, it, vi } from 'vitest';
-import { sync } from '#src/commands/root/sync.js';
+import { describe, it } from 'vitest';
+import { runSync } from '#src/commands/root/sync.js';
 import { discoverWorkspace } from '#src/lib/discovery.js';
 import { mergePackageScripts, readJsonFile, writeJsonFile } from '#src/lib/file-writer.js';
+import { createLogger } from '#src/lib/logger.js';
 import { ManifestSchema } from '#src/lib/manifest.js';
 import {
   generatePackageScripts,
   generateRootScripts,
   generateTurboJson,
 } from '#src/lib/turbo-config.js';
+import { createTempDir, writeJson } from './helpers.ts';
 
-const runSync = async (dir: string, args: readonly string[]): Promise<void> => {
-  const origCwd = process.cwd();
-  vi.spyOn(console, 'log').mockReturnValue();
-
-  try {
-    process.chdir(dir);
-    await runCommand(sync, { rawArgs: [...args] });
-  } finally {
-    process.chdir(origCwd);
-  }
-};
+const silentSink = new Writable({
+  write: (_chunk, _enc, cb) => {
+    cb();
+  },
+});
+const silentLogger = createLogger(silentSink, silentSink);
 
 const createConsumerProject = (): string => {
-  const root = mkdtempSync(path.join(tmpdir(), 'gtb-sync-'));
+  const root = createTempDir();
   writeFileSync(
     path.join(root, 'pnpm-workspace.yaml'),
     "packages:\n  - 'packages/*'\n",
   );
-  writeFileSync(path.join(root, 'package.json'), JSON.stringify({
+  writeJson(root, 'package.json', {
     devDependencies: {
       '@gtbuchanan/cli': '^0.1.0',
       '@gtbuchanan/eslint-config': '^0.1.0',
@@ -42,12 +38,12 @@ const createConsumerProject = (): string => {
     name: 'consumer-app',
     private: true,
     scripts: { prepare: 'gtb prepare' },
-  }));
+  });
 
   const app = path.join(root, 'packages', 'app');
   mkdirSync(path.join(app, 'src'), { recursive: true });
   mkdirSync(path.join(app, 'test'), { recursive: true });
-  writeFileSync(path.join(app, 'package.json'), JSON.stringify({
+  writeJson(app, 'package.json', {
     devDependencies: {
       '@gtbuchanan/eslint-config': '^0.1.0',
       '@gtbuchanan/tsconfig': '^0.1.0',
@@ -56,14 +52,14 @@ const createConsumerProject = (): string => {
     name: '@consumer/app',
     publishConfig: { directory: 'dist/source' },
     version: '1.0.0',
-  }));
+  });
   writeFileSync(path.join(app, 'tsconfig.json'), '{}');
   writeFileSync(path.join(app, 'eslint.config.ts'), '');
   writeFileSync(path.join(app, 'vitest.config.ts'), '');
 
   const lib = path.join(root, 'packages', 'lib');
   mkdirSync(path.join(lib, 'src'), { recursive: true });
-  writeFileSync(path.join(lib, 'package.json'), JSON.stringify({
+  writeJson(lib, 'package.json', {
     devDependencies: {
       '@gtbuchanan/eslint-config': '^0.1.0',
       '@gtbuchanan/tsconfig': '^0.1.0',
@@ -71,7 +67,7 @@ const createConsumerProject = (): string => {
     name: '@consumer/lib',
     private: true,
     version: '1.0.0',
-  }));
+  });
   writeFileSync(path.join(lib, 'tsconfig.json'), '{}');
   writeFileSync(path.join(lib, 'eslint.config.ts'), '');
 
@@ -167,10 +163,10 @@ describe.concurrent('sync helpers', () => {
   });
 
   it('detects self-hosted workspace', ({ expect }) => {
-    const root = mkdtempSync(path.join(tmpdir(), 'gtb-selfhost-'));
-    writeFileSync(path.join(root, 'package.json'), JSON.stringify({
+    const root = createTempDir();
+    writeJson(root, 'package.json', {
       devDependencies: { '@gtbuchanan/cli': 'workspace:*' },
-    }));
+    });
 
     const discovery = discoverWorkspace({ cwd: root });
 
@@ -178,13 +174,13 @@ describe.concurrent('sync helpers', () => {
   });
 
   it('generates gtb shim for self-hosted', ({ expect }) => {
-    const root = mkdtempSync(path.join(tmpdir(), 'gtb-selfhost-'));
-    writeFileSync(path.join(root, 'package.json'), JSON.stringify({
+    const root = createTempDir();
+    writeJson(root, 'package.json', {
       devDependencies: {
         '@gtbuchanan/cli': 'workspace:*',
         '@gtbuchanan/tsconfig': 'workspace:*',
       },
-    }));
+    });
     mkdirSync(path.join(root, 'src'));
     writeFileSync(path.join(root, 'tsconfig.json'), '{}');
 
@@ -198,10 +194,10 @@ describe.concurrent('sync helpers', () => {
   });
 });
 
-describe('sync command', () => {
-  it('writes turbo.json and scripts', async ({ expect }) => {
+describe.concurrent(runSync, () => {
+  it('writes turbo.json and scripts', ({ expect }) => {
     const root = createConsumerProject();
-    await runSync(root, []);
+    runSync({ cwd: root, logger: silentLogger });
 
     expect(existsSync(path.join(root, 'turbo.json'))).toBe(true);
 
@@ -212,9 +208,9 @@ describe('sync command', () => {
     expect(scripts).toHaveProperty('scripts.typecheck:ts');
   });
 
-  it('generates codecov.yml when packages have vitest tests', async ({ expect }) => {
+  it('generates codecov.yml when packages have vitest tests', ({ expect }) => {
     const root = createConsumerProject();
-    await runSync(root, []);
+    runSync({ cwd: root, logger: silentLogger });
 
     const codecovPath = path.join(root, 'codecov.yml');
 
@@ -226,14 +222,14 @@ describe('sync command', () => {
     expect(content).toContain('carryforward');
   });
 
-  it('preserves existing codecov.yml user config', async ({ expect }) => {
+  it('preserves existing codecov.yml user config', ({ expect }) => {
     const root = createConsumerProject();
     writeFileSync(
       path.join(root, 'codecov.yml'),
       'codecov:\n  require_ci_to_pass: true\n',
     );
 
-    await runSync(root, []);
+    runSync({ cwd: root, logger: silentLogger });
 
     const content = readFileSync(path.join(root, 'codecov.yml'), 'utf8');
 
@@ -241,16 +237,16 @@ describe('sync command', () => {
     expect(content).toContain('carryforward');
   });
 
-  it('--force overwrites existing scripts', async ({ expect }) => {
+  it('force overwrites existing scripts', ({ expect }) => {
     const root = createConsumerProject();
-    await runSync(root, []);
+    runSync({ cwd: root, logger: silentLogger });
 
     const appPkg = path.join(root, 'packages', 'app', 'package.json');
     const manifest = v.parse(ManifestSchema, readJsonFile(appPkg));
     const scripts = { ...manifest.scripts, 'typecheck:ts': 'custom-tsc' };
     writeJsonFile(appPkg, { ...manifest, scripts });
 
-    await runSync(root, ['--force']);
+    runSync({ cwd: root, force: true, logger: silentLogger });
 
     const result: unknown = JSON.parse(
       readFileSync(path.join(root, 'packages', 'app', 'package.json'), 'utf8'),

--- a/packages/cli/test/sync.test.ts
+++ b/packages/cli/test/sync.test.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import { Writable } from 'node:stream';
 import * as v from 'valibot';
 import { describe, it } from 'vitest';
-import { runSync } from '#src/commands/root/sync.js';
+import { runSync, syncCommand } from '#src/commands/root/sync.js';
 import { discoverWorkspace } from '#src/lib/discovery.js';
 import { mergePackageScripts, readJsonFile, writeJsonFile } from '#src/lib/file-writer.js';
 import { createLogger } from '#src/lib/logger.js';
@@ -13,7 +13,7 @@ import {
   generateRootScripts,
   generateTurboJson,
 } from '#src/lib/turbo-config.js';
-import { createTempDir, writeJson } from './helpers.ts';
+import { captureLogger, createTempDir, writeJson } from './helpers.ts';
 
 const silentSink = new Writable({
   write: (_chunk, _enc, cb) => {
@@ -253,5 +253,46 @@ describe.concurrent(runSync, () => {
     );
 
     expect(result).toHaveProperty('scripts.typecheck:ts', 'gtb task typecheck:ts');
+  });
+});
+
+describe.concurrent(syncCommand, () => {
+  it('passes cwd from args through to runSync', ({ expect }) => {
+    const root = createConsumerProject();
+    const { logger } = captureLogger();
+
+    syncCommand({ cwd: root }, logger);
+
+    expect(existsSync(path.join(root, 'turbo.json'))).toBe(true);
+  });
+
+  it('passes force from args through to runSync', ({ expect }) => {
+    const root = createConsumerProject();
+    const { logger } = captureLogger();
+    syncCommand({ cwd: root }, logger);
+
+    const appPkg = path.join(root, 'packages', 'app', 'package.json');
+    const manifest = v.parse(ManifestSchema, readJsonFile(appPkg));
+    writeJsonFile(appPkg, {
+      ...manifest,
+      scripts: { ...manifest.scripts, 'typecheck:ts': 'custom-tsc' },
+    });
+
+    syncCommand({ cwd: root, force: true }, logger);
+
+    const result: unknown = JSON.parse(
+      readFileSync(appPkg, 'utf8'),
+    );
+
+    expect(result).toHaveProperty('scripts.typecheck:ts', 'gtb task typecheck:ts');
+  });
+
+  it('routes progress messages through the injected logger', ({ expect }) => {
+    const root = createConsumerProject();
+    const { logger, out } = captureLogger();
+
+    syncCommand({ cwd: root }, logger);
+
+    expect(out()).toContain(`wrote ${path.join(root, 'turbo.json')}`);
   });
 });

--- a/packages/cli/test/verify.test.ts
+++ b/packages/cli/test/verify.test.ts
@@ -1,8 +1,7 @@
 import { mkdirSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
-import { runCommand } from 'citty';
-import { describe, it, vi } from 'vitest';
-import { parseIgnoreArgs, verify } from '#src/commands/root/verify.js';
+import { describe, it } from 'vitest';
+import { parseIgnoreArgs, runVerify } from '#src/commands/root/verify.js';
 import { discoverWorkspace } from '#src/lib/discovery.js';
 import { writeJsonFile } from '#src/lib/file-writer.js';
 import {
@@ -12,25 +11,6 @@ import {
 import {
   createTempDir, initProject, readScripts, readTurboTasks, writeJson,
 } from './helpers.ts';
-
-const runVerify = async (
-  dir: string,
-  args: readonly string[],
-): Promise<typeof process.exitCode> => {
-  const origCwd = process.cwd();
-  const origExitCode = process.exitCode;
-  vi.spyOn(console, 'log').mockReturnValue();
-  vi.spyOn(console, 'error').mockReturnValue();
-
-  try {
-    process.chdir(dir);
-    await runCommand(verify, { rawArgs: [...args] });
-    return process.exitCode;
-  } finally {
-    process.chdir(origCwd);
-    process.exitCode = origExitCode;
-  }
-};
 
 const createConsumerProject = (): string => {
   const root = createTempDir();
@@ -135,17 +115,17 @@ describe.concurrent('verify drift detection', () => {
   });
 });
 
-describe('verify', () => {
-  it('passes with no drift', async ({ expect }) => {
+describe.concurrent(runVerify, () => {
+  it('returns no drift when project is fully synced', ({ expect }) => {
     const root = createConsumerProject();
     initProject(root);
 
-    const exitCode = await runVerify(root, []);
+    const drift = runVerify({ cwd: root });
 
-    expect(exitCode).not.toBe(1);
+    expect(drift).toHaveLength(0);
   });
 
-  it('sets exitCode 1 on drift', async ({ expect }) => {
+  it('reports drift on missing turbo task', ({ expect }) => {
     const root = createConsumerProject();
     initProject(root);
 
@@ -153,12 +133,12 @@ describe('verify', () => {
     delete tasks['typecheck:ts'];
     writeJsonFile(path.join(root, 'turbo.json'), { $schema: '', tasks });
 
-    const exitCode = await runVerify(root, []);
+    const drift = runVerify({ cwd: root });
 
-    expect(exitCode).toBe(1);
+    expect(drift.some(msg => msg.includes('typecheck:ts'))).toBe(true);
   });
 
-  it('--ignore suppresses specific drift', async ({ expect }) => {
+  it('ignored set suppresses specific drift', ({ expect }) => {
     const root = createConsumerProject();
     initProject(root);
 
@@ -166,9 +146,55 @@ describe('verify', () => {
     delete tasks['typecheck:ts'];
     writeJsonFile(path.join(root, 'turbo.json'), { $schema: '', tasks });
 
-    const exitCode = await runVerify(root, ['--ignore', 'typecheck:ts']);
+    const drift = runVerify({ cwd: root, ignored: new Set(['typecheck:ts']) });
 
-    expect(exitCode).not.toBe(1);
+    expect(drift).toHaveLength(0);
+  });
+
+  it('reports drift when codecov.yml has invalid YAML', ({ expect }) => {
+    const root = createConsumerProject();
+    initProject(root);
+    writeFileSync(path.join(root, 'codecov.yml'), 'invalid: [}');
+
+    const drift = runVerify({ cwd: root });
+
+    expect(drift.some(msg => msg.includes('codecov.yml'))).toBe(true);
+  });
+
+  it('reports drift when codecov.yml is empty', ({ expect }) => {
+    const root = createConsumerProject();
+    initProject(root);
+    writeFileSync(path.join(root, 'codecov.yml'), '');
+
+    const drift = runVerify({ cwd: root });
+
+    expect(drift.some(msg => msg.includes('codecov.yml'))).toBe(true);
+  });
+
+  it('reports drift when a codecov flag is missing', ({ expect }) => {
+    const root = createConsumerProject();
+    initProject(root);
+    writeFileSync(
+      path.join(root, 'codecov.yml'),
+      'flags: {}\ncomponent_management:\n  individual_components: []\n',
+    );
+
+    const drift = runVerify({ cwd: root });
+
+    expect(drift.some(msg => msg.includes("missing flag 'app'"))).toBe(true);
+  });
+
+  it('ignored set suppresses missing codecov flag drift', ({ expect }) => {
+    const root = createConsumerProject();
+    initProject(root);
+    writeFileSync(
+      path.join(root, 'codecov.yml'),
+      'flags: {}\ncomponent_management:\n  individual_components: []\n',
+    );
+
+    const drift = runVerify({ cwd: root, ignored: new Set(['app']) });
+
+    expect(drift).toHaveLength(0);
   });
 });
 
@@ -199,62 +225,5 @@ describe.concurrent(parseIgnoreArgs, () => {
     const result = parseIgnoreArgs(['--ignore']);
 
     expect(result.size).toBe(0);
-  });
-});
-
-describe('verify codecov drift detection', () => {
-  it('passes with valid codecov.yml after init', async ({ expect }) => {
-    const root = createConsumerProject();
-    initProject(root);
-
-    const exitCode = await runVerify(root, []);
-
-    expect(exitCode).not.toBe(1);
-  });
-
-  it('sets exitCode 1 when codecov.yml has invalid YAML', async ({ expect }) => {
-    const root = createConsumerProject();
-    initProject(root);
-    writeFileSync(path.join(root, 'codecov.yml'), 'invalid: [}');
-
-    const exitCode = await runVerify(root, []);
-
-    expect(exitCode).toBe(1);
-  });
-
-  it('sets exitCode 1 when codecov.yml is missing', async ({ expect }) => {
-    const root = createConsumerProject();
-    initProject(root);
-    writeFileSync(path.join(root, 'codecov.yml'), '');
-
-    const exitCode = await runVerify(root, []);
-
-    expect(exitCode).toBe(1);
-  });
-
-  it('sets exitCode 1 when flag is missing', async ({ expect }) => {
-    const root = createConsumerProject();
-    initProject(root);
-    writeFileSync(
-      path.join(root, 'codecov.yml'),
-      'flags: {}\ncomponent_management:\n  individual_components: []\n',
-    );
-
-    const exitCode = await runVerify(root, []);
-
-    expect(exitCode).toBe(1);
-  });
-
-  it('--ignore suppresses missing flag error', async ({ expect }) => {
-    const root = createConsumerProject();
-    initProject(root);
-    writeFileSync(
-      path.join(root, 'codecov.yml'),
-      'flags: {}\ncomponent_management:\n  individual_components: []\n',
-    );
-
-    const exitCode = await runVerify(root, ['--ignore', 'app']);
-
-    expect(exitCode).not.toBe(1);
   });
 });

--- a/packages/cli/test/verify.test.ts
+++ b/packages/cli/test/verify.test.ts
@@ -1,7 +1,7 @@
 import { mkdirSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { describe, it } from 'vitest';
-import { parseIgnoreArgs, runVerify } from '#src/commands/root/verify.js';
+import { parseIgnoreArgs, runVerify, verifyCommand } from '#src/commands/root/verify.js';
 import { discoverWorkspace } from '#src/lib/discovery.js';
 import { writeJsonFile } from '#src/lib/file-writer.js';
 import {
@@ -9,7 +9,7 @@ import {
   generateTurboJson,
 } from '#src/lib/turbo-config.js';
 import {
-  createTempDir, initProject, readScripts, readTurboTasks, writeJson,
+  captureLogger, createTempDir, initProject, readScripts, readTurboTasks, writeJson,
 } from './helpers.ts';
 
 const createConsumerProject = (): string => {
@@ -225,5 +225,47 @@ describe.concurrent(parseIgnoreArgs, () => {
     const result = parseIgnoreArgs(['--ignore']);
 
     expect(result.size).toBe(0);
+  });
+});
+
+describe.concurrent(verifyCommand, () => {
+  it('returns 0 and logs success when there is no drift', ({ expect }) => {
+    const root = createConsumerProject();
+    initProject(root);
+    const { logger, out, err } = captureLogger();
+
+    const code = verifyCommand([], { cwd: root }, logger);
+
+    expect(code).toBe(0);
+    expect(out()).toContain('verify passed');
+    expect(err()).toBe('');
+  });
+
+  it('returns 1 and writes each drift message to stderr on drift', ({ expect }) => {
+    const root = createConsumerProject();
+    initProject(root);
+    const tasks = readTurboTasks(root);
+    delete tasks['typecheck:ts'];
+    writeJsonFile(path.join(root, 'turbo.json'), { $schema: '', tasks });
+    const { logger, out, err } = captureLogger();
+
+    const code = verifyCommand([], { cwd: root }, logger);
+
+    expect(code).toBe(1);
+    expect(err()).toContain('typecheck:ts');
+    expect(out()).toBe('');
+  });
+
+  it('forwards --ignore flags from rawArgs to runVerify', ({ expect }) => {
+    const root = createConsumerProject();
+    initProject(root);
+    const tasks = readTurboTasks(root);
+    delete tasks['typecheck:ts'];
+    writeJsonFile(path.join(root, 'turbo.json'), { $schema: '', tasks });
+    const { logger } = captureLogger();
+
+    const code = verifyCommand(['--ignore', 'typecheck:ts'], { cwd: root }, logger);
+
+    expect(code).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

- Extract pure `runSync({ cwd?, force?, logger? })` and `runVerify({ cwd?, ignored? }): readonly string[]` from the citty `sync` and `verify` commands. The citty wrappers become thin: parse args, default streams, call the pure function, set `process.exitCode` if drift.
- Add a stream-injectable `Logger` interface (`packages/cli/src/lib/logger.ts`) — `info`/`error` only, plain text, no level/timestamp prefixing. Names match `~/Code/lsp-proxy`'s logger so this can extract to a shared package later. Defaults to `process.stdout`/`process.stderr`; tests pass a `Writable` sink that discards.
- Add `--cwd` / `-C` flag to `gtb sync` and `gtb verify`. `-C` matches the convention from `git -C`, `pnpm -C`, `make -C`. Defaults to `process.cwd()`.
- Drop `process.chdir` + `vi.spyOn(console, ...)` wrappers from `sync.test.ts` and `verify.test.ts`. Tests now call `runSync` / `runVerify` directly with `{ cwd: tempDir, logger: silentLogger }`. The four `runSync` tests and seven `runVerify` tests join the existing `describe.concurrent` blocks; `verify` codecov drift tests merged into the main `runVerify` describe (drops one duplicate).

## Notes

- `runSync`/`runVerify`/`Logger`/`createLogger` are exported from their source modules but not re-exported from the package's public entry point (`src/index.ts` only exports `main`). This is purely a CLI-flag addition for consumers; no changeset since the published surface didn't change.
- citty doesn't support global/inherited args ([unjs/citty#154](https://github.com/unjs/citty/issues/154)), so `-C` is declared per command. If we ever migrate the rest of the commands (`pipeline`, `task` leaves, `prepare`, etc.), we'd either keep duplicating the flag or build a small argv preprocessor. Out of scope here.
- Codebase still has 4 commands using `console.*` directly (`prepare`, `pipeline`, `deploy-skills`, `coverage-codecov-upload`). Their tests don't currently need the logger abstraction; migrate when concurrency or capture is needed.

## Test plan

- [x] `pnpm exec turbo run lint:eslint test:vitest:fast --filter='@gtbuchanan/cli'` — 9/9 tasks pass, lint clean, 188/188 tests green
- [x] Verified the four previously-sequential `runSync` tests and seven `runVerify` tests now run inside `describe.concurrent` blocks
- [x] CI green
- [ ] Manual: `gtb sync -C some/dir` and `gtb verify --cwd some/dir` behave as expected against a real consumer repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)