### PR TITLE
Use Termux-pkg turbo for the Android escape hatch

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -33,22 +33,25 @@ pnpm exec gtb turbo run test:fast
 ```
 
 `gtb turbo` is a thin pass-through to `turbo` on every supported
-platform. On Android, `process.platform === 'android'` causes turbo's
-launcher to refuse to start; the wrapper resolves the matching
-`@turbo/linux-<arch>` binary from your workspace and execs it directly.
-For this to work, pnpm must materialize the Linux binary — add to your
-per-user pnpm rc and re-run `pnpm install --force`:
+platform. On Android, `process.platform === 'android'` causes the
+node_modules launcher to refuse to start; the wrapper resolves the
+native turbo from Termux's package registry and execs it directly.
+Install it once per Termux environment:
 
-```text
-# ~/.config/pnpm/rc
-supported-architectures.os[]=current
-supported-architectures.os[]=linux
+```sh
+pkg install turbo
 ```
 
-A second Termux issue — turbo's child-process spawns tripping on
-`/usr/bin/env` shebangs because the glibc binary bypasses Termux's
-Bionic libc preload — is solved out-of-band by
-[`@gtbuchanan/pnpm-termux-shim`](../pnpm-termux-shim). Add it to
+That puts a Bionic-built `turbo` at `$PREFIX/bin/turbo` (typically
+`/data/data/com.termux/files/usr/bin/turbo`), which `gtb turbo`
+resolves and execs.
+
+The Termux-pkg turbo is Bionic-built, so its child-process spawns
+honor Termux's `LD_PRELOAD` shebang rewriter and resolve
+`#!/usr/bin/env <name>` correctly.
+[`@gtbuchanan/pnpm-termux-shim`](../pnpm-termux-shim) is retained
+defensively in case turbo reintroduces a glibc npm distribution, or
+another glibc binary in the graph needs to spawn `pnpm`. Add it to
 your **workspace root** `package.json` `optionalDependencies` (not
 inside any individual package — under pnpm strict layout, only the
 root's `node_modules/.bin/` is on turbo's PATH at spawn time). The

--- a/packages/cli/skills/gtb-build-pipeline/SKILL.md
+++ b/packages/cli/skills/gtb-build-pipeline/SKILL.md
@@ -23,8 +23,9 @@ Root `package.json` scripts are thin aliases that route through the
 
 `gtb turbo` is a thin pass-through to `turbo` on every supported
 platform. On Android (`process.platform === 'android'`) it resolves
-the matching `@turbo/linux-<arch>` binary and execs it directly,
-bypassing turbo's launcher (which rejects the platform upfront). See
+the global turbo binary installed via Termux's package registry
+(`$PREFIX/bin/turbo`) and execs it directly, bypassing the
+node_modules launcher (which rejects the platform upfront). See
 [Android-Termux setup](#android-termux-setup) below.
 
 `pnpm verify`, `pnpm prepare`, and `pnpm run gtb <cmd>` invoke the CLI directly.
@@ -87,11 +88,17 @@ Run after adding packages, changing the task graph, or updating tooling. Without
 
 Two issues are caused by Termux's Node reporting `process.platform === 'android'`; a third (memory pressure) is unrelated and applies to any low-memory host. Native Android support upstream was declined in [vercel/turborepo#5616](https://github.com/vercel/turborepo/issues/5616), so `gtb turbo` ships the workaround instead.
 
-**1. Turbo platform binary missing.** pnpm filters `@turbo/<os>-<arch>` optional dependencies by host platform; none target `android`, so all six are skipped on install. Run `pnpm install --force` from the workspace root — that's a known side-effect path that bypasses the optional-dep filter and installs every `@turbo/<os>-<arch>` package locally. The Linux binary lands in `node_modules/.pnpm/turbo@<v>/node_modules/@turbo/linux-<arch>/`. `gtb turbo` resolves it via `require.resolve` from inside `node_modules/turbo/bin/turbo` (mirroring how the launcher itself looks up its platform package under pnpm strict layout) and execs it directly. The launcher's android-platform check is bypassed entirely; no `TURBO_BINARY_PATH` env var.
+**1. Node_modules launcher rejects android.** The launcher in `node_modules/.bin/turbo` exits early when `process.platform === 'android'`, and pnpm filters `@turbo/<os>-<arch>` optional dependencies by host platform so none of the bundled platform binaries are installed either. Install the native turbo from Termux's package registry instead:
 
-**2. Turbo child-process spawn ENOENT.** The Linux turbo binary is glibc-built, but Termux is Bionic. Termux's `LD_PRELOAD=libtermux-exec-ld-preload.so` rewrites `/usr/bin/env` shebangs in `execve` syscalls — but the preload is Bionic-only, so it never loads into the glibc turbo. When turbo spawns `pnpm`, the kernel sees `#!/usr/bin/env node` and fails because Termux has no `/usr/bin/env`.
+```sh
+pkg install turbo
+```
 
-Fixed by `@gtbuchanan/pnpm-termux-shim` — an `os: ["android"]`-filtered package whose `bin: { pnpm: ... }` entry has an absolute-path shebang. pnpm symlinks it into `<rootDir>/node_modules/.bin/pnpm`, which is first in `pnpm exec` PATH, so turbo's child-spawn resolves it ahead of the broken system pnpm. On non-Android hosts the package is skipped at install — zero footprint.
+That puts a Bionic-built `turbo` at `$PREFIX/bin/turbo` (typically `/data/data/com.termux/files/usr/bin/turbo`). `gtb turbo` resolves it directly via `$PREFIX` (with the standard prefix as fallback) and execs it, bypassing the node_modules launcher entirely.
+
+**2. Turbo child-process spawn ENOENT (historically).** The npm-distributed Linux turbo binary is glibc-built, but Termux is Bionic. Termux's `LD_PRELOAD=libtermux-exec-ld-preload.so` rewrites `/usr/bin/env` shebangs in `execve` syscalls — but the preload is Bionic-only, so it never loads into a glibc turbo. When such a turbo spawns `pnpm`, the kernel sees `#!/usr/bin/env node` and fails because Termux has no `/usr/bin/env`.
+
+The Termux-pkg turbo is Bionic-built, so the preload loads correctly and child-process spawns resolve `pnpm` without issue. `@gtbuchanan/pnpm-termux-shim` is retained defensively in case turbo reintroduces a glibc npm distribution, or another glibc binary in the graph needs to spawn `pnpm`. The shim is an `os: ["android"]`-filtered package whose `bin: { pnpm: ... }` entry has an absolute-path shebang; pnpm symlinks it into `<rootDir>/node_modules/.bin/pnpm` ahead of the system `pnpm` in PATH. On non-Android hosts it's filtered out at install — zero footprint.
 
 Add it as an `optionalDependencies` entry on the workspace root (so the bin lands in the root's `node_modules/.bin`, not nested under a transitive dep):
 

--- a/packages/cli/skills/gtb-build-pipeline/evals/evals.json
+++ b/packages/cli/skills/gtb-build-pipeline/evals/evals.json
@@ -13,14 +13,14 @@
     },
     {
       "expectations": [
-        "Recommends running `pnpm install --force` from the workspace root",
-        "Explains pnpm's optional-dependency platform filtering — none of the @turbo/<os>-<arch> packages target android, so all six are skipped by default",
-        "Notes that `--force` bypasses the optional-dep filter and installs every @turbo platform locally"
+        "Recommends running `pkg install turbo` to install the native turbo from the Termux package registry",
+        "Explains that the node_modules launcher rejects `process.platform === 'android'` upfront, and pnpm filters `@turbo/<os>-<arch>` optional deps by host platform so none of the bundled platform binaries are installed either",
+        "Notes that `gtb turbo` resolves `$PREFIX/bin/turbo` (with `/data/data/com.termux/files/usr` as the standard fallback) and execs it directly, bypassing the launcher"
       ],
-      "expected_output": "Activates skill. Tells me to run `pnpm install --force` from the workspace root. Explains that pnpm filters `@turbo/<os>-<arch>` optional deps by host platform; none target Android, so all six are skipped by default. Notes that `--force` bypasses the filter and installs every @turbo platform locally. After install the Linux binary is available and `gtb turbo` resolves it via `require.resolve` and execs it directly.",
+      "expected_output": "Activates skill. Tells me to run `pkg install turbo` to install the native turbo from the Termux package registry. Explains that the node_modules launcher rejects `process.platform === 'android'` upfront, and pnpm filters `@turbo/<os>-<arch>` optional deps by host platform so none of the bundled binaries are installed either. After install the Bionic turbo lands at `$PREFIX/bin/turbo` and `gtb turbo` resolves it directly (honoring `$PREFIX`, with `/data/data/com.termux/files/usr` as fallback) and execs it, bypassing the launcher.",
       "files": [],
       "id": 2,
-      "prompt": "When I run `gtb turbo run build` on Termux it says `the linux turbo binary is not installed`. How do I fix that?"
+      "prompt": "When I run `gtb turbo run build` on Termux it says `the global turbo binary is not installed`. How do I fix that?"
     },
     {
       "expectations": [

--- a/packages/cli/src/commands/root/turbo.ts
+++ b/packages/cli/src/commands/root/turbo.ts
@@ -1,56 +1,44 @@
-import { realpathSync } from 'node:fs';
-import { createRequire } from 'node:module';
+import { existsSync } from 'node:fs';
 import path from 'node:path';
 import { defineCommand } from 'citty';
 import { run } from '../../lib/process.ts';
-import { resolveWorkspace } from '../../lib/workspace.ts';
 import { rootNames } from './names.ts';
 
 /**
- * Setup help shown when `@turbo/linux-*` is missing on Android. Termux's
- * Node reports `process.platform === 'android'`, so pnpm filters out
- * every turbo platform binary on install. The fix is to widen pnpm's
- * `supportedArchitectures` whitelist via the per-user global rc.
+ * Setup help shown when the global turbo binary is missing on Android.
+ * Termux ships a native turbo via its package registry; the npm
+ * `@turbo/linux-<arch>` workaround is no longer needed and the
+ * launcher in `node_modules/.bin/turbo` rejects
+ * `process.platform === 'android'` upfront.
  *
  * Native android binaries are not coming from upstream — vercel/turborepo#5616
- * was closed as "not planned" — so the linux-arm64 binary is the workaround.
+ * was closed as "not planned" — so the Termux-pkg turbo (Bionic-built
+ * against `aarch64-linux-android`) is the supported path.
  */
 const androidSetupHelp = `
-gtb turbo: the linux turbo binary is not installed.
+gtb turbo: the global turbo binary is not installed.
 
-On Android (Termux), pnpm filters optional dependencies by host platform,
-so @turbo/linux-${process.arch === 'arm64' ? 'arm64' : '64'} is skipped by default.
-Add the following to your global pnpm rc and reinstall:
+On Android (Termux), gtb turbo execs the native turbo from the Termux
+package registry instead of the npm-distributed Linux binary. The
+node_modules launcher refuses to start when process.platform === 'android'.
 
-  ~/.config/pnpm/rc
+Install it from the Termux registry:
 
-    supported-architectures.os[]=current
-    supported-architectures.os[]=linux
+  pkg install turbo
 
-Then run \`pnpm install --force\` from the workspace root.
+If your Termux prefix is non-standard, set $PREFIX before running.
 `.trimStart();
 
-const linuxArchSuffix = (): '64' | 'arm64' =>
-  process.arch === 'arm64' ? 'arm64' : '64';
-
 /**
- * Resolves the linux turbo binary by mirroring how turbo's own launcher
- * locates its platform package: `require.resolve` from inside
- * `node_modules/turbo/bin/`. Uses realpath because pnpm's strict
- * `node_modules/turbo` is a symlink into `.pnpm/`, and Node's module
- * lookup walks the literal path components of the parent — without
- * realpath we'd never reach the `@turbo/<plat>-<arch>` siblings.
+ * Resolves the global Termux-pkg-installed turbo binary. Honors
+ * Termux's $PREFIX env var; falls back to the standard install path
+ * when $PREFIX is unset (matching the convention used by
+ * `@gtbuchanan/pnpm-termux-shim`).
  */
-const resolveAndroidTurboBinary = (rootDir: string): string | undefined => {
-  const launcherSymlink = path.join(rootDir, 'node_modules', 'turbo', 'bin', 'turbo');
-  try {
-    const launcherRealpath = realpathSync(launcherSymlink);
-    return createRequire(launcherRealpath).resolve(
-      `@turbo/linux-${linuxArchSuffix()}/bin/turbo`,
-    );
-  } catch {
-    return undefined;
-  }
+const resolveAndroidTurboBinary = (): string | undefined => {
+  const prefix = process.env['PREFIX'] ?? '/data/data/com.termux/files/usr';
+  const candidate = path.join(prefix, 'bin', 'turbo');
+  return existsSync(candidate) ? candidate : undefined;
 };
 
 /** Discriminated plan for how to invoke turbo from the current host. */
@@ -60,25 +48,24 @@ export type TurboInvocation =
 
 /** Inputs to {@link planTurboInvocation}. */
 export interface PlanTurboInvocationOptions {
-  readonly arch: string;
   readonly platform: string;
   readonly rawArgs: readonly string[];
-  readonly resolveAndroidBinary?: (rootDir: string) => string | undefined;
-  readonly rootDir: string;
+  readonly resolveAndroidBinary?: () => string | undefined;
 }
 
 /**
  * Computes the turbo invocation plan for a given host. On Android
- * resolves the linux platform binary directly (bypassing turbo's
- * launcher, which rejects `android` upfront). On every other platform
- * delegates to the launcher on PATH so its native install behavior is
- * preserved.
+ * resolves the Termux-pkg turbo binary directly (bypassing the
+ * node_modules launcher, which rejects `android` upfront). On every
+ * other platform delegates to the launcher on PATH so its native
+ * install behavior is preserved.
  *
- * Issue 2 — turbo's child-process spawn tripping on `/usr/bin/env`
- * shebangs because the glibc binary bypasses Termux's Bionic libc
- * preload — is handled out-of-band by `@gtbuchanan/pnpm-termux-shim`,
- * which lands a working `pnpm` in `node_modules/.bin/` via an
- * `os: ["android"]`-filtered optional dependency.
+ * The Termux-pkg turbo is Bionic-built, so its child-process spawns
+ * honor Termux's `LD_PRELOAD` shebang rewriter and resolve
+ * `#!/usr/bin/env <name>` correctly. The companion
+ * `@gtbuchanan/pnpm-termux-shim` package is retained defensively in
+ * case turbo reintroduces a glibc npm distribution, or another glibc
+ * binary in the graph needs to spawn `pnpm`.
  */
 export const planTurboInvocation = (
   options: PlanTurboInvocationOptions,
@@ -87,7 +74,7 @@ export const planTurboInvocation = (
     return { args: [...options.rawArgs], bin: 'turbo', kind: 'spawn' };
   }
   const resolveBin = options.resolveAndroidBinary ?? resolveAndroidTurboBinary;
-  const resolved = resolveBin(options.rootDir);
+  const resolved = resolveBin();
   if (resolved === undefined) {
     return { kind: 'error', message: androidSetupHelp };
   }
@@ -101,12 +88,9 @@ export const turbo = defineCommand({
     name: rootNames.turbo,
   },
   run: async ({ rawArgs }) => {
-    const { rootDir } = resolveWorkspace();
     const plan = planTurboInvocation({
-      arch: process.arch,
       platform: process.platform,
       rawArgs,
-      rootDir,
     });
     if (plan.kind === 'error') {
       console.error(plan.message);

--- a/packages/cli/test/turbo.test.ts
+++ b/packages/cli/test/turbo.test.ts
@@ -1,10 +1,28 @@
-import { describe, it } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { describe, it, vi } from 'vitest';
 import { type TurboInvocation, planTurboInvocation } from '#src/commands/root/turbo.js';
 
+interface PrefixFixture {
+  readonly prefix: string;
+  readonly turboBin: string;
+  readonly [Symbol.dispose]: () => void;
+}
+
+const createPrefixFixture = (): PrefixFixture => {
+  const prefix = mkdtempSync(path.join(tmpdir(), 'gtb-turbo-test-'));
+  return {
+    prefix,
+    turboBin: path.join(prefix, 'bin', 'turbo'),
+    [Symbol.dispose]: () => {
+      rmSync(prefix, { force: true, recursive: true });
+    },
+  };
+};
+
 const baseOptions = {
-  arch: 'arm64',
   rawArgs: ['run', 'build'] as const,
-  rootDir: '/fake/root',
 };
 
 const stubResolver = (resolved?: string) => (): string | undefined => resolved;
@@ -57,40 +75,20 @@ describe.concurrent(planTurboInvocation, () => {
     expect(called).toBe(false);
   });
 
-  it('resolves the linux-arm64 binary on android arm64', ({ expect }) => {
+  it('uses the resolved global turbo binary on android', ({ expect }) => {
     const plan = planTurboInvocation({
       ...baseOptions,
-      arch: 'arm64',
       platform: 'android',
       resolveAndroidBinary: stubResolver(
-        '/fake/root/node_modules/@turbo/linux-arm64/bin/turbo',
+        '/data/data/com.termux/files/usr/bin/turbo',
       ),
     });
 
     expect(plan).toStrictEqual({
       args: ['run', 'build'],
-      bin: '/fake/root/node_modules/@turbo/linux-arm64/bin/turbo',
+      bin: '/data/data/com.termux/files/usr/bin/turbo',
       kind: 'spawn',
     });
-  });
-
-  it('resolves the linux-64 binary on android x64', ({ expect }) => {
-    const calls: string[] = [];
-    const plan = planTurboInvocation({
-      ...baseOptions,
-      arch: 'x64',
-      platform: 'android',
-      resolveAndroidBinary: (rootDir) => {
-        calls.push(rootDir);
-        return '/fake/root/node_modules/@turbo/linux-64/bin/turbo';
-      },
-    });
-
-    expect(plan).toMatchObject({
-      bin: '/fake/root/node_modules/@turbo/linux-64/bin/turbo',
-      kind: 'spawn',
-    });
-    expect(calls).toStrictEqual(['/fake/root']);
   });
 
   it('forwards raw args verbatim to the spawn plan', ({ expect }) => {
@@ -107,7 +105,7 @@ describe.concurrent(planTurboInvocation, () => {
     });
   });
 
-  it('returns an error plan when the linux binary is missing on android', ({ expect }) => {
+  it('returns an error plan when the global turbo is missing on android', ({ expect }) => {
     const plan = planTurboInvocation({
       ...baseOptions,
       platform: 'android',
@@ -115,7 +113,34 @@ describe.concurrent(planTurboInvocation, () => {
     });
     assertErrorPlan(plan);
 
-    expect(plan.message).toContain('supported-architectures');
-    expect(plan.message).toContain('pnpm install --force');
+    expect(plan.message).toContain('pkg install turbo');
+    expect(plan.message).toContain('global turbo binary is not installed');
+  });
+});
+
+/*
+ * Default-resolver tests stub $PREFIX, which is global state, so they
+ * run serially (no `.concurrent`) and rely on vitest's `unstubEnvs`
+ * setting to restore the env between cases.
+ */
+describe('planTurboInvocation default android resolver', () => {
+  it('resolves $PREFIX/bin/turbo when the binary exists', ({ expect }) => {
+    using fixture = createPrefixFixture();
+    mkdirSync(path.dirname(fixture.turboBin), { recursive: true });
+    writeFileSync(fixture.turboBin, '');
+    vi.stubEnv('PREFIX', fixture.prefix);
+
+    const plan = planTurboInvocation({ ...baseOptions, platform: 'android' });
+
+    expect(plan).toMatchObject({ bin: fixture.turboBin, kind: 'spawn' });
+  });
+
+  it('returns an error plan when $PREFIX/bin/turbo is missing', ({ expect }) => {
+    using fixture = createPrefixFixture();
+    vi.stubEnv('PREFIX', fixture.prefix);
+
+    const plan = planTurboInvocation({ ...baseOptions, platform: 'android' });
+
+    expect(plan.kind).toBe('error');
   });
 });


### PR DESCRIPTION
## Summary

- `turbo` is now in the Termux package registry. The wrapper's Android escape hatch no longer needs to chase the npm `@turbo/linux-<arch>` binary; it resolves `$PREFIX/bin/turbo` (with `/data/data/com.termux/files/usr` as the standard fallback) and execs the Bionic-built native turbo directly.
- The node_modules launcher still rejects `process.platform === 'android'` upfront, so `gtb turbo` continues to bypass it. Setup is now a one-shot `pkg install turbo` instead of editing `~/.config/pnpm/rc` and running `pnpm install --force`.
- `@gtbuchanan/pnpm-termux-shim` is retained defensively in case turbo reintroduces a glibc npm distribution, or another glibc binary in the graph needs to spawn `pnpm`. The shim's `os: ["android"]` filter keeps it off non-Android hosts.
- Drops the now-unused `arch` / `rootDir` options from `planTurboInvocation`; updates the build-pipeline skill, its evals, the cli README, and the wrapper's setup-help string to match.

## Test plan

- [x] `gtb turbo run check --concurrency=1` on Termux — runs against `/data/data/com.termux/files/usr/bin/turbo`
- [x] `pnpm build --concurrency=1` on Termux (63/63 tasks, 5m19s): full pipeline including slow + e2e + pack + deploy:skills
- [x] `vitest run test/turbo.test.ts` (8/8): covers non-Android delegation, Android resolution via injected stub, raw-arg forwarding, missing-binary error path, real `$PREFIX/bin/turbo` resolution + missing-binary cases against tmpdir fixtures
- [x] `eslint --max-warnings=0` clean on changed files
- [x] CI: build + slow + e2e + coverage