### PR TITLE
Ignore skills-npm symlinks and skill-creator workspaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 dist/
 node_modules/
 skills-lock.json
+
+# Agent skills from npm packages (managed by skills-npm)
+**/skills/npm-*

--- a/packages/eslint-config/src/index.ts
+++ b/packages/eslint-config/src/index.ts
@@ -76,6 +76,8 @@ export const configure = async (
       '**/dist/**',
       '**/pnpm-lock.yaml',
       '**/skills-lock.json',
+      '**/skills/*-workspace/**',
+      '**/skills/npm-*/**',
     ],
     onlyWarn: options.onlyWarn ?? true,
     pnpm: options.pnpm ?? true,


### PR DESCRIPTION
## Summary

- `gtb prepare` runs `skills-npm`, which symlinks npm-shipped skills into agent dirs (e.g. `.claude/skills/npm-<source>-<skill>`). Add the matching `**/skills/npm-*` pattern to `.gitignore` so the symlinks don't dirty the worktree on install.
- Both that pattern and `**/skills/*-workspace/**` (skill-creator's per-iteration eval artifacts under `<pkg>/skills/<name>-workspace/`) trip the cli's `--max-warnings=0` lint with prettier and `json/sort-keys` warnings on generated `eval_metadata.json` files and on symlinked external skill content.
- Add both globs to the default `ignores` in `@gtbuchanan/eslint-config` — consumers shouldn't lint auto-managed skill artifacts.

## Test plan

- [x] `vitest run test/configure.test.ts` (23/23) — covers default + custom `ignores`
- [x] Manually verified: a stub `<pkg>/skills/<name>-workspace/iteration-1/eval_metadata.json` with prettier + sort-keys violations triggers warnings outside the ignored path, zero warnings inside it
- [ ] CI: build + slow + e2e + coverage