### PR TITLE
Pin Termux rule and author gtb-build-pipeline evals

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,6 +180,12 @@ JSDoc on exports, two-plugin Markdown lint split) live in the
   the full result object (including stderr) in the diff, making failures
   self-diagnosing.
 
+## Operational notes
+
+- **Termux** — run `pnpm build`, `pnpm test:slow`, and `pnpm test:e2e`
+  with `--concurrency=1` to avoid OOM. See the `gtb-build-pipeline`
+  skill for why.
+
 ## Versioning
 
 Every PR requires a changeset — CI enforces this. Create a `.changeset/<name>.md`

--- a/packages/cli/skills/gtb-build-pipeline/SKILL.md
+++ b/packages/cli/skills/gtb-build-pipeline/SKILL.md
@@ -121,6 +121,8 @@ pnpm test:e2e --concurrency=1
 
 `gtb turbo` does not auto-set this — the right ceiling depends on which aggregate you're running and on free memory at invocation time, neither of which the wrapper can predict. Same applies to any low-memory host (small CI runners, etc.), not just Termux.
 
+If your host _always_ needs this (e.g., a Termux dev machine, a tight CI runner), encode it as a project rule in always-loaded agent context (`AGENTS.md`, `CLAUDE.md`, repo memory, etc.) rather than relying on discretionary skill activation. Skills load body-on-trigger, but operational rules that must fire every session belong in the system prompt.
+
 ## Customizing behavior
 
 Consumers override behavior by replacing `package.json` script values. No hooks or plugin system.

--- a/packages/cli/skills/gtb-build-pipeline/SKILL.md
+++ b/packages/cli/skills/gtb-build-pipeline/SKILL.md
@@ -87,15 +87,7 @@ Run after adding packages, changing the task graph, or updating tooling. Without
 
 Two issues are caused by Termux's Node reporting `process.platform === 'android'`; a third (memory pressure) is unrelated and applies to any low-memory host. Native Android support upstream was declined in [vercel/turborepo#5616](https://github.com/vercel/turborepo/issues/5616), so `gtb turbo` ships the workaround instead.
 
-**1. Turbo platform binary missing.** pnpm filters `@turbo/<os>-<arch>` optional dependencies by host platform; none target `android`, so all six are skipped on install. Widen the whitelist in the per-user pnpm rc:
-
-```text
-# ~/.config/pnpm/rc
-supported-architectures.os[]=current
-supported-architectures.os[]=linux
-```
-
-Then `pnpm install --force` from the workspace root. The Linux binary lands in `node_modules/.pnpm/turbo@<v>/node_modules/@turbo/linux-<arch>/`. `gtb turbo` resolves it via `require.resolve` from inside `node_modules/turbo/bin/turbo` (mirroring how the launcher itself looks up its platform package under pnpm strict layout) and execs it directly. The launcher's android-platform check is bypassed entirely; no `TURBO_BINARY_PATH` env var.
+**1. Turbo platform binary missing.** pnpm filters `@turbo/<os>-<arch>` optional dependencies by host platform; none target `android`, so all six are skipped on install. Run `pnpm install --force` from the workspace root — that's a known side-effect path that bypasses the optional-dep filter and installs every `@turbo/<os>-<arch>` package locally. The Linux binary lands in `node_modules/.pnpm/turbo@<v>/node_modules/@turbo/linux-<arch>/`. `gtb turbo` resolves it via `require.resolve` from inside `node_modules/turbo/bin/turbo` (mirroring how the launcher itself looks up its platform package under pnpm strict layout) and execs it directly. The launcher's android-platform check is bypassed entirely; no `TURBO_BINARY_PATH` env var.
 
 **2. Turbo child-process spawn ENOENT.** The Linux turbo binary is glibc-built, but Termux is Bionic. Termux's `LD_PRELOAD=libtermux-exec-ld-preload.so` rewrites `/usr/bin/env` shebangs in `execve` syscalls — but the preload is Bionic-only, so it never loads into the glibc turbo. When turbo spawns `pnpm`, the kernel sees `#!/usr/bin/env node` and fails because Termux has no `/usr/bin/env`.
 

--- a/packages/cli/skills/gtb-build-pipeline/evals/evals.json
+++ b/packages/cli/skills/gtb-build-pipeline/evals/evals.json
@@ -1,0 +1,53 @@
+{
+  "evals": [
+    {
+      "expected_output": "Activates skill. Recommends `pnpm build --concurrency=1` (and the same flag for `test:slow` and `test:e2e`). Explains that turbo's default `--concurrency=10` is fine for `check` but not for `build`/`test:slow`/`test:e2e`, which fork their own vitest worker pools per task. Notes that `gtb turbo` does not auto-set this and that the same applies to any low-memory host (small CI runners), not just Termux.",
+      "files": [],
+      "id": 1,
+      "prompt": "I'm running pnpm build in Termux on my Android phone and it's crashing with OOM partway through. What should I try?"
+    },
+    {
+      "expected_output": "Activates skill. Tells me to add `supported-architectures.os[]=current` and `supported-architectures.os[]=linux` to `~/.config/pnpm/rc`, then run `pnpm install --force` from the workspace root. Explains that pnpm filters `@turbo/<os>-<arch>` optional deps by host platform; none target Android, so widening the whitelist installs the Linux binary, which `gtb turbo` resolves and execs directly to bypass the launcher's android-platform check.",
+      "files": [],
+      "id": 2,
+      "prompt": "When I run `gtb turbo run build` on Termux it says `the linux turbo binary is not installed`. How do I fix that?"
+    },
+    {
+      "expected_output": "Activates skill. Explains that the Linux turbo binary is glibc-built but Termux is Bionic; Termux's `LD_PRELOAD=libtermux-exec-ld-preload.so` rewrites `/usr/bin/env` shebangs in `execve` syscalls, but the preload is Bionic-only and doesn't load into glibc turbo, so the kernel sees `#!/usr/bin/env node` and fails because `/usr/bin/env` doesn't exist. Fix: add `@gtbuchanan/pnpm-termux-shim` as an `optionalDependencies` entry on the workspace root so its absolute-path `bin/pnpm` lands in `<rootDir>/node_modules/.bin/pnpm` ahead of the system pnpm.",
+      "files": [],
+      "id": 3,
+      "prompt": "On Termux turbo fails to spawn pnpm with ENOENT. What's going on and how do I fix it?"
+    },
+    {
+      "expected_output": "Activates skill. Explains: `gtb sync` reconciles generated state — `turbo.json` tasks and aggregates, per-package `tsconfig.json`/`tsconfig.build.json`, per-package and root `package.json` scripts, `codecov.yml` flags. Without `--force`, existing script values are preserved (consumers keep custom overrides); use `--force` to reset to defaults. `gtb verify` validates no drift from the expected baseline and exits non-zero if anything is out of sync; run in CI as a drift gate.",
+      "files": [],
+      "id": 4,
+      "prompt": "What's the difference between `gtb sync` and `gtb verify`?"
+    },
+    {
+      "expected_output": "Activates skill. Explains aggregate semantics: pick by scope — `check` for fast pre-commit checks (typecheck/lint/fast tests), `build:ci` for PR-suitable runs (skips slow/e2e/skill deploys), `build` for full local validation. Add a `dependsOn` entry from the chosen aggregate to the new task in `turbo.json`. For PR coverage, `build:ci` is the right home.",
+      "files": [],
+      "id": 5,
+      "prompt": "I added a custom `lint:custom` task to my package. How do I plug it into the build aggregate so CI runs it?"
+    },
+    {
+      "expected_output": "Activates skill. Explains that `deploy:skills` keys on `skills/**` and `skills-npm.config.ts` only — installing or removing an agent changes neither, so turbo's cache reports HIT. Run `gtb turbo run deploy:skills --force` once to bypass the cache and resymlink into the new agent's project-local dir.",
+      "files": [],
+      "id": 6,
+      "prompt": "I just installed a new coding agent and want my existing skills symlinked into its project-local directory, but `deploy:skills` keeps showing as a turbo cache hit and skips."
+    },
+    {
+      "expected_output": "Activates skill. Explains: `lint:eslint` depends on `typecheck:ts` to prevent confusing linter output when there are type errors — ESLint via `typescript-eslint` runs its own type resolution, so the dep isn't strictly required, and consumers who prefer parallelism over cleaner output can remove it. Test tasks deliberately skip the dep — parallelism wins there because tests fail loudly on their own when types are broken.",
+      "files": [],
+      "id": 7,
+      "prompt": "Why does `lint:eslint` depend on `typecheck:ts` in this build graph, but the test tasks don't?"
+    },
+    {
+      "expected_output": "Activates skill. Explains that source changes in any `packages/*` workspace fully invalidate every task across all packages — Turbo 2.x mixes every file in every workspace package reachable from the root `package.json` deps/devDeps into `hashOfInternalDependencies`, salting every task hash. Root devDeps (`@gtbuchanan/cli`, eslint-config, tsconfig, vitest-config) transitively reach all packages. Root-only edits (docs, `.github/`) still hit cache. Consumers see our packages as external npm deps (lockfile-keyed), so they're unaffected. References vercel/turborepo#8202.",
+      "files": [],
+      "id": 8,
+      "prompt": "Why is turbo reporting `Cached: 0 cached, N total` after I edited one source file in one workspace package?"
+    }
+  ],
+  "skill_name": "gtb-build-pipeline"
+}

--- a/packages/cli/skills/gtb-build-pipeline/evals/evals.json
+++ b/packages/cli/skills/gtb-build-pipeline/evals/evals.json
@@ -1,48 +1,86 @@
 {
   "evals": [
     {
+      "expectations": [
+        "Recommends running with `--concurrency=1` (specifically `pnpm build --concurrency=1`)",
+        "Notes that `test:slow` and `test:e2e` need the same flag (heavy aggregates, not check)",
+        "Explains the rationale — turbo's default --concurrency=10 plus vitest worker pools forked per task creates memory pressure"
+      ],
       "expected_output": "Activates skill. Recommends `pnpm build --concurrency=1` (and the same flag for `test:slow` and `test:e2e`). Explains that turbo's default `--concurrency=10` is fine for `check` but not for `build`/`test:slow`/`test:e2e`, which fork their own vitest worker pools per task. Notes that `gtb turbo` does not auto-set this and that the same applies to any low-memory host (small CI runners), not just Termux.",
       "files": [],
       "id": 1,
       "prompt": "I'm running pnpm build in Termux on my Android phone and it's crashing with OOM partway through. What should I try?"
     },
     {
-      "expected_output": "Activates skill. Tells me to add `supported-architectures.os[]=current` and `supported-architectures.os[]=linux` to `~/.config/pnpm/rc`, then run `pnpm install --force` from the workspace root. Explains that pnpm filters `@turbo/<os>-<arch>` optional deps by host platform; none target Android, so widening the whitelist installs the Linux binary, which `gtb turbo` resolves and execs directly to bypass the launcher's android-platform check.",
+      "expectations": [
+        "Recommends running `pnpm install --force` from the workspace root",
+        "Explains pnpm's optional-dependency platform filtering — none of the @turbo/<os>-<arch> packages target android, so all six are skipped by default",
+        "Notes that `--force` bypasses the optional-dep filter and installs every @turbo platform locally"
+      ],
+      "expected_output": "Activates skill. Tells me to run `pnpm install --force` from the workspace root. Explains that pnpm filters `@turbo/<os>-<arch>` optional deps by host platform; none target Android, so all six are skipped by default. Notes that `--force` bypasses the filter and installs every @turbo platform locally. After install the Linux binary is available and `gtb turbo` resolves it via `require.resolve` and execs it directly.",
       "files": [],
       "id": 2,
       "prompt": "When I run `gtb turbo run build` on Termux it says `the linux turbo binary is not installed`. How do I fix that?"
     },
     {
+      "expectations": [
+        "Identifies the cause: glibc turbo's `#!/usr/bin/env node` shebang fails because Termux's LD_PRELOAD shebang shim is Bionic-only and never loads into the glibc turbo, while /usr/bin/env doesn't exist in Termux",
+        "Recommends adding `@gtbuchanan/pnpm-termux-shim` as an `optionalDependencies` entry on the workspace root (not a sub-package)"
+      ],
       "expected_output": "Activates skill. Explains that the Linux turbo binary is glibc-built but Termux is Bionic; Termux's `LD_PRELOAD=libtermux-exec-ld-preload.so` rewrites `/usr/bin/env` shebangs in `execve` syscalls, but the preload is Bionic-only and doesn't load into glibc turbo, so the kernel sees `#!/usr/bin/env node` and fails because `/usr/bin/env` doesn't exist. Fix: add `@gtbuchanan/pnpm-termux-shim` as an `optionalDependencies` entry on the workspace root so its absolute-path `bin/pnpm` lands in `<rootDir>/node_modules/.bin/pnpm` ahead of the system pnpm.",
       "files": [],
       "id": 3,
       "prompt": "On Termux turbo fails to spawn pnpm with ENOENT. What's going on and how do I fix it?"
     },
     {
+      "expectations": [
+        "Explains `gtb sync` reconciles generated state — covers turbo.json, per-package tsconfigs, package.json scripts, codecov.yml",
+        "Explains `gtb verify` validates no drift; exits non-zero if anything is out of sync; intended as a CI drift gate",
+        "Mentions that without `--force`, `gtb sync` preserves existing script values (so consumers keep custom overrides)"
+      ],
       "expected_output": "Activates skill. Explains: `gtb sync` reconciles generated state — `turbo.json` tasks and aggregates, per-package `tsconfig.json`/`tsconfig.build.json`, per-package and root `package.json` scripts, `codecov.yml` flags. Without `--force`, existing script values are preserved (consumers keep custom overrides); use `--force` to reset to defaults. `gtb verify` validates no drift from the expected baseline and exits non-zero if anything is out of sync; run in CI as a drift gate.",
       "files": [],
       "id": 4,
       "prompt": "What's the difference between `gtb sync` and `gtb verify`?"
     },
     {
-      "expected_output": "Activates skill. Explains aggregate semantics: pick by scope — `check` for fast pre-commit checks (typecheck/lint/fast tests), `build:ci` for PR-suitable runs (skips slow/e2e/skill deploys), `build` for full local validation. Add a `dependsOn` entry from the chosen aggregate to the new task in `turbo.json`. For PR coverage, `build:ci` is the right home.",
+      "expectations": [
+        "Explains aggregate semantics — pick the right aggregate by scope (`check` for fast pre-commit checks, `build:ci` for PR-suitable runs, `build` for full local)",
+        "Recommends adding a `dependsOn` entry in `turbo.json` from the chosen aggregate to the new task",
+        "Identifies that lint-class tasks like `lint:custom` belong in `check` (since check covers lint), which then propagates transitively into `build:ci` on PRs"
+      ],
+      "expected_output": "Activates skill. Explains aggregate semantics: pick by scope — `check` for fast pre-commit checks (typecheck/lint/fast tests), `build:ci` for PR-suitable runs (skips slow/e2e/skill deploys), `build` for full local validation. For a lint task like `lint:custom`, the right home is `check` (which propagates transitively into `build:ci` on PRs). Add the `dependsOn` entry on the chosen aggregate.",
       "files": [],
       "id": 5,
       "prompt": "I added a custom `lint:custom` task to my package. How do I plug it into the build aggregate so CI runs it?"
     },
     {
+      "expectations": [
+        "Identifies that `deploy:skills` keys on `skills/**` and `skills-npm.config.ts` only — installing or removing an agent changes neither, so turbo's cache reports HIT",
+        "Recommends running `gtb turbo run deploy:skills --force` once to bypass the cache and resymlink into the new agent's project-local dir"
+      ],
       "expected_output": "Activates skill. Explains that `deploy:skills` keys on `skills/**` and `skills-npm.config.ts` only — installing or removing an agent changes neither, so turbo's cache reports HIT. Run `gtb turbo run deploy:skills --force` once to bypass the cache and resymlink into the new agent's project-local dir.",
       "files": [],
       "id": 6,
       "prompt": "I just installed a new coding agent and want my existing skills symlinked into its project-local directory, but `deploy:skills` keeps showing as a turbo cache hit and skips."
     },
     {
+      "expectations": [
+        "Explains the rationale: prevents confusing linter output from type errors",
+        "Notes ESLint via typescript-eslint runs its own type resolution, so the dep isn't strictly required (consumers who prefer parallelism over cleaner output can remove it)",
+        "Notes that test tasks deliberately skip the typecheck:ts dep — parallelism wins because tests fail loudly on their own when types are broken"
+      ],
       "expected_output": "Activates skill. Explains: `lint:eslint` depends on `typecheck:ts` to prevent confusing linter output when there are type errors — ESLint via `typescript-eslint` runs its own type resolution, so the dep isn't strictly required, and consumers who prefer parallelism over cleaner output can remove it. Test tasks deliberately skip the dep — parallelism wins there because tests fail loudly on their own when types are broken.",
       "files": [],
       "id": 7,
       "prompt": "Why does `lint:eslint` depend on `typecheck:ts` in this build graph, but the test tasks don't?"
     },
     {
+      "expectations": [
+        "Explains that Turbo 2.x mixes every file in every workspace package reachable from root package.json deps/devDeps into hashOfInternalDependencies, salting every task hash",
+        "Notes the root devDeps (e.g., @gtbuchanan/cli, eslint-config, tsconfig, vitest-config) transitively reach all packages",
+        "Notes that consumers see our packages as external npm deps (lockfile-keyed) and so are unaffected, and that root-only edits (docs, .github/) still hit cache"
+      ],
       "expected_output": "Activates skill. Explains that source changes in any `packages/*` workspace fully invalidate every task across all packages — Turbo 2.x mixes every file in every workspace package reachable from the root `package.json` deps/devDeps into `hashOfInternalDependencies`, salting every task hash. Root devDeps (`@gtbuchanan/cli`, eslint-config, tsconfig, vitest-config) transitively reach all packages. Root-only edits (docs, `.github/`) still hit cache. Consumers see our packages as external npm deps (lockfile-keyed), so they're unaffected. References vercel/turborepo#8202.",
       "files": [],
       "id": 8,


### PR DESCRIPTION
## Summary

Three commits, all in scope of the `gtb-build-pipeline` skill (`@gtbuchanan/cli`):

1. **Pin Termux concurrency rule in always-loaded context** — adds an "Operational notes" section to `AGENTS.md` listing the canonical commands that need `--concurrency=1` on Termux (`pnpm build`, `pnpm test:slow`, `pnpm test:e2e`). The skill body documents *why*, but trigger-gated activation can miss the moment commands are about to run, so the rule belongs in always-loaded project context. Also updates the `gtb-build-pipeline` skill to recommend consumers with persistently constrained hosts encode the same rule in their own always-loaded context (`AGENTS.md`, `CLAUDE.md`, repo memory).

2. **Author gtb-build-pipeline evals** — drafts `evals/evals.json` with 8 prompts and assertion expectations covering Termux OOM (`--concurrency=1`), missing Linux turbo binary, glibc/Bionic ENOENT + pnpm-termux-shim, `gtb sync` vs `gtb verify`, plugging custom tasks into aggregates, `deploy:skills` cache bust, `lint:eslint`→`typecheck:ts` dependency rationale, and turbo's `hashOfInternalDependencies` cache invalidation. Also adds `**/skills/*-workspace/` to root `.gitignore` so per-skill eval harness workspaces (the `<skill-name>-workspace/` convention from `skill-creator`) stay out of source control. (Mirrors the gitignore line in #84; duplicating here so this PR is self-sufficient regardless of merge order.)

3. **Correct Termux setup story in build-pipeline skill** — empirical testing on pnpm 10.32.1 showed the user-level pnpm rc edit (`supported-architectures.os[]=linux`) is a no-op — plain `pnpm install` still skips `@turbo/linux-arm64` even with the line present. Only `pnpm install --force` actually installs the linux binary, by bypassing the optional-dep platform filter as a side effect. SKILL.md drops the rc edit step and explains the `--force` rationale (~70 MB of unused binaries on disk vs polluting non-Termux installs with project-level `pnpm.supportedArchitectures`). Eval 2 updated to match.

Part of #41.

## Test plan

- [x] Linting passes (eslint, prettier, markdownlint) on all touched files
- [x] Eval harness run via `skill-creator`: **100% pass with skill, 35.4% without (delta +0.65)** across 22 assertions / 8 evals
- [x] Empirical verification on Termux that `pnpm install --force` is required (rc edit is a no-op)
- [x] CI green