### PR TITLE
Add gtb-eslint-config skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.tsbuildinfo
+**/skills/*-workspace/
 .agents/skills/
 .claude/skills/
 .claude/worktrees/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,11 +43,14 @@ deploy:skills` for dogfooding.
   `gtb sync` / `gtb verify` / `gtb turbo` (with the Android/Termux
   escape hatch), consumer script customization, test-bucket strategy,
   aggregate semantics
+- **`gtb-eslint-config`** (`@gtbuchanan/eslint-config`) — `configure()`
+  API and options, pre-commit `createRequire` pattern, bundled plugin
+  set, suppression conventions, two-plugin Markdown lint split,
+  per-package vs. workspace-root config split
 
-Packages without skills yet (vitest-config, eslint-config,
-eslint-plugin-markdownlint, eslint-plugin-yamllint, tsconfig, test-utils)
-keep their conventions in the sections below until those skills are
-authored.
+Packages without skills yet (vitest-config, eslint-plugin-markdownlint,
+eslint-plugin-yamllint, tsconfig, test-utils) keep their conventions in
+the sections below until those skills are authored.
 
 ## Architecture
 
@@ -65,54 +68,13 @@ coverage, setupFiles, and mock reset.
 
 ### Per-package tool configs
 
-- **ESLint** — Per-package `eslint.config.ts` importing `configure()`
-  from `@gtbuchanan/eslint-config`. ESLint caching enabled via
-  `--cache --cache-location dist/.eslintcache`. In monorepos with a
-  root ESLint config, `gtb sync` also generates a `//#lint:eslint`
-  turbo task and root `lint:eslint` script that lints workspace-root
-  files (`package.json`, `pnpm-workspace.yaml`, `.github/`, etc.) which
-  per-package lint never sees. Per-package dirs are excluded via
-  `--ignore-pattern` derived from `pnpm-workspace.yaml` package globs.
+- **ESLint** — Per-package `eslint.config.ts` calling `configure()`
+  from `@gtbuchanan/eslint-config`. API surface, plugin set,
+  suppression conventions, Markdown lint split, and the per-package
+  vs. workspace-root config split (incl. `//#lint:eslint` generation)
+  live in the `gtb-eslint-config` skill.
 - **Vitest** — Per-package `vitest.config.ts` using `configurePackage()`
   from `@gtbuchanan/vitest-config/configure`.
-
-### Linter
-
-- **ESLint** — Primary linter and formatter. `typescript-eslint`
-  strictTypeChecked + stylisticTypeChecked presets, `eslint-plugin-unicorn`
-  (recommended), `eslint-plugin-promise`, `eslint-plugin-regexp` (regex
-  safety), `eslint-plugin-jsdoc` (JSDoc/TSDoc validation),
-  `@stylistic/eslint-plugin` (JS/TS formatting), `eslint-plugin-format`
-  (Prettier formatting for JSON, Markdown, YAML, CSS, XML via ESLint
-  rules), `@eslint-community/eslint-plugin-eslint-comments`,
-  `eslint-plugin-import-x` (ordering), `@eslint/json` (JSON linting),
-  `eslint-plugin-pnpm` (workspace validation), `eslint-plugin-n` (Node.js
-  rules), `eslint-plugin-yml` (YAML linting + key sorting),
-  `eslint-plugin-yamllint` (yamllint gap rules: truthy, octal-values,
-  anchors, document-start/end),
-  `@eslint/markdown` (official Markdown plugin, commonmark AST,
-  recommended rule set),
-  `eslint-plugin-markdownlint` (Markdown structural linting for the
-  rules `@eslint/markdown` doesn't yet cover; rules it does cover are
-  disabled in this config to avoid duplicate diagnostics),
-  `eslint-plugin-md-frontmatter` (generic Markdown frontmatter
-  validation via JSON Schema, ajv-backed),
-  `eslint-plugin-agent-skills` (Agent Skills JSON Schema + rules
-  covering spec constraints schemas can't express; the schema plugs
-  into `eslint-plugin-md-frontmatter`),
-  `@vitest/eslint-plugin` (test rules), and `eslint-plugin-only-warn`
-  (downgrades errors to warnings).
-
-### Formatter
-
-- **Prettier (via eslint-plugin-format)** — Formats non-JS/TS files
-  (JSON, Markdown, YAML, CSS/SCSS/Less, XML) through ESLint rules.
-  JS/TS formatting is handled by `@stylistic/eslint-plugin`. Prettier
-  plugins (`prettier-plugin-sort-json`, `prettier-plugin-multiline-arrays`,
-  `prettier-plugin-packagejson`, `prettier-plugin-css-order`,
-  `@prettier/plugin-xml`) are resolved as `file://` URLs from this
-  package's dependencies for reliable resolution under pnpm strict
-  hoisting.
 
 ### Pre-commit hooks
 
@@ -205,19 +167,13 @@ skill.
 
 ## Conventions
 
-- All lint violations report as warnings in IDEs (not errors) so TypeScript
-  diagnostics stand out. CI enforces via `--max-warnings=0`.
-- Inline suppressions require a `--` reason suffix.
-- Markdown lints through two plugins: `@eslint/markdown` (recommended
-  rule set) and `@gtbuchanan/eslint-plugin-markdownlint` for the gaps
-  it doesn't cover. `markdown/*` rules suppress with the standard
-  `<!-- eslint-disable-next-line markdown/no-duplicate-headings -- ... -->`
-  syntax; the wrapped `markdownlint/lint` rule needs markdownlint's
-  own per-rule directive instead: `<!-- markdownlint-disable-next-line MD036 -->`.
-- All exported functions, types, interfaces, and constants must have JSDoc comments.
+ESLint conventions enforced by `@gtbuchanan/eslint-config` (warnings-only
+in IDE / `--max-warnings=0` in CI, `--` reason suffix on suppressions,
+JSDoc on exports, two-plugin Markdown lint split) live in the
+`gtb-eslint-config` skill. Repo-local conventions:
+
 - When adding or removing a package, update the packages table in
-  `README.md`, the structure tree above, and the linter/formatter
-  sections as applicable.
+  `README.md` and the structure tree above.
 - When asserting on `CommandResult` (exit code, stdout, stderr), use
   `expect(result).toMatchObject({ exitCode: 0 })` instead of
   `expect(result.exitCode).toBe(0)`. On failure, `toMatchObject` shows

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -10,9 +10,11 @@
     ".": "./src/index.ts"
   },
   "scripts": {
+    "compile:skills": "pnpm run gtb task compile:skills",
     "compile:ts": "pnpm run gtb task compile:ts",
     "coverage:codecov:upload": "pnpm run gtb task coverage:codecov:upload",
     "coverage:vitest:merge": "pnpm run gtb task coverage:vitest:merge",
+    "deploy:skills": "pnpm run gtb task deploy:skills",
     "gtb": "node --experimental-strip-types ../../packages/cli/bin/gtb.ts",
     "lint:eslint": "pnpm run gtb task lint:eslint",
     "pack:npm": "pnpm run gtb task pack:npm",

--- a/packages/eslint-config/skills/gtb-eslint-config/SKILL.md
+++ b/packages/eslint-config/skills/gtb-eslint-config/SKILL.md
@@ -1,0 +1,201 @@
+---
+name: gtb-eslint-config
+description: ESLint configuration guidance for projects using @gtbuchanan/eslint-config. Covers the configure() API and options, pre-commit isolated-environment setup via createRequire, the bundled plugin set, suppression conventions, the two-plugin Markdown lint split, and the per-package vs. workspace-root config split. Trigger keywords - @gtbuchanan/eslint-config, eslint.config.ts, configure, ESLintConfigureOptions, eslint-disable, eslint-disable-next-line, markdownlint-disable, --max-warnings, dist/.eslintcache, lint:eslint, ESLint flat config, ESLint suppression.
+---
+
+# @gtbuchanan/eslint-config
+
+Shared ESLint flat-config factory for TypeScript projects. Bundles
+`typescript-eslint` strict + stylistic presets and a curated plugin set,
+plus Prettier-via-ESLint formatting for non-JS/TS files.
+
+## Quickstart
+
+Install peers and configure:
+
+```sh
+pnpm add -D @gtbuchanan/eslint-config eslint jiti
+```
+
+```typescript
+// eslint.config.ts
+import { configure } from '@gtbuchanan/eslint-config';
+
+export default configure({
+  tsconfigRootDir: import.meta.dirname,
+});
+```
+
+`configure()` returns `Promise<Linter.Config[]>`; ESLint awaits async
+flat configs natively.
+
+## `configure()` options
+
+All optional except `tsconfigRootDir` (recommended for type-aware rules):
+
+- **`tsconfigRootDir`** — Root directory for the TypeScript project
+  service. Pass `import.meta.dirname` from the config file.
+- **`target`** — `'server'` (default) or `'browser'`. Server enables
+  `require-unicode-regexp` with the `/v` flag. Browser enables
+  `no-console` and `no-alert`; entry points are exempt from `no-console`.
+- **`entryPoints`** — Glob patterns exempt from `process.exit` and
+  hashbang restrictions (and from `no-console` in browser mode).
+  Defaults to `**/bin/**/*.{js,mjs,cjs,ts,mts,cts}` and `**/scripts/**/*`.
+- **`ignores`** — Global ignore patterns. Defaults to
+  `.claude/worktrees/**`, `**/.turbo/**`, `**/dist/**`,
+  `**/pnpm-lock.yaml`, `**/skills-lock.json`.
+- **`onlyWarn`** — Downgrades all errors to warnings via
+  `eslint-plugin-only-warn`. Defaults to `true`. Irreversible within
+  a process — uses a side-effect import that monkey-patches the ESLint
+  Linter class.
+- **`pnpm`** — Enables `eslint-plugin-pnpm` rules for `package.json`
+  and `pnpm-workspace.yaml`. Defaults to `true`.
+
+## Pre-commit isolation
+
+[pre-commit](https://pre-commit.com/) and [prek](https://prek.dev) run
+hooks in an isolated environment where the project's `node_modules` is
+not available — the import `'@gtbuchanan/eslint-config'` would fail
+under default ESM resolution.
+
+Use `createRequire` to bridge ESM → CJS resolution, which respects the
+`NODE_PATH` the hook manager sets:
+
+```typescript
+// eslint.config.ts
+import { createRequire } from 'node:module';
+import { pathToFileURL } from 'node:url';
+import type * as EslintConfig from '@gtbuchanan/eslint-config';
+
+interface ModuleMap {
+  '@gtbuchanan/eslint-config': typeof EslintConfig;
+}
+
+const { resolve } = createRequire(import.meta.url);
+
+async function importModule<S extends keyof ModuleMap>(
+  specifier: S,
+): Promise<ModuleMap[S]> {
+  const { href } = pathToFileURL(resolve(specifier));
+  const module: ModuleMap[S] = await import(href);
+  return module;
+}
+
+const { configure } = await importModule('@gtbuchanan/eslint-config');
+
+export default configure({
+  tsconfigRootDir: import.meta.dirname,
+});
+```
+
+## Bundled plugins
+
+Enabled by `configure()`. Each is a separate concern; per-plugin rule
+depth lives in that plugin's own skill (where one exists).
+
+- **`typescript-eslint`** — `strictTypeChecked` + `stylisticTypeChecked`
+- **`eslint-plugin-unicorn`** — recommended modern JS/TS rules
+- **`eslint-plugin-promise`** — promise hygiene
+- **`eslint-plugin-regexp`** — regex correctness and safety
+- **`eslint-plugin-jsdoc`** — JSDoc/TSDoc validation
+- **`@stylistic/eslint-plugin`** — JS/TS formatting (semicolons, quotes,
+  spacing)
+- **`eslint-plugin-format`** — Prettier formatting for JSON, Markdown,
+  YAML, CSS, XML via ESLint rules. JS/TS formatting goes through
+  `@stylistic` instead.
+- **`@eslint-community/eslint-plugin-eslint-comments`** — suppression
+  comment hygiene
+- **`eslint-plugin-import-x`** — import ordering
+- **`@eslint/json`** — JSON file linting
+- **`eslint-plugin-pnpm`** — workspace validation (gated by the `pnpm`
+  option)
+- **`eslint-plugin-n`** — Node.js best practices
+- **`eslint-plugin-yml`** — YAML linting + key sorting
+- **`@gtbuchanan/eslint-plugin-yamllint`** — yamllint gap rules
+  (truthy, octal-values, anchors, document-start/end)
+- **`@eslint/markdown`** — official Markdown plugin (commonmark AST,
+  recommended rule set)
+- **`@gtbuchanan/eslint-plugin-markdownlint`** — Markdown structural
+  linting for the rules `@eslint/markdown` doesn't cover yet
+- **`@gtbuchanan/eslint-plugin-md-frontmatter`** — Markdown frontmatter
+  validation via JSON Schema (ajv-backed)
+- **`@gtbuchanan/eslint-plugin-agent-skills`** — Agent Skills
+  frontmatter schema + spec rules; plugs into `md-frontmatter`
+- **`@vitest/eslint-plugin`** — test-specific rules
+- **`eslint-plugin-only-warn`** — downgrades errors to warnings (gated
+  by the `onlyWarn` option)
+
+Prettier plugins (`prettier-plugin-sort-json`,
+`prettier-plugin-multiline-arrays`, `prettier-plugin-packagejson`,
+`prettier-plugin-css-order`, `@prettier/plugin-xml`) are resolved as
+`file://` URLs from this package's dependencies for reliable resolution
+under pnpm strict hoisting.
+
+## Conventions
+
+- **Warnings-only in IDE, errors in CI.** `onlyWarn: true` (the default)
+  surfaces every lint violation as a warning so TypeScript diagnostics
+  stand out in editors. CI runs `eslint --max-warnings=0` to enforce
+  zero violations. The `gtb task lint:eslint` command sets this flag
+  along with `--cache --cache-location dist/.eslintcache`.
+- **Inline suppressions require a `--` reason suffix.** Enforced by
+  `@eslint-community/eslint-plugin-eslint-comments`. Use the multiline
+  format for readability:
+
+  ```ts
+  /* eslint-disable-next-line rule-name-1, rule-name-2 --
+     This is my reason */
+  ```
+
+- **Prefer `eslint-disable-next-line` over `eslint-disable`.** Scope
+  suppressions to the narrowest possible range.
+- **All exported functions, types, interfaces, and constants must have
+  JSDoc comments.** Enforced by `eslint-plugin-jsdoc`.
+
+## Markdown lint split
+
+Two plugins lint Markdown together:
+
+- `@eslint/markdown` runs its `recommended` rule set (CommonMark AST).
+- `@gtbuchanan/eslint-plugin-markdownlint` fills the structural gaps
+  `@eslint/markdown` doesn't cover yet. Rules `@eslint/markdown`
+  already enforces are disabled in the markdownlint plugin to keep
+  diagnostics single-sourced. As `@eslint/markdown` adds rules upstream,
+  the markdownlint counterparts retire one by one.
+
+Suppressions use different syntax for each:
+
+```markdown
+<!-- eslint-disable-next-line markdown/no-duplicate-headings --
+     intentional -->
+
+# Duplicate heading allowed here
+```
+
+```markdown
+<!-- markdownlint-disable-next-line MD036 -->
+
+**Bold paragraph used as heading**
+```
+
+`markdownlint/lint` runs as a single ESLint rule, so per-rule control
+must use markdownlint's own directive — `<!-- eslint-disable
+markdownlint/lint -->` would suppress every markdownlint rule at once.
+
+## Per-package vs. workspace-root config
+
+Monorepos using `@gtbuchanan/cli` follow a two-tier ESLint setup:
+
+- **Per-package `eslint.config.ts`** — calls `configure()` and lints
+  source under that package. The generated `lint:eslint` task runs with
+  `--cache --cache-location dist/.eslintcache --max-warnings=0`. Cache
+  files live under each package's `dist/`.
+- **Root `eslint.config.ts`** — when present, `gtb sync` also generates
+  a `//#lint:eslint` turbo task and a root `lint:eslint` script. The
+  root script lints workspace-root files (`package.json`,
+  `pnpm-workspace.yaml`, `.github/`, etc.) that per-package lint never
+  sees. Per-package directories are excluded automatically via
+  `--ignore-pattern` flags derived from `pnpm-workspace.yaml` package
+  globs — no manual upkeep.
+
+Single-package repos only need the root config.

--- a/packages/eslint-config/skills/gtb-eslint-config/evals/evals.json
+++ b/packages/eslint-config/skills/gtb-eslint-config/evals/evals.json
@@ -1,0 +1,92 @@
+{
+  "evals": [
+    {
+      "expectations": [
+        "Recommends installing @gtbuchanan/eslint-config, eslint, and jiti as devDependencies (e.g., via pnpm add -D)",
+        "Shows or describes an eslint.config.ts that imports configure from @gtbuchanan/eslint-config and exports its result",
+        "Recommends passing tsconfigRootDir: import.meta.dirname to configure()"
+      ],
+      "expected_output": "Activates skill. Recommends `pnpm add -D @gtbuchanan/eslint-config eslint jiti`. Shows a minimal `eslint.config.ts` calling `configure({ tsconfigRootDir: import.meta.dirname })`.",
+      "files": [],
+      "id": 1,
+      "prompt": "I'm starting a new TypeScript project. How do I set up @gtbuchanan/eslint-config?"
+    },
+    {
+      "expectations": [
+        "Identifies the cause as pre-commit / prek hooks running in an isolated environment without project node_modules",
+        "Recommends using createRequire from node:module to bridge ESM to CJS resolution so NODE_PATH is respected",
+        "Shows or references a pattern that uses createRequire(import.meta.url) plus pathToFileURL to resolve and dynamically import @gtbuchanan/eslint-config"
+      ],
+      "expected_output": "Activates skill. Explains that pre-commit / prek run hooks in an isolated environment without project node_modules. Provides the `createRequire` + `pathToFileURL` import-bridge pattern from the skill, importing the config dynamically.",
+      "files": [],
+      "id": 2,
+      "prompt": "ESLint can't resolve @gtbuchanan/eslint-config when running under pre-commit. How do I fix it?"
+    },
+    {
+      "expectations": [
+        "Recommends eslint-disable-next-line over eslint-disable for narrow scope",
+        "States that suppression comments must include a -- reason suffix",
+        "Shows the multiline /* eslint-disable-next-line rule-name -- reason */ format with the reason on the next line"
+      ],
+      "expected_output": "Activates skill. Recommends `eslint-disable-next-line` over `eslint-disable` for narrow scope, with the multiline `--` reason format. Mentions that the `--` reason suffix is enforced.",
+      "files": [],
+      "id": 3,
+      "prompt": "What's the right way to suppress an ESLint rule for one line in a file using this config?"
+    },
+    {
+      "expectations": [
+        "Recommends the markdownlint-native directive: <!-- markdownlint-disable-next-line MD036 -->",
+        "Does NOT recommend an eslint-disable directive (e.g., <!-- eslint-disable-next-line markdownlint/lint -->) as the primary fix",
+        "Explains that markdownlint/lint runs as a single ESLint rule, so per-rule control needs markdownlint's own directive (or notes that eslint-disable markdownlint/lint would suppress every markdownlint rule at once)"
+      ],
+      "expected_output": "Activates skill. Recommends the markdownlint-native directive `<!-- markdownlint-disable-next-line MD036 -->`, NOT `eslint-disable`. Explains that `markdownlint/lint` runs as a single ESLint rule so per-rule control needs markdownlint's own syntax — `eslint-disable markdownlint/lint` would suppress every markdownlint rule at once.",
+      "files": [],
+      "id": 4,
+      "prompt": "How do I suppress a markdownlint MD036 warning on just one line of a Markdown file?"
+    },
+    {
+      "expectations": [
+        "Recommends setting target: 'browser' in the configure() options",
+        "Mentions that target: 'browser' enables no-console (and no-alert)",
+        "Notes that entry points (default: bin/** and scripts/**) are exempt from no-console even in browser mode, and that the entryPoints option can customize this"
+      ],
+      "expected_output": "Activates skill. Explains that `target: 'browser'` enables `no-console` and `no-alert`. Notes that entry points (`bin/**`, `scripts/**` by default) are exempt from `no-console` even in browser mode, and can be customized via `entryPoints`.",
+      "files": [],
+      "id": 5,
+      "prompt": "I'm using @gtbuchanan/eslint-config in a browser project but no-console isn't firing on my source files. What option do I need?"
+    },
+    {
+      "expectations": [
+        "Mentions that gtb sync generates a //#lint:eslint root turbo task when a root eslint.config.ts is present",
+        "Mentions that gtb sync generates a root lint:eslint script that lints workspace-root files (e.g., package.json, pnpm-workspace.yaml, .github/)",
+        "Mentions that per-package directories are auto-excluded via --ignore-pattern flags derived from pnpm-workspace.yaml package globs"
+      ],
+      "expected_output": "Activates skill. Explains that gtb sync generates a `//#lint:eslint` turbo task and a root `lint:eslint` script when a root eslint.config.ts is present. The root script lints workspace-root files (package.json, pnpm-workspace.yaml, .github/, etc.); per-package directories are auto-excluded via `--ignore-pattern` flags derived from `pnpm-workspace.yaml` package globs.",
+      "files": [],
+      "id": 6,
+      "prompt": "We have a monorepo with a root eslint.config.ts and per-package configs. What does gtb sync generate at the root?"
+    },
+    {
+      "expectations": [
+        "States that ESLint caches to dist/.eslintcache (per-package)",
+        "Mentions the --cache and --cache-location flags"
+      ],
+      "expected_output": "Activates skill. States that the per-package `lint:eslint` task runs with `--cache --cache-location dist/.eslintcache --max-warnings=0`. Cache lives under each package's `dist/`.",
+      "files": [],
+      "id": 7,
+      "prompt": "Where does ESLint cache its results when I run lint:eslint via gtb?"
+    },
+    {
+      "expectations": [
+        "Confirms both plugins are used together (the answer is yes, both are needed/active)",
+        "Mentions @eslint/markdown runs its recommended rule set on the CommonMark AST",
+        "Mentions @gtbuchanan/eslint-plugin-markdownlint fills the structural gaps that @eslint/markdown does not yet cover (rules already enforced by @eslint/markdown are disabled in the markdownlint plugin to keep diagnostics single-sourced)"
+      ],
+      "expected_output": "Activates skill. Explains the two-plugin split: `@eslint/markdown` runs its `recommended` rule set on the CommonMark AST; `@gtbuchanan/eslint-plugin-markdownlint` fills the structural gaps `@eslint/markdown` doesn't yet cover. Rules already enforced by `@eslint/markdown` are disabled in markdownlint to keep diagnostics single-sourced. As `@eslint/markdown` adds rules, the markdownlint counterparts retire.",
+      "files": [],
+      "id": 8,
+      "prompt": "What's the deal with @eslint/markdown vs @gtbuchanan/eslint-plugin-markdownlint — do I need both?"
+    }
+  ],
+  "skill_name": "gtb-eslint-config"
+}


### PR DESCRIPTION
## Summary

- Authors a new `gtb-eslint-config` Agent Skill at `packages/eslint-config/skills/gtb-eslint-config/SKILL.md` covering the `configure()` API and options, the pre-commit `createRequire` pattern, the bundled plugin set, suppression conventions, the two-plugin Markdown lint split, and the per-package vs. workspace-root config split.
- Trims `AGENTS.md`: removes the Linter and Formatter sections (now redundant with the skill), shortens the per-package ESLint bullet to a pointer, and drops the consumer-facing convention bullets (warnings-only / `--reason` suffix / Markdown split / JSDoc on exports). Repo-local rules (`CommandResult` matcher pattern, packages-table-update) stay.
- Authors `evals/evals.json` with 8 prompts, expected-output descriptions, and assertion expectations covering the skill's main surfaces (setup, pre-commit `createRequire`, suppression, markdownlint suppression, browser target, monorepo root, cache flags, Markdown plugin split).
- Adds `**/skills/*-workspace/` to root `.gitignore` so per-skill eval workspaces (the `<skill-name>-workspace/` convention from `skill-creator`) stay out of source control.

`gtb sync` auto-wires `compile:skills` and `deploy:skills` scripts in `packages/eslint-config/package.json` based on the new `skills/` directory.

Part of #41 (v2 — first per-plugin skill after `gtb-build-pipeline`).

## Test plan

- [x] `gtb sync` adds expected scripts; `gtb verify` clean
- [x] `compile:skills` copies into `dist/source/skills/`
- [x] `deploy:skills` symlinks into `.claude/skills/gtb-eslint-config`
- [x] Full `pnpm build --concurrency=1` passes (63/63 tasks)
- [x] Linting passes (eslint, prettier, markdownlint)
- [x] Eval harness run via `skill-creator`: 100% pass with skill, 43.8% pass without (delta +0.56)