### PR TITLE
Add agent-skills/min-evals and evals-schema rules

### DIFF
--- a/packages/eslint-config/e2e/skill.test.ts
+++ b/packages/eslint-config/e2e/skill.test.ts
@@ -26,6 +26,16 @@ describe.concurrent('SKILL.md validation', () => {
           ],
           ['# Example skill', '', 'Body content.', ''],
         ),
+        'skills/example-skill/evals/evals.json': `${JSON.stringify({
+          evals: [{
+            expectations: ['Activates skill'],
+            expected_output: 'Example output',
+            files: [],
+            id: 1,
+            prompt: 'Example prompt',
+          }],
+          skill_name: 'example-skill',
+        }, undefined, 2)}\n`,
       },
     });
 

--- a/packages/eslint-plugin-agent-skills/README.md
+++ b/packages/eslint-plugin-agent-skills/README.md
@@ -9,7 +9,7 @@ ships:
 
 - The Agent Skills frontmatter JSON Schema (exported as
   `skillFrontmatterSchema`).
-- Three rules covering [spec](https://agentskills.io/specification)
+- Rules covering [spec](https://agentskills.io/specification)
   constraints that pure schemas can't express:
   - `agent-skills/name-matches-dir` — `name` must equal the parent
     directory name.
@@ -18,6 +18,8 @@ ships:
     spec's "one level deep" depth guidance.
   - `agent-skills/max-lines` — markdown-aware version of core's
     `max-lines` that fires under any markdown parser/language.
+  - `agent-skills/min-evals` — each skill must ship at least N
+    eval cases in `evals/evals.json`.
 - A `configs.recommended` flat-config that wires the plugin's rules
   plus the schema rule for `**/skills/*/SKILL.md`, and applies a
   smaller `max-lines` cap (300) to `**/skills/*/references/**/*.md`.
@@ -67,6 +69,7 @@ export default [
     rules: {
       'agent-skills/file-references': 'error',
       'agent-skills/max-lines': ['error', { max: 500 }],
+      'agent-skills/min-evals': 'error',
       'agent-skills/name-matches-dir': 'error',
       'md-frontmatter/schema': ['error', { schema: skillFrontmatterSchema }],
     },
@@ -82,7 +85,8 @@ export default [
   no unknown top-level fields.
 - **Rule-driven** (this plugin): `name === parent directory name`,
   link/image/reference targets exist within the skill root and stay
-  within the spec's depth guidance, file length cap.
+  within the spec's depth guidance, file length cap, and minimum
+  eval coverage.
 
 ## Rules
 
@@ -140,6 +144,23 @@ guidance:
 Options:
 
 - `max` — maximum line count. Defaults to `500`.
+
+### `agent-skills/min-evals`
+
+Requires every skill to ship at least N eval cases in its sibling
+`evals/evals.json` file. Missing file, malformed JSON, and empty
+`evals` array all count as zero. Reports on `SKILL.md`.
+
+Options:
+
+- `min` — minimum number of eval cases. Defaults to `1`. Raise for
+  a stricter coverage bar.
+
+```json
+{
+  "agent-skills/min-evals": ["error", { "min": 3 }]
+}
+```
 
 ### `agent-skills/name-matches-dir`
 

--- a/packages/eslint-plugin-agent-skills/README.md
+++ b/packages/eslint-plugin-agent-skills/README.md
@@ -1,14 +1,14 @@
 # @gtbuchanan/eslint-plugin-agent-skills
 
-Agent Skills-specific ESLint rules and the canonical
-[Agent Skills frontmatter JSON Schema](./src/schema.json).
+Agent Skills-specific ESLint rules plus the canonical
+[SKILL.md frontmatter JSON Schema](./src/schema.json) and
+[evals.json JSON Schema](./src/schemas/evals.json).
 
-Most validation is expressed in the schema and runs via
-`@gtbuchanan/eslint-plugin-md-frontmatter`'s `schema` rule. This package
-ships:
+Most validation is expressed in JSON Schemas; the rules cover spec
+constraints that pure schemas can't express. This package ships:
 
-- The Agent Skills frontmatter JSON Schema (exported as
-  `skillFrontmatterSchema`).
+- JSON Schemas (exported as `skillFrontmatterSchema` and
+  `skillEvalsSchema`).
 - Rules covering [spec](https://agentskills.io/specification)
   constraints that pure schemas can't express:
   - `agent-skills/name-matches-dir` — `name` must equal the parent
@@ -20,9 +20,13 @@ ships:
     `max-lines` that fires under any markdown parser/language.
   - `agent-skills/min-evals` — each skill must ship at least N
     eval cases in `evals/evals.json`.
+  - `agent-skills/evals-schema` — `evals/evals.json` matches the
+    canonical schema, with sequential unique `id` values and a
+    `skill_name` that matches the sibling `SKILL.md`.
 - A `configs.recommended` flat-config that wires the plugin's rules
-  plus the schema rule for `**/skills/*/SKILL.md`, and applies a
-  smaller `max-lines` cap (300) to `**/skills/*/references/**/*.md`.
+  for `**/skills/*/SKILL.md`, `**/skills/*/references/**/*.md`
+  (with a tighter 300-line `max-lines` cap), and
+  `**/skills/*/evals/evals.json`.
 
 ## Install
 
@@ -85,10 +89,23 @@ export default [
   no unknown top-level fields.
 - **Rule-driven** (this plugin): `name === parent directory name`,
   link/image/reference targets exist within the skill root and stay
-  within the spec's depth guidance, file length cap, and minimum
-  eval coverage.
+  within the spec's depth guidance, file length cap, minimum eval
+  coverage, and `evals.json` shape and cross-file integrity.
 
 ## Rules
+
+### `agent-skills/evals-schema`
+
+Validates an Agent Skill's `evals/evals.json` against
+[`skillEvalsSchema`](./src/schemas/evals.json), and also enforces
+invariants the schema can't express:
+
+- `id` values are unique.
+- `id` values are sequential starting at `1`.
+- `skill_name` matches the sibling `SKILL.md` frontmatter `name`,
+  and a sibling `SKILL.md` exists at all.
+
+No options.
 
 ### `agent-skills/file-references`
 

--- a/packages/eslint-plugin-agent-skills/package.json
+++ b/packages/eslint-plugin-agent-skills/package.json
@@ -21,8 +21,10 @@
     "typecheck:ts": "pnpm run gtb task typecheck:ts"
   },
   "dependencies": {
+    "@eslint/json": "catalog:",
     "@eslint/markdown": "catalog:",
     "@gtbuchanan/eslint-plugin-md-frontmatter": "workspace:*",
+    "ajv": "catalog:",
     "yaml": "catalog:"
   },
   "devDependencies": {

--- a/packages/eslint-plugin-agent-skills/src/index.ts
+++ b/packages/eslint-plugin-agent-skills/src/index.ts
@@ -3,6 +3,7 @@ import frontmatter from '@gtbuchanan/eslint-plugin-md-frontmatter';
 import type { ESLint, Linter } from 'eslint';
 import { fileReferences } from './rules/file-references.ts';
 import { maxLines } from './rules/max-lines.ts';
+import { minEvals } from './rules/min-evals.ts';
 import { nameMatchesDir } from './rules/name-matches-dir.ts';
 import schema from './schema.json' with { type: 'json' };
 
@@ -26,6 +27,7 @@ const plugin: ESLint.Plugin = {
   rules: {
     'file-references': fileReferences,
     'max-lines': maxLines,
+    'min-evals': minEvals,
     'name-matches-dir': nameMatchesDir,
   },
 };
@@ -55,6 +57,7 @@ export const configs: {
       rules: {
         'agent-skills/file-references': 'warn',
         'agent-skills/max-lines': ['warn', { max: 500 }],
+        'agent-skills/min-evals': 'warn',
         'agent-skills/name-matches-dir': 'warn',
         'md-frontmatter/schema': ['warn', { schema }],
       },

--- a/packages/eslint-plugin-agent-skills/src/index.ts
+++ b/packages/eslint-plugin-agent-skills/src/index.ts
@@ -1,6 +1,8 @@
+import json from '@eslint/json';
 import markdown from '@eslint/markdown';
 import frontmatter from '@gtbuchanan/eslint-plugin-md-frontmatter';
 import type { ESLint, Linter } from 'eslint';
+import { evalsSchema } from './rules/evals-schema.ts';
 import { fileReferences } from './rules/file-references.ts';
 import { maxLines } from './rules/max-lines.ts';
 import { minEvals } from './rules/min-evals.ts';
@@ -19,12 +21,25 @@ export { default as skillFrontmatterSchema }
   from './schema.json' with { type: 'json' };
 
 /**
+ * JSON Schema for an Agent Skill's `evals/evals.json` file, matching
+ * the canonical layout documented by Anthropic's `skill-creator`
+ * skill (top-level `skill_name` plus an `evals[]` array, each entry
+ * with `id`, `prompt`, `expected_output`, optional `files`, and
+ * `expectations`). Consumers can reference it via `$schema` for
+ * editor autocomplete; the `agent-skills/evals-schema` rule
+ * validates against it at lint time.
+ */
+export { default as skillEvalsSchema }
+  from './schemas/evals.json' with { type: 'json' };
+
+/**
  * ESLint plugin for Agent Skills-specific lint checks. Most validation
  * lives in the JSON Schema (see `skillFrontmatterSchema`); the rules
  * here cover spec constraints schemas can't express.
  */
 const plugin: ESLint.Plugin = {
   rules: {
+    'evals-schema': evalsSchema,
     'file-references': fileReferences,
     'max-lines': maxLines,
     'min-evals': minEvals,
@@ -68,6 +83,14 @@ export const configs: {
       plugins: { 'agent-skills': plugin, markdown },
       rules: {
         'agent-skills/max-lines': ['warn', { max: 300 }],
+      },
+    },
+    {
+      files: ['**/skills/*/evals/evals.json'],
+      language: 'json/json',
+      plugins: { 'agent-skills': plugin, json },
+      rules: {
+        'agent-skills/evals-schema': 'warn',
       },
     },
   ],

--- a/packages/eslint-plugin-agent-skills/src/rules/evals-schema.ts
+++ b/packages/eslint-plugin-agent-skills/src/rules/evals-schema.ts
@@ -1,0 +1,193 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { Ajv } from 'ajv';
+import type { ErrorObject, ValidateFunction } from 'ajv';
+import type { JSRuleDefinition } from 'eslint';
+import { isMap, isScalar, parseDocument } from 'yaml';
+import schema from '../schemas/evals.json' with { type: 'json' };
+
+interface EvalCase {
+  readonly expectations: readonly string[];
+  readonly expected_output: string;
+  readonly files?: readonly string[];
+  readonly id: number;
+  readonly prompt: string;
+}
+
+interface EvalsFile {
+  readonly evals: readonly EvalCase[];
+  readonly skill_name: string;
+}
+
+type MessageId =
+  | 'duplicateId'
+  | 'nameMismatch'
+  | 'nonSequentialId'
+  | 'schemaViolation'
+  | 'skillFileMissing';
+
+type EvalsSchemaRule = JSRuleDefinition<{
+  MessageIds: MessageId;
+  RuleOptions: [];
+}>;
+
+/* `validateSchema: false` skips the meta-schema lookup so the
+   imported schema doesn't need a matching meta-schema registered. */
+const validate: ValidateFunction<EvalsFile> = new Ajv({
+  allErrors: true,
+  strict: false,
+  validateSchema: false,
+}).compile<EvalsFile>(schema);
+
+const fileLoc = {
+  end: { column: 0, line: 1 },
+  start: { column: 0, line: 1 },
+};
+
+const decodeJsonPointer = (segment: string): string =>
+  segment.replaceAll('~1', '/').replaceAll('~0', '~');
+
+const formatPath = (instancePath: string): string => {
+  if (instancePath === '') return 'evals.json';
+  const segments = instancePath.split('/').slice(1).map(decodeJsonPointer);
+  return ['evals.json', ...segments].join('.');
+};
+
+const frontmatterPattern = /^---\r?\n(?<content>[\s\S]*?)\r?\n---/v;
+
+const readSkillName = (skillMdPath: string): string | undefined => {
+  const text = fs.readFileSync(skillMdPath, 'utf8');
+  const { content } = frontmatterPattern.exec(text)?.groups ?? {};
+  if (content === undefined) return undefined;
+  const doc = parseDocument(content);
+  if (!isMap(doc.contents)) return undefined;
+  const pair = doc.contents.items.find(
+    item => isScalar(item.key) && item.key.value === 'name',
+  );
+  if (!pair || !isScalar(pair.value)) return undefined;
+  const { value } = pair.value;
+  return typeof value === 'string' ? value : undefined;
+};
+
+type Reporter = (descriptor: {
+  data?: Record<string, string>;
+  messageId: MessageId;
+}) => void;
+
+const reportSchemaErrors = (
+  errors: readonly ErrorObject[],
+  report: Reporter,
+): void => {
+  for (const error of errors) {
+    report({
+      data: {
+        message: error.message ?? 'is invalid',
+        path: formatPath(error.instancePath),
+      },
+      messageId: 'schemaViolation',
+    });
+  }
+};
+
+const reportIdInvariants = (
+  evals: readonly EvalCase[],
+  report: Reporter,
+): void => {
+  const seenIds = new Set<number>();
+  for (const [index, item] of evals.entries()) {
+    const expected = index + 1;
+    if (item.id !== expected) {
+      report({
+        data: { actual: String(item.id), expected: String(expected) },
+        messageId: 'nonSequentialId',
+      });
+    }
+    if (seenIds.has(item.id)) {
+      report({
+        data: { id: String(item.id) },
+        messageId: 'duplicateId',
+      });
+    }
+    seenIds.add(item.id);
+  }
+};
+
+const reportSkillNameMismatch = (
+  filename: string,
+  skillName: string,
+  report: Reporter,
+): void => {
+  const skillMdPath = path.resolve(
+    path.dirname(filename),
+    '..',
+    'SKILL.md',
+  );
+  if (!fs.existsSync(skillMdPath)) {
+    report({ data: { path: skillMdPath }, messageId: 'skillFileMissing' });
+    return;
+  }
+  const expectedName = readSkillName(skillMdPath);
+  if (expectedName === undefined || expectedName === skillName) return;
+  report({
+    data: { actual: skillName, expected: expectedName },
+    messageId: 'nameMismatch',
+  });
+};
+
+/**
+ * Validates an Agent Skill's `evals/evals.json` against the canonical
+ * schema (exported as `skillEvalsSchema`), then enforces the
+ * structural invariants the schema can't express: `id` values are
+ * unique and sequential starting at `1`, and `skill_name` matches
+ * the sibling `SKILL.md`'s frontmatter `name`. The companion
+ * `min-evals` rule covers the count threshold.
+ */
+export const evalsSchema: EvalsSchemaRule = {
+  meta: {
+    messages: {
+      duplicateId:
+        'Duplicate eval `id`: {{id}}. Each eval must have a unique id.',
+      nameMismatch:
+        '`skill_name` must match SKILL.md `name` ' +
+        '(expected `{{expected}}`, got `{{actual}}`)',
+      nonSequentialId:
+        'Eval `id` must be sequential starting at 1 ' +
+        '(expected {{expected}}, got {{actual}})',
+      schemaViolation: '`{{path}}` {{message}}',
+      skillFileMissing: 'No sibling SKILL.md found at `{{path}}`',
+    },
+    schema: [],
+    type: 'problem',
+  },
+
+  create(context) {
+    const report: Reporter = (descriptor) => {
+      context.report({ ...descriptor, loc: fileLoc });
+    };
+    return {
+      // Key off the actual AST root so this fires under any JSON
+      // parser (e.g. @eslint/json's `Document`) or generic parser.
+      [context.sourceCode.ast.type]() {
+        const { filename } = context;
+        if (!filename) return;
+
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(context.sourceCode.getText());
+        } catch {
+          /* @eslint/json reports syntax errors; nothing
+             schema-meaningful to add here. */
+          return;
+        }
+
+        if (!validate(parsed)) {
+          reportSchemaErrors(validate.errors ?? [], report);
+          return;
+        }
+
+        reportIdInvariants(parsed.evals, report);
+        reportSkillNameMismatch(filename, parsed.skill_name, report);
+      },
+    };
+  },
+};

--- a/packages/eslint-plugin-agent-skills/src/rules/min-evals.ts
+++ b/packages/eslint-plugin-agent-skills/src/rules/min-evals.ts
@@ -1,0 +1,80 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import type { JSRuleDefinition } from 'eslint';
+
+interface MinEvalsOptions {
+  readonly min?: number;
+}
+
+type MinEvalsRule = JSRuleDefinition<{
+  MessageIds: 'tooFew';
+  RuleOptions: [MinEvalsOptions?];
+}>;
+
+const defaultMin = 1;
+
+const countEvals = (evalsPath: string): number => {
+  try {
+    const parsed: unknown = JSON.parse(fs.readFileSync(evalsPath, 'utf8'));
+    if (typeof parsed !== 'object' || parsed === null) return 0;
+    if (!('evals' in parsed)) return 0;
+    const { evals } = parsed;
+    return Array.isArray(evals) ? evals.length : 0;
+  } catch {
+    /* Missing file or malformed JSON. The `evals-schema` rule
+       provides the precise diagnostic for malformed cases. */
+    return 0;
+  }
+};
+
+/**
+ * Requires every Agent Skill to ship at least N eval cases in its
+ * sibling `evals/evals.json` file. Missing file, malformed JSON, and
+ * empty `evals` array all count as zero — the `evals-schema` rule
+ * provides precise diagnostics for the malformed cases. Defaults to
+ * `min: 1`; raise via the `min` option for a stricter coverage bar.
+ */
+export const minEvals: MinEvalsRule = {
+  meta: {
+    messages: {
+      tooFew:
+        'Skill has too few eval cases ({{actual}}) in ' +
+        '`evals/evals.json`. Minimum is {{min}}.',
+    },
+    schema: [{
+      additionalProperties: false,
+      properties: { min: { minimum: 0, type: 'integer' } },
+      type: 'object',
+    }],
+    type: 'problem',
+  },
+
+  create(context) {
+    return {
+      // Key off the actual AST root so this fires under any markdown
+      // parser or language (e.g. @eslint/markdown's `root` mdast node).
+      [context.sourceCode.ast.type]() {
+        const { filename } = context;
+        if (!filename) return;
+        const { min = defaultMin } = context.options[0] ?? {};
+
+        const evalsPath = path.join(
+          path.dirname(filename),
+          'evals',
+          'evals.json',
+        );
+        const actual = countEvals(evalsPath);
+        if (actual >= min) return;
+
+        context.report({
+          data: { actual: String(actual), min: String(min) },
+          loc: {
+            end: { column: 0, line: 1 },
+            start: { column: 0, line: 1 },
+          },
+          messageId: 'tooFew',
+        });
+      },
+    };
+  },
+};

--- a/packages/eslint-plugin-agent-skills/src/schemas/evals.json
+++ b/packages/eslint-plugin-agent-skills/src/schemas/evals.json
@@ -1,0 +1,55 @@
+{
+  "$id": "https://gtbuchanan.github.io/tooling/schemas/agent-skills/skill-evals.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "properties": {
+    "evals": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "expectations": {
+            "items": { "minLength": 1, "type": "string" },
+            "minItems": 1,
+            "type": "array"
+          },
+          "expected_output": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "files": {
+            "items": { "minLength": 1, "type": "string" },
+            "type": "array"
+          },
+          "id": {
+            "minimum": 1,
+            "type": "integer"
+          },
+          "prompt": {
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "prompt",
+          "expected_output",
+          "expectations"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "skill_name": {
+      "maxLength": 64,
+      "minLength": 1,
+      "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$",
+      "type": "string"
+    }
+  },
+  "required": [
+    "evals",
+    "skill_name"
+  ],
+  "title": "Agent Skills evals.json",
+  "type": "object"
+}

--- a/packages/eslint-plugin-agent-skills/test/evals-schema.test.ts
+++ b/packages/eslint-plugin-agent-skills/test/evals-schema.test.ts
@@ -1,0 +1,118 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { RuleTester } from 'eslint';
+import { describe, it } from 'vitest';
+import { evalsSchema } from '#src/rules/evals-schema.js';
+import * as parser from './parser.js';
+
+const ruleTester = new RuleTester({
+  languageOptions: { parser },
+});
+
+const fixturesDir = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  'fixtures',
+  'evals-schema',
+);
+const evalsFile = (name: string): string =>
+  path.join(fixturesDir, name, 'evals', 'evals.json');
+
+/* RuleTester passes source text via `code`; loading from disk keeps
+   the fixture the single source of truth so what ESLint sees matches
+   what the rule reads via fs for cross-file checks. */
+const codeFor = (name: string): string =>
+  fs.readFileSync(evalsFile(name), 'utf8');
+
+describe.concurrent('agent-skills/evals-schema', () => {
+  it('passes for a valid evals.json with sequential ids', ({ expect }) => {
+    expect(() => {
+      ruleTester.run('agent-skills/evals-schema', evalsSchema, {
+        invalid: [],
+        valid: [
+          { code: codeFor('valid'), filename: evalsFile('valid') },
+        ],
+      });
+    }).not.toThrow();
+  });
+
+  it('flags schema violations (missing required field)', ({ expect }) => {
+    expect(() => {
+      ruleTester.run('agent-skills/evals-schema', evalsSchema, {
+        invalid: [
+          {
+            code: codeFor('missing-field'),
+            errors: [{ message: /expected_output/v }],
+            filename: evalsFile('missing-field'),
+          },
+        ],
+        valid: [],
+      });
+    }).not.toThrow();
+  });
+
+  it('flags duplicate ids', ({ expect }) => {
+    expect(() => {
+      ruleTester.run('agent-skills/evals-schema', evalsSchema, {
+        invalid: [
+          {
+            code: codeFor('duplicate-ids'),
+            errors: [
+              { message: /Eval `id` must be sequential.*expected 2, got 1/v },
+              { message: /Duplicate eval `id`: 1/v },
+            ],
+            filename: evalsFile('duplicate-ids'),
+          },
+        ],
+        valid: [],
+      });
+    }).not.toThrow();
+  });
+
+  it('flags non-sequential ids', ({ expect }) => {
+    expect(() => {
+      ruleTester.run('agent-skills/evals-schema', evalsSchema, {
+        invalid: [
+          {
+            code: codeFor('non-sequential-ids'),
+            errors: [{ message: /expected 2, got 3/v }],
+            filename: evalsFile('non-sequential-ids'),
+          },
+        ],
+        valid: [],
+      });
+    }).not.toThrow();
+  });
+
+  it('flags skill_name mismatch against SKILL.md', ({ expect }) => {
+    expect(() => {
+      ruleTester.run('agent-skills/evals-schema', evalsSchema, {
+        invalid: [
+          {
+            code: codeFor('name-mismatch'),
+            errors: [{
+              message: /expected `name-mismatch`, got `wrong-name`/v,
+            }],
+            filename: evalsFile('name-mismatch'),
+          },
+        ],
+        valid: [],
+      });
+    }).not.toThrow();
+  });
+
+  it('flags missing sibling SKILL.md', ({ expect }) => {
+    expect(() => {
+      ruleTester.run('agent-skills/evals-schema', evalsSchema, {
+        invalid: [
+          {
+            code: codeFor('no-skill'),
+            errors: [{ message: /No sibling SKILL\.md found/v }],
+            filename: evalsFile('no-skill'),
+          },
+        ],
+        valid: [],
+      });
+    }).not.toThrow();
+  });
+});

--- a/packages/eslint-plugin-agent-skills/test/fixtures/evals-schema/duplicate-ids/SKILL.md
+++ b/packages/eslint-plugin-agent-skills/test/fixtures/evals-schema/duplicate-ids/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: duplicate-ids
+description: Fixture whose evals.json has duplicate ids.
+---
+
+# Duplicate ids

--- a/packages/eslint-plugin-agent-skills/test/fixtures/evals-schema/duplicate-ids/evals/evals.json
+++ b/packages/eslint-plugin-agent-skills/test/fixtures/evals-schema/duplicate-ids/evals/evals.json
@@ -1,0 +1,23 @@
+{
+  "evals": [
+    {
+      "expectations": [
+        "e1"
+      ],
+      "expected_output": "o1",
+      "files": [],
+      "id": 1,
+      "prompt": "p1"
+    },
+    {
+      "expectations": [
+        "e2"
+      ],
+      "expected_output": "o2",
+      "files": [],
+      "id": 1,
+      "prompt": "p2"
+    }
+  ],
+  "skill_name": "duplicate-ids"
+}

--- a/packages/eslint-plugin-agent-skills/test/fixtures/evals-schema/missing-field/SKILL.md
+++ b/packages/eslint-plugin-agent-skills/test/fixtures/evals-schema/missing-field/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: missing-field
+description: Fixture whose evals.json is missing a required eval field.
+---
+
+# Missing field

--- a/packages/eslint-plugin-agent-skills/test/fixtures/evals-schema/missing-field/evals/evals.json
+++ b/packages/eslint-plugin-agent-skills/test/fixtures/evals-schema/missing-field/evals/evals.json
@@ -1,0 +1,13 @@
+{
+  "evals": [
+    {
+      "expectations": [
+        "e1"
+      ],
+      "files": [],
+      "id": 1,
+      "prompt": "p1"
+    }
+  ],
+  "skill_name": "missing-field"
+}

--- a/packages/eslint-plugin-agent-skills/test/fixtures/evals-schema/name-mismatch/SKILL.md
+++ b/packages/eslint-plugin-agent-skills/test/fixtures/evals-schema/name-mismatch/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: name-mismatch
+description: Fixture whose evals.json skill_name doesn't match SKILL.md.
+---
+
+# Name mismatch

--- a/packages/eslint-plugin-agent-skills/test/fixtures/evals-schema/name-mismatch/evals/evals.json
+++ b/packages/eslint-plugin-agent-skills/test/fixtures/evals-schema/name-mismatch/evals/evals.json
@@ -1,0 +1,14 @@
+{
+  "evals": [
+    {
+      "expectations": [
+        "e1"
+      ],
+      "expected_output": "o1",
+      "files": [],
+      "id": 1,
+      "prompt": "p1"
+    }
+  ],
+  "skill_name": "wrong-name"
+}

--- a/packages/eslint-plugin-agent-skills/test/fixtures/evals-schema/no-skill/evals/evals.json
+++ b/packages/eslint-plugin-agent-skills/test/fixtures/evals-schema/no-skill/evals/evals.json
@@ -1,0 +1,14 @@
+{
+  "evals": [
+    {
+      "expectations": [
+        "e1"
+      ],
+      "expected_output": "o1",
+      "files": [],
+      "id": 1,
+      "prompt": "p1"
+    }
+  ],
+  "skill_name": "no-skill"
+}

--- a/packages/eslint-plugin-agent-skills/test/fixtures/evals-schema/non-sequential-ids/SKILL.md
+++ b/packages/eslint-plugin-agent-skills/test/fixtures/evals-schema/non-sequential-ids/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: non-sequential-ids
+description: Fixture whose evals.json ids are not sequential.
+---
+
+# Non-sequential ids

--- a/packages/eslint-plugin-agent-skills/test/fixtures/evals-schema/non-sequential-ids/evals/evals.json
+++ b/packages/eslint-plugin-agent-skills/test/fixtures/evals-schema/non-sequential-ids/evals/evals.json
@@ -1,0 +1,23 @@
+{
+  "evals": [
+    {
+      "expectations": [
+        "e1"
+      ],
+      "expected_output": "o1",
+      "files": [],
+      "id": 1,
+      "prompt": "p1"
+    },
+    {
+      "expectations": [
+        "e3"
+      ],
+      "expected_output": "o3",
+      "files": [],
+      "id": 3,
+      "prompt": "p3"
+    }
+  ],
+  "skill_name": "non-sequential-ids"
+}

--- a/packages/eslint-plugin-agent-skills/test/fixtures/evals-schema/valid/SKILL.md
+++ b/packages/eslint-plugin-agent-skills/test/fixtures/evals-schema/valid/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: valid
+description: Fixture with a valid evals.json.
+---
+
+# Valid

--- a/packages/eslint-plugin-agent-skills/test/fixtures/evals-schema/valid/evals/evals.json
+++ b/packages/eslint-plugin-agent-skills/test/fixtures/evals-schema/valid/evals/evals.json
@@ -1,0 +1,23 @@
+{
+  "evals": [
+    {
+      "expectations": [
+        "e1"
+      ],
+      "expected_output": "o1",
+      "files": [],
+      "id": 1,
+      "prompt": "p1"
+    },
+    {
+      "expectations": [
+        "e2"
+      ],
+      "expected_output": "o2",
+      "files": [],
+      "id": 2,
+      "prompt": "p2"
+    }
+  ],
+  "skill_name": "valid"
+}

--- a/packages/eslint-plugin-agent-skills/test/fixtures/min-evals/empty-evals/SKILL.md
+++ b/packages/eslint-plugin-agent-skills/test/fixtures/min-evals/empty-evals/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: empty-evals
+description: Fixture with an empty evals array.
+---
+
+# Empty evals

--- a/packages/eslint-plugin-agent-skills/test/fixtures/min-evals/empty-evals/evals/evals.json
+++ b/packages/eslint-plugin-agent-skills/test/fixtures/min-evals/empty-evals/evals/evals.json
@@ -1,0 +1,4 @@
+{
+  "evals": [],
+  "skill_name": "empty-evals"
+}

--- a/packages/eslint-plugin-agent-skills/test/fixtures/min-evals/no-evals/SKILL.md
+++ b/packages/eslint-plugin-agent-skills/test/fixtures/min-evals/no-evals/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: no-evals
+description: Fixture without an evals/ directory.
+---
+
+# No evals

--- a/packages/eslint-plugin-agent-skills/test/fixtures/min-evals/one-eval/SKILL.md
+++ b/packages/eslint-plugin-agent-skills/test/fixtures/min-evals/one-eval/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: one-eval
+description: Fixture with one eval case.
+---
+
+# One eval

--- a/packages/eslint-plugin-agent-skills/test/fixtures/min-evals/one-eval/evals/evals.json
+++ b/packages/eslint-plugin-agent-skills/test/fixtures/min-evals/one-eval/evals/evals.json
@@ -1,0 +1,14 @@
+{
+  "evals": [
+    {
+      "expectations": [
+        "Activates skill"
+      ],
+      "expected_output": "Example output",
+      "files": [],
+      "id": 1,
+      "prompt": "Example prompt"
+    }
+  ],
+  "skill_name": "one-eval"
+}

--- a/packages/eslint-plugin-agent-skills/test/fixtures/min-evals/three-evals/SKILL.md
+++ b/packages/eslint-plugin-agent-skills/test/fixtures/min-evals/three-evals/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: three-evals
+description: Fixture with three eval cases.
+---
+
+# Three evals

--- a/packages/eslint-plugin-agent-skills/test/fixtures/min-evals/three-evals/evals/evals.json
+++ b/packages/eslint-plugin-agent-skills/test/fixtures/min-evals/three-evals/evals/evals.json
@@ -1,0 +1,32 @@
+{
+  "evals": [
+    {
+      "expectations": [
+        "e1"
+      ],
+      "expected_output": "o1",
+      "files": [],
+      "id": 1,
+      "prompt": "p1"
+    },
+    {
+      "expectations": [
+        "e2"
+      ],
+      "expected_output": "o2",
+      "files": [],
+      "id": 2,
+      "prompt": "p2"
+    },
+    {
+      "expectations": [
+        "e3"
+      ],
+      "expected_output": "o3",
+      "files": [],
+      "id": 3,
+      "prompt": "p3"
+    }
+  ],
+  "skill_name": "three-evals"
+}

--- a/packages/eslint-plugin-agent-skills/test/min-evals.test.ts
+++ b/packages/eslint-plugin-agent-skills/test/min-evals.test.ts
@@ -1,0 +1,83 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { RuleTester } from 'eslint';
+import { describe, it } from 'vitest';
+import { minEvals } from '#src/rules/min-evals.js';
+import * as parser from './parser.js';
+
+const ruleTester = new RuleTester({
+  languageOptions: { parser },
+});
+
+const fixturesDir = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  'fixtures',
+  'min-evals',
+);
+const skillFile = (name: string): string =>
+  path.join(fixturesDir, name, 'SKILL.md');
+
+describe.concurrent('agent-skills/min-evals', () => {
+  it('passes when evals.json has at least min cases', ({ expect }) => {
+    expect(() => {
+      ruleTester.run('agent-skills/min-evals', minEvals, {
+        invalid: [],
+        valid: [
+          { code: '# Body\n', filename: skillFile('one-eval') },
+        ],
+      });
+    }).not.toThrow();
+  });
+
+  it('flags when evals/ directory is missing', ({ expect }) => {
+    expect(() => {
+      ruleTester.run('agent-skills/min-evals', minEvals, {
+        invalid: [
+          {
+            code: '# Body\n',
+            errors: [{ message: /too few eval cases \(0\).*Minimum is 1/v }],
+            filename: skillFile('no-evals'),
+          },
+        ],
+        valid: [],
+      });
+    }).not.toThrow();
+  });
+
+  it('flags when evals array is empty', ({ expect }) => {
+    expect(() => {
+      ruleTester.run('agent-skills/min-evals', minEvals, {
+        invalid: [
+          {
+            code: '# Body\n',
+            errors: [{ message: /too few eval cases \(0\).*Minimum is 1/v }],
+            filename: skillFile('empty-evals'),
+          },
+        ],
+        valid: [],
+      });
+    }).not.toThrow();
+  });
+
+  it('respects a custom min option', ({ expect }) => {
+    expect(() => {
+      ruleTester.run('agent-skills/min-evals', minEvals, {
+        invalid: [
+          {
+            code: '# Body\n',
+            errors: [{ message: /too few eval cases \(1\).*Minimum is 3/v }],
+            filename: skillFile('one-eval'),
+            options: [{ min: 3 }],
+          },
+        ],
+        valid: [
+          {
+            code: '# Body\n',
+            filename: skillFile('three-evals'),
+            options: [{ min: 3 }],
+          },
+        ],
+      });
+    }).not.toThrow();
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -359,12 +359,18 @@ importers:
 
   packages/eslint-plugin-agent-skills:
     dependencies:
+      '@eslint/json':
+        specifier: 'catalog:'
+        version: 1.2.0
       '@eslint/markdown':
         specifier: 'catalog:'
         version: 8.0.1
       '@gtbuchanan/eslint-plugin-md-frontmatter':
         specifier: workspace:*
         version: link:../eslint-plugin-md-frontmatter
+      ajv:
+        specifier: 'catalog:'
+        version: 8.20.0
       eslint:
         specifier: ^10.0.0
         version: 10.1.0(jiti@2.6.1)


### PR DESCRIPTION
## Summary

- `agent-skills/min-evals` (new) — flags skills shipping fewer than N eval cases in `evals/evals.json`. Counts missing file, malformed JSON, and empty `evals` array as zero. Default `min: 1`; raise for a stricter coverage bar. Reports on `SKILL.md`.
- `agent-skills/evals-schema` (new) — validates `evals/evals.json` against the new exported `skillEvalsSchema` JSON Schema, plus invariants the schema can't express: unique sequential `id` values and a `skill_name` that matches the sibling `SKILL.md` frontmatter `name`.
- Both rules wired into `configs.recommended` at `warn` severity, matching sibling rules.
- New `**/skills/*/evals/evals.json` config block uses `@eslint/json`'s `json/json` language.

## Test plan

- [x] `pnpm test:vitest:fast` — 30 tests pass (10 new across the two rules)
- [x] `pnpm typecheck:ts` clean
- [x] `pnpm lint:eslint` clean
- [x] `pnpm gtb turbo run build:ci --filter=@gtbuchanan/eslint-plugin-agent-skills` green
- [ ] Consumer dogfooding — apply `configs.recommended` to a real project, confirm rules fire on intentional violations and stay quiet on the existing valid skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)