### PR TITLE
Add test-data builders to @gtbuchanan/test-utils

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ packages/
   pnpm-termux-shim/             — @gtbuchanan/pnpm-termux-shim (pnpm bin shim for Termux/Android, os: ["android"])
   tsconfig/                     — @gtbuchanan/tsconfig (shared base tsconfig.json)
   vitest-config/                — @gtbuchanan/vitest-config (configurePackage, configureGlobal, + e2e variants)
-  test-utils/                   — private shared E2E fixture utilities
+  test-utils/                   — private shared E2E fixture utilities + test-data builders
 ```
 
 ## Published-package behavior
@@ -179,6 +179,19 @@ JSDoc on exports, two-plugin Markdown lint split) live in the
   `expect(result.exitCode).toBe(0)`. On failure, `toMatchObject` shows
   the full result object (including stderr) in the diff, making failures
   self-diagnosing.
+- Generate incidental test data via
+  `@gtbuchanan/test-utils/builders` (or `@faker-js/faker` directly for
+  one-off primitives) and capture the result in a local so the
+  assertion references the captured value, not a duplicate literal.
+  Convention: `import * as build from '@gtbuchanan/test-utils/builders'`,
+  then `const name = build.scopedPackageName()` and
+  `expect(result).toHaveProperty('name', name)`. Only hard-code literals
+  when the SUT branches on the specific string (reserved keys, known
+  enum values). Add a builder when the value has a domain shape worth
+  centralizing (scoped package name, semver range, GitHub URL, etc.);
+  inline faker is fine for raw primitives where the shape is exactly
+  what faker already returns. See `packages/cli/test/manifest.test.ts`
+  for the reference pattern.
 
 ## Operational notes
 

--- a/packages/cli/e2e/cli.test.ts
+++ b/packages/cli/e2e/cli.test.ts
@@ -4,7 +4,9 @@ import {
   type ProjectFixture,
   createProjectFixture,
   extendWithFixture,
+  matchTarball,
 } from '@gtbuchanan/test-utils';
+import * as build from '@gtbuchanan/test-utils/builders';
 import { describe } from 'vitest';
 
 const createFixture = (): ProjectFixture =>
@@ -71,10 +73,11 @@ describe.concurrent('gtb CLI', () => {
 describe.concurrent('gtb task pack:npm', () => {
   it('produces tarball for publishable package', async ({ expect }) => {
     using fixture = createFixture();
+    const name = build.scopedPackageName();
     writeJson(fixture.projectDir, 'package.json', {
-      name: '@test/my-lib',
-      publishConfig: { directory: 'dist/source' },
-      version: '1.0.0',
+      name,
+      publishConfig: { directory: build.publishDirectory() },
+      version: build.semverVersion(),
     });
 
     const result = await fixture.run('gtb', ['task', 'pack:npm']);
@@ -86,16 +89,16 @@ describe.concurrent('gtb task pack:npm', () => {
     );
 
     expect(tarballs).toHaveLength(1);
-    expect(tarballs[0]).toMatch(/^test-my-lib-.*\.tgz$/v);
+    expect(matchTarball(tarballs, name)).toBe(tarballs[0]);
   });
 
   it('skips private package', async ({ expect }) => {
     using fixture = createFixture();
     writeJson(fixture.projectDir, 'package.json', {
-      name: '@test/internal',
+      name: build.scopedPackageName(),
       private: true,
-      publishConfig: { directory: 'dist/source' },
-      version: '1.0.0',
+      publishConfig: { directory: build.publishDirectory() },
+      version: build.semverVersion(),
     });
 
     const result = await fixture.run('gtb', ['task', 'pack:npm']);
@@ -109,8 +112,8 @@ describe.concurrent('gtb task pack:npm', () => {
   it('skips package without publishConfig.directory', async ({ expect }) => {
     using fixture = createFixture();
     writeJson(fixture.projectDir, 'package.json', {
-      name: '@test/my-lib',
-      version: '1.0.0',
+      name: build.scopedPackageName(),
+      version: build.semverVersion(),
     });
 
     const result = await fixture.run('gtb', ['task', 'pack:npm']);
@@ -123,23 +126,28 @@ describe.concurrent('gtb task pack:npm', () => {
 
   it('generates dist/source manifests before packing', async ({ expect }) => {
     using fixture = createFixture();
+    const bugs = build.gitHubIssuesUrl();
+    const homepage = build.gitHubRepoUrl();
+    const repository = { type: 'git', url: build.gitHubGitUrl() };
+    const dependencies = build.dependencyMap();
+    const name = build.scopedPackageName();
+    const version = build.semverVersion();
+    const publishDir = build.publishDirectory();
+    const publishedExports = build.exportsMap();
     writeJson(fixture.projectDir, 'package.json', {
-      bugs: 'https://github.com/test/repo/issues',
-      dependencies: { valibot: '^1.0.0' },
-      devDependencies: { vitest: '^4.0.0' },
-      exports: { '.': './src/index.ts' },
-      homepage: 'https://github.com/test/repo',
-      name: '@test/my-lib',
+      bugs,
+      dependencies,
+      devDependencies: build.dependencyMap(),
+      exports: build.exportsMap(),
+      homepage,
+      name,
       publishConfig: {
-        directory: 'dist/source',
-        exports: { '.': './index.js' },
+        directory: publishDir,
+        exports: publishedExports,
       },
-      repository: {
-        type: 'git',
-        url: 'https://github.com/test/repo.git',
-      },
-      scripts: { test: 'vitest' },
-      version: '1.0.0',
+      repository,
+      scripts: build.scriptMap(),
+      version,
     });
 
     const result = await fixture.run('gtb', ['task', 'pack:npm']);
@@ -147,19 +155,15 @@ describe.concurrent('gtb task pack:npm', () => {
     expect(result).toMatchObject({ exitCode: 0 });
 
     const output = readJson(
-      path.join(fixture.projectDir, 'dist', 'source', 'package.json'),
+      path.join(fixture.projectDir, publishDir, 'package.json'),
     );
 
     expect(output).toMatchObject({
-      bugs: 'https://github.com/test/repo/issues',
-      exports: { '.': './index.js' },
-      homepage: 'https://github.com/test/repo/tree/main/',
-      name: '@test/my-lib',
-      repository: {
-        directory: '',
-        type: 'git',
-        url: 'https://github.com/test/repo.git',
-      },
+      bugs,
+      exports: publishedExports,
+      homepage: `${homepage}/tree/main/`,
+      name,
+      repository: { ...repository, directory: '' },
     });
     expect(output).not.toHaveProperty('devDependencies');
     expect(output).not.toHaveProperty('scripts');
@@ -169,13 +173,14 @@ describe.concurrent('gtb task pack:npm', () => {
   it('cleans dist/packages/npm before packing', async ({ expect }) => {
     using fixture = createFixture();
     writeJson(fixture.projectDir, 'package.json', {
-      name: '@test/my-lib',
-      publishConfig: { directory: 'dist/source' },
-      version: '1.0.0',
+      name: build.scopedPackageName(),
+      publishConfig: { directory: build.publishDirectory() },
+      version: build.semverVersion(),
     });
     const distDir = path.join(fixture.projectDir, 'dist', 'packages', 'npm');
     mkdirSync(distDir, { recursive: true });
-    writeFileSync(path.join(distDir, 'stale-0.0.0.tgz'), '');
+    const stalePath = path.join(distDir, `${build.packageName()}-0.0.0.tgz`);
+    writeFileSync(stalePath, '');
 
     const result = await fixture.run('gtb', ['task', 'pack:npm']);
 
@@ -183,7 +188,7 @@ describe.concurrent('gtb task pack:npm', () => {
 
     const tarballs = readdirSync(distDir);
 
-    expect(tarballs).not.toContain('stale-0.0.0.tgz');
+    expect(tarballs).not.toContain(path.basename(stalePath));
     expect(tarballs).toHaveLength(1);
   });
 });

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -34,6 +34,7 @@
     "yaml": "catalog:"
   },
   "devDependencies": {
+    "@faker-js/faker": "catalog:",
     "@gtbuchanan/eslint-config": "workspace:*",
     "@gtbuchanan/test-utils": "workspace:*",
     "@gtbuchanan/vitest-config": "workspace:*",

--- a/packages/cli/test/codecov-config.test.ts
+++ b/packages/cli/test/codecov-config.test.ts
@@ -1,113 +1,129 @@
 import { mkdirSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
+import * as build from '@gtbuchanan/test-utils/builders';
 import { describe, it } from 'vitest';
 import { generateCodecovSections } from '#src/lib/codecov-config.js';
 import { discoverWorkspace } from '#src/lib/discovery.js';
 import { createTempDir, writeJson } from './helpers.ts';
 
-const createMonorepo = (): string => {
+interface CodecovMonorepo {
+  readonly alpha: { basename: string; dir: string };
+  readonly beta: { basename: string; dir: string };
+  readonly gamma: { basename: string; dir: string };
+  readonly root: string;
+}
+
+const createMonorepo = (): CodecovMonorepo => {
   const root = createTempDir();
   writeFileSync(path.join(root, 'pnpm-workspace.yaml'), "packages:\n  - 'packages/*'\n");
-  writeJson(root, 'package.json', { name: 'root', private: true });
+  writeJson(root, 'package.json', { name: build.packageName(), private: true });
 
-  const alpha = path.join(root, 'packages', 'alpha');
-  mkdirSync(path.join(alpha, 'src'), { recursive: true });
-  mkdirSync(path.join(alpha, 'test'));
-  writeJson(alpha, 'package.json', {
-    devDependencies: { '@gtbuchanan/vitest-config': '^0.1.0' },
-    name: '@test/alpha',
+  const alphaBasename = build.packageName();
+  const alphaDir = path.join(root, 'packages', alphaBasename);
+  mkdirSync(path.join(alphaDir, 'src'), { recursive: true });
+  mkdirSync(path.join(alphaDir, 'test'));
+  writeJson(alphaDir, 'package.json', {
+    devDependencies: { '@gtbuchanan/vitest-config': build.semverRange() },
+    name: build.scopedPackageName(),
   });
-  writeFileSync(path.join(alpha, 'vitest.config.ts'), '');
+  writeFileSync(path.join(alphaDir, 'vitest.config.ts'), '');
 
-  const beta = path.join(root, 'packages', 'beta');
-  mkdirSync(path.join(beta, 'src'), { recursive: true });
-  mkdirSync(path.join(beta, 'test'));
-  mkdirSync(path.join(beta, 'bin'));
-  mkdirSync(path.join(beta, 'scripts'));
-  writeJson(beta, 'package.json', {
-    devDependencies: { '@gtbuchanan/vitest-config': '^0.1.0' },
-    name: '@test/beta',
+  const betaBasename = build.packageName();
+  const betaDir = path.join(root, 'packages', betaBasename);
+  mkdirSync(path.join(betaDir, 'src'), { recursive: true });
+  mkdirSync(path.join(betaDir, 'test'));
+  mkdirSync(path.join(betaDir, 'bin'));
+  mkdirSync(path.join(betaDir, 'scripts'));
+  writeJson(betaDir, 'package.json', {
+    devDependencies: { '@gtbuchanan/vitest-config': build.semverRange() },
+    name: build.scopedPackageName(),
   });
-  writeFileSync(path.join(beta, 'vitest.config.ts'), '');
+  writeFileSync(path.join(betaDir, 'vitest.config.ts'), '');
 
-  const gamma = path.join(root, 'packages', 'gamma');
-  mkdirSync(path.join(gamma, 'src'), { recursive: true });
-  writeJson(gamma, 'package.json', { name: '@test/gamma', private: true });
+  const gammaBasename = build.packageName();
+  const gammaDir = path.join(root, 'packages', gammaBasename);
+  mkdirSync(path.join(gammaDir, 'src'), { recursive: true });
+  writeJson(gammaDir, 'package.json', { name: build.scopedPackageName(), private: true });
 
-  return root;
+  return {
+    alpha: { basename: alphaBasename, dir: alphaDir },
+    beta: { basename: betaBasename, dir: betaDir },
+    gamma: { basename: gammaBasename, dir: gammaDir },
+    root,
+  };
 };
 
 describe.concurrent(generateCodecovSections, () => {
   it('generates a flag per coverage package', ({ expect }) => {
-    const root = createMonorepo();
+    const { alpha, beta, gamma, root } = createMonorepo();
     const discovery = discoverWorkspace({ cwd: root });
 
     const { flags } = generateCodecovSections(discovery);
 
-    expect(Object.keys(flags)).toContain('alpha');
-    expect(Object.keys(flags)).toContain('beta');
-    expect(Object.keys(flags)).not.toContain('gamma');
+    expect(Object.keys(flags)).toContain(alpha.basename);
+    expect(Object.keys(flags)).toContain(beta.basename);
+    expect(Object.keys(flags)).not.toContain(gamma.basename);
   });
 
   it('flag has carryforward true and correct path', ({ expect }) => {
-    const root = createMonorepo();
+    const { alpha, root } = createMonorepo();
     const discovery = discoverWorkspace({ cwd: root });
 
     const { flags } = generateCodecovSections(discovery);
 
-    expect(flags['alpha']).toMatchObject({
+    expect(flags[alpha.basename]).toMatchObject({
       carryforward: true,
-      paths: ['packages/alpha/'],
+      paths: [`packages/${alpha.basename}/`],
     });
   });
 
   it('generates a component per coverage package', ({ expect }) => {
-    const root = createMonorepo();
+    const { alpha, beta, gamma, root } = createMonorepo();
     const discovery = discoverWorkspace({ cwd: root });
 
     const { component_management: componentManagement } = generateCodecovSections(discovery);
     const ids = componentManagement.individual_components.map(comp => comp.component_id);
 
-    expect(ids).toContain('alpha');
-    expect(ids).toContain('beta');
-    expect(ids).not.toContain('gamma');
+    expect(ids).toContain(alpha.basename);
+    expect(ids).toContain(beta.basename);
+    expect(ids).not.toContain(gamma.basename);
   });
 
   it('component paths include only src for package without bin/scripts', ({ expect }) => {
-    const root = createMonorepo();
+    const { alpha, root } = createMonorepo();
     const discovery = discoverWorkspace({ cwd: root });
 
     const { component_management: componentManagement } = generateCodecovSections(discovery);
-    const alpha = componentManagement.individual_components.find(
-      comp => comp.component_id === 'alpha',
+    const alphaComp = componentManagement.individual_components.find(
+      comp => comp.component_id === alpha.basename,
     );
 
-    expect(alpha?.paths).toStrictEqual(['packages/alpha/src/**']);
+    expect(alphaComp?.paths).toStrictEqual([`packages/${alpha.basename}/src/**`]);
   });
 
   it('component paths include bin and scripts when present', ({ expect }) => {
-    const root = createMonorepo();
+    const { beta, root } = createMonorepo();
     const discovery = discoverWorkspace({ cwd: root });
 
     const { component_management: componentManagement } = generateCodecovSections(discovery);
-    const beta = componentManagement.individual_components.find(
-      comp => comp.component_id === 'beta',
+    const betaComp = componentManagement.individual_components.find(
+      comp => comp.component_id === beta.basename,
     );
 
-    expect(beta?.paths).toStrictEqual([
-      'packages/beta/bin/**',
-      'packages/beta/scripts/**',
-      'packages/beta/src/**',
+    expect(betaComp?.paths).toStrictEqual([
+      `packages/${beta.basename}/bin/**`,
+      `packages/${beta.basename}/scripts/**`,
+      `packages/${beta.basename}/src/**`,
     ]);
   });
 
   it('returns empty sections when no package has vitest tests', ({ expect }) => {
     const root = createTempDir();
-    writeJson(root, 'package.json', { name: 'root', private: true });
+    writeJson(root, 'package.json', { name: build.packageName(), private: true });
     writeFileSync(path.join(root, 'pnpm-workspace.yaml'), "packages:\n  - 'packages/*'\n");
-    const pkg = path.join(root, 'packages', 'lib');
-    mkdirSync(path.join(pkg, 'src'), { recursive: true });
-    writeJson(pkg, 'package.json', { name: '@test/lib', private: true });
+    const pkgDir = path.join(root, 'packages', build.packageName());
+    mkdirSync(path.join(pkgDir, 'src'), { recursive: true });
+    writeJson(pkgDir, 'package.json', { name: build.scopedPackageName(), private: true });
 
     const discovery = discoverWorkspace({ cwd: root });
     const { flags, component_management: componentManagement } = generateCodecovSections(discovery);
@@ -122,17 +138,18 @@ describe.concurrent(generateCodecovSections, () => {
       path.join(root, 'pnpm-workspace.yaml'),
       "packages:\n  - 'apps/*'\n  - 'packages/*'\n",
     );
-    writeJson(root, 'package.json', { name: 'root', private: true });
+    writeJson(root, 'package.json', { name: build.packageName(), private: true });
 
+    const sharedBasename = build.packageName();
     for (const base of ['apps', 'packages']) {
-      const pkg = path.join(root, base, 'app');
-      mkdirSync(path.join(pkg, 'src'), { recursive: true });
-      mkdirSync(path.join(pkg, 'test'));
-      writeJson(pkg, 'package.json', {
-        devDependencies: { '@gtbuchanan/vitest-config': '^0.1.0' },
-        name: `@test/${base}-app`,
+      const pkgDir = path.join(root, base, sharedBasename);
+      mkdirSync(path.join(pkgDir, 'src'), { recursive: true });
+      mkdirSync(path.join(pkgDir, 'test'));
+      writeJson(pkgDir, 'package.json', {
+        devDependencies: { '@gtbuchanan/vitest-config': build.semverRange() },
+        name: build.scopedPackageName(),
       });
-      writeFileSync(path.join(pkg, 'vitest.config.ts'), '');
+      writeFileSync(path.join(pkgDir, 'vitest.config.ts'), '');
     }
 
     const discovery = discoverWorkspace({ cwd: root });

--- a/packages/cli/test/compile-skills.test.ts
+++ b/packages/cli/test/compile-skills.test.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import * as build from '@gtbuchanan/test-utils/builders';
 import { runCommand } from 'citty';
 import { describe, it, vi } from 'vitest';
 import type { Manifest } from '#src/lib/manifest.js';
@@ -29,8 +30,10 @@ interface Fixture {
   readonly mockManifest: ReturnType<typeof vi.mocked<typeof readParsedManifest>>;
 }
 
+const publishDir = build.publishDirectory();
+
 const defaultManifest: Manifest = {
-  publishConfig: { directory: 'dist/source' },
+  publishConfig: { directory: publishDir },
 };
 
 const createFixture = (manifest: Manifest = defaultManifest): Fixture => {
@@ -55,12 +58,12 @@ describe('gtb task compile:skills', () => {
     const pkgDir = process.cwd();
 
     expect(fixture.mockRmSync).toHaveBeenCalledWith(
-      path.join(pkgDir, 'dist/source', 'skills'),
+      path.join(pkgDir, publishDir, 'skills'),
       { force: true, recursive: true },
     );
     expect(fixture.mockCpSync).toHaveBeenCalledWith(
       path.join(pkgDir, 'skills'),
-      path.join(pkgDir, 'dist/source', 'skills'),
+      path.join(pkgDir, publishDir, 'skills'),
       { recursive: true },
     );
   });
@@ -68,7 +71,7 @@ describe('gtb task compile:skills', () => {
   it('skips when package is private', async ({ expect }) => {
     const fixture = createFixture({
       private: true,
-      publishConfig: { directory: 'dist/source' },
+      publishConfig: { directory: publishDir },
     });
 
     await invoke();

--- a/packages/cli/test/deploy-skills.test.ts
+++ b/packages/cli/test/deploy-skills.test.ts
@@ -1,3 +1,4 @@
+import { faker } from '@faker-js/faker';
 import { runCommand } from 'citty';
 import { describe, it, vi } from 'vitest';
 
@@ -72,14 +73,14 @@ const runArgs = (fixture: Fixture): readonly string[] => {
 describe('gtb task deploy:skills', () => {
   it('uses configured agents when skills-npm.config.ts declares them', async ({ expect }) => {
     const fixture = createFixture();
-    fixture.mockLoadConfigured.mockResolvedValue(['claude-code', 'codex']);
+    const agents = [faker.lorem.slug({ min: 1, max: 2 }), faker.lorem.slug({ min: 1, max: 2 })];
+    fixture.mockLoadConfigured.mockResolvedValue(agents);
 
     await invoke();
 
     expect(runArgs(fixture)).toStrictEqual([
       'add', '.', '--skill', '*', '--yes',
-      '--agent', 'claude-code',
-      '--agent', 'codex',
+      ...agents.flatMap(agent => ['--agent', agent]),
     ]);
     expect(fixture.mockDetected).not.toHaveBeenCalled();
   });
@@ -115,7 +116,7 @@ describe('gtb task deploy:skills', () => {
       packageGlobs: [],
       rootDir: `${process.cwd()}/..`,
     });
-    fixture.mockLoadConfigured.mockResolvedValue(['claude-code']);
+    fixture.mockLoadConfigured.mockResolvedValue([faker.lorem.slug({ min: 1, max: 2 })]);
 
     await invoke();
 

--- a/packages/cli/test/discovery.test.ts
+++ b/packages/cli/test/discovery.test.ts
@@ -1,5 +1,7 @@
 import { mkdirSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
+import { faker } from '@faker-js/faker';
+import * as build from '@gtbuchanan/test-utils/builders';
 import { describe, it } from 'vitest';
 import { discoverPackage, discoverWorkspace } from '#src/lib/discovery.js';
 import { createTempDir, writeJson } from './helpers.ts';
@@ -42,7 +44,7 @@ describe.concurrent(discoverPackage, () => {
   it('detects eslint via dependency', ({ expect }) => {
     const dir = createTempDir();
     writeJson(dir, 'package.json', {
-      devDependencies: { '@gtbuchanan/eslint-config': '^0.1.0' },
+      devDependencies: { '@gtbuchanan/eslint-config': build.semverRange() },
     });
 
     const result = discoverPackage(dir);
@@ -53,7 +55,7 @@ describe.concurrent(discoverPackage, () => {
   it('detects vitest via dependency', ({ expect }) => {
     const dir = createTempDir();
     writeJson(dir, 'package.json', {
-      devDependencies: { '@gtbuchanan/vitest-config': '^0.1.0' },
+      devDependencies: { '@gtbuchanan/vitest-config': build.semverRange() },
     });
 
     const result = discoverPackage(dir);
@@ -74,7 +76,7 @@ describe.concurrent(discoverPackage, () => {
   it('detects typescript via dependency', ({ expect }) => {
     const dir = createTempDir();
     writeJson(dir, 'package.json', {
-      devDependencies: { '@gtbuchanan/tsconfig': '^0.1.0' },
+      devDependencies: { '@gtbuchanan/tsconfig': build.semverRange() },
     });
 
     const result = discoverPackage(dir);
@@ -95,7 +97,7 @@ describe.concurrent(discoverPackage, () => {
   it('detects published package', ({ expect }) => {
     const dir = createTempDir();
     writeJson(dir, 'package.json', {
-      publishConfig: { directory: 'dist/source' },
+      publishConfig: { directory: build.publishDirectory() },
     });
 
     const result = discoverPackage(dir);
@@ -107,7 +109,7 @@ describe.concurrent(discoverPackage, () => {
     const dir = createTempDir();
     writeJson(dir, 'package.json', {
       private: true,
-      publishConfig: { directory: 'dist/source' },
+      publishConfig: { directory: build.publishDirectory() },
     });
 
     const result = discoverPackage(dir);
@@ -147,37 +149,41 @@ describe.concurrent(discoverPackage, () => {
 
   it('detects generate via script prefix', ({ expect }) => {
     const dir = createTempDir();
+    const generateKey = `generate:${faker.lorem.word()}`;
     writeJson(dir, 'package.json', {
-      scripts: { 'generate:prisma': 'prisma generate' },
+      scripts: { [generateKey]: faker.lorem.words({ min: 1, max: 3 }) },
     });
 
     const result = discoverPackage(dir);
 
     expect(result.hasGenerate).toBe(true);
-    expect(result.generateScripts).toStrictEqual(['generate:prisma']);
+    expect(result.generateScripts).toStrictEqual([generateKey]);
   });
 
   it('collects multiple generate scripts', ({ expect }) => {
     const dir = createTempDir();
+    const generateKeys = [
+      `generate:${faker.lorem.word()}`,
+      `generate:${faker.lorem.word()}`,
+    ].toSorted();
     writeJson(dir, 'package.json', {
-      scripts: {
-        'generate:paraglide': 'paraglide-js compile',
-        'generate:prisma': 'prisma generate',
-      },
+      scripts: Object.fromEntries(
+        generateKeys.map(key => [key, faker.lorem.words({ min: 1, max: 3 })]),
+      ),
     });
 
     const result = discoverPackage(dir);
 
-    expect(result.generateScripts).toStrictEqual([
-      'generate:paraglide',
-      'generate:prisma',
-    ]);
+    expect(result.generateScripts).toStrictEqual(generateKeys);
   });
 
   it('does not detect generate without colon prefix', ({ expect }) => {
     const dir = createTempDir();
     writeJson(dir, 'package.json', {
-      scripts: { codegen: 'some-tool generate', generate: 'gen all' },
+      scripts: {
+        codegen: faker.lorem.words({ min: 1, max: 3 }),
+        generate: faker.lorem.words({ min: 1, max: 3 }),
+      },
     });
 
     const result = discoverPackage(dir);
@@ -215,25 +221,24 @@ describe.concurrent(discoverWorkspace, () => {
       "packages:\n  - 'packages/*'\n",
     );
     writeJson(root, 'package.json', {});
-    const alpha = path.join(root, 'packages', 'alpha');
-    mkdirSync(alpha, { recursive: true });
-    writeJson(alpha, 'package.json', {
-      devDependencies: { '@gtbuchanan/eslint-config': '^0.1.0' },
+    const pkgDir = path.join(root, 'packages', build.packageName());
+    mkdirSync(pkgDir, { recursive: true });
+    writeJson(pkgDir, 'package.json', {
+      devDependencies: { '@gtbuchanan/eslint-config': build.semverRange() },
     });
-    mkdirSync(path.join(alpha, 'src'));
+    mkdirSync(path.join(pkgDir, 'src'));
 
     const result = discoverWorkspace({ cwd: root });
 
     expect(result.isMonorepo).toBe(true);
     expect(result.packages).toHaveLength(1);
     expect(result.packages[0]!.hasEslint).toBe(true);
-    expect(result.packages[0]!.hasEslint).toBe(true);
   });
 
   it('discovers single-package repo', ({ expect }) => {
     const root = createTempDir();
     writeJson(root, 'package.json', {
-      devDependencies: { '@gtbuchanan/tsconfig': '^0.1.0' },
+      devDependencies: { '@gtbuchanan/tsconfig': build.semverRange() },
     });
     mkdirSync(path.join(root, 'src'));
 
@@ -253,9 +258,9 @@ describe.concurrent(discoverWorkspace, () => {
     writeJson(root, 'package.json', {
       devDependencies: { '@gtbuchanan/cli': 'workspace:*' },
     });
-    const pkg = path.join(root, 'packages', 'lib');
-    mkdirSync(pkg, { recursive: true });
-    writeJson(pkg, 'package.json', {});
+    const pkgDir = path.join(root, 'packages', build.packageName());
+    mkdirSync(pkgDir, { recursive: true });
+    writeJson(pkgDir, 'package.json', {});
 
     const result = discoverWorkspace({ cwd: root });
 

--- a/packages/cli/test/file-writer.test.ts
+++ b/packages/cli/test/file-writer.test.ts
@@ -1,5 +1,7 @@
 import { readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
+import { faker } from '@faker-js/faker';
+import * as build from '@gtbuchanan/test-utils/builders';
 import { describe, it } from 'vitest';
 import { parse as parseYaml } from 'yaml';
 import {
@@ -45,9 +47,11 @@ describe.concurrent(mergePackageScripts, () => {
   it('adds missing scripts to existing package.json', ({ expect }) => {
     const dir = createTempDir();
     const filePath = path.join(dir, 'package.json');
+    const existingScriptName = faker.lorem.word();
+    const existingScriptValue = faker.lorem.words({ min: 1, max: 3 });
     writeFileSync(filePath, JSON.stringify({
-      name: 'test',
-      scripts: { existing: 'keep' },
+      name: build.scopedPackageName(),
+      scripts: { [existingScriptName]: existingScriptValue },
     }));
 
     const result = mergePackageScripts(
@@ -55,7 +59,10 @@ describe.concurrent(mergePackageScripts, () => {
     );
 
     expect(readJson(filePath)).toMatchObject({
-      scripts: { 'existing': 'keep', 'typecheck:ts': 'gtb typecheck:ts' },
+      scripts: {
+        [existingScriptName]: existingScriptValue,
+        'typecheck:ts': 'gtb typecheck:ts',
+      },
     });
     expect(result.added).toContain('typecheck:ts');
   });
@@ -63,8 +70,9 @@ describe.concurrent(mergePackageScripts, () => {
   it('does not overwrite existing scripts without force', ({ expect }) => {
     const dir = createTempDir();
     const filePath = path.join(dir, 'package.json');
+    const userTypecheck = faker.lorem.words({ min: 1, max: 3 });
     writeFileSync(filePath, JSON.stringify({
-      scripts: { 'typecheck:ts': 'vue-tsc --noEmit' },
+      scripts: { 'typecheck:ts': userTypecheck },
     }));
 
     const result = mergePackageScripts(
@@ -72,7 +80,7 @@ describe.concurrent(mergePackageScripts, () => {
     );
 
     expect(readJson(filePath)).toMatchObject({
-      scripts: { 'typecheck:ts': 'vue-tsc --noEmit' },
+      scripts: { 'typecheck:ts': userTypecheck },
     });
     expect(result.skipped).toContain('typecheck:ts');
   });
@@ -81,7 +89,7 @@ describe.concurrent(mergePackageScripts, () => {
     const dir = createTempDir();
     const filePath = path.join(dir, 'package.json');
     writeFileSync(filePath, JSON.stringify({
-      scripts: { 'typecheck:ts': 'vue-tsc --noEmit' },
+      scripts: { 'typecheck:ts': faker.lorem.words({ min: 1, max: 3 }) },
     }));
 
     const result = mergePackageScripts(
@@ -97,7 +105,7 @@ describe.concurrent(mergePackageScripts, () => {
   it('creates scripts field if missing', ({ expect }) => {
     const dir = createTempDir();
     const filePath = path.join(dir, 'package.json');
-    writeFileSync(filePath, JSON.stringify({ name: 'test' }));
+    writeFileSync(filePath, JSON.stringify({ name: build.scopedPackageName() }));
 
     mergePackageScripts(filePath, { 'lint:eslint': 'gtb lint:eslint' }, false);
 
@@ -109,19 +117,14 @@ describe.concurrent(mergePackageScripts, () => {
   it('preserves non-script fields in package.json', ({ expect }) => {
     const dir = createTempDir();
     const filePath = path.join(dir, 'package.json');
-    writeFileSync(filePath, JSON.stringify({
-      dependencies: { valibot: '^1.0.0' },
-      name: 'test',
-      version: '1.0.0',
-    }));
+    const dependencies = build.dependencyMap();
+    const name = build.scopedPackageName();
+    const version = build.semverVersion();
+    writeFileSync(filePath, JSON.stringify({ dependencies, name, version }));
 
     mergePackageScripts(filePath, { 'typecheck:ts': 'gtb typecheck:ts' }, false);
 
-    expect(readJson(filePath)).toMatchObject({
-      dependencies: { valibot: '^1.0.0' },
-      name: 'test',
-      version: '1.0.0',
-    });
+    expect(readJson(filePath)).toMatchObject({ dependencies, name, version });
   });
 });
 

--- a/packages/cli/test/manifest.test.ts
+++ b/packages/cli/test/manifest.test.ts
@@ -1,97 +1,92 @@
+import * as build from '@gtbuchanan/test-utils/builders';
 import { describe, it } from 'vitest';
 import { buildOutput, buildRepoFields } from '#src/lib/manifest.js';
 
 describe.concurrent(buildOutput, () => {
   it('strips devDependencies and scripts', ({ expect }) => {
+    const name = build.scopedPackageName();
     const result = buildOutput({
-      devDependencies: { vitest: '^4.0.0' },
-      name: '@test/pkg',
-      scripts: { test: 'vitest' },
+      devDependencies: build.dependencyMap(),
+      name,
+      scripts: build.scriptMap(),
     });
 
     expect(result).not.toHaveProperty('devDependencies');
     expect(result).not.toHaveProperty('scripts');
-    expect(result).toHaveProperty('name', '@test/pkg');
+    expect(result).toHaveProperty('name', name);
   });
 
   it('remaps publishConfig.exports to top-level exports', ({ expect }) => {
+    const publishedExports = build.exportsMap();
     const result = buildOutput({
-      exports: { '.': './src/index.ts' },
-      publishConfig: {
-        exports: { '.': './index.js' },
-      },
+      exports: build.exportsMap(),
+      publishConfig: { exports: publishedExports },
     });
 
-    expect(result['exports']).toStrictEqual({ '.': './index.js' });
+    expect(result['exports']).toStrictEqual(publishedExports);
   });
 
   it('remaps publishConfig.scripts to top-level scripts', ({ expect }) => {
+    const publishedScripts = build.scriptMap();
     const result = buildOutput({
-      publishConfig: {
-        scripts: { postinstall: 'echo done' },
-      },
-      scripts: { test: 'vitest' },
+      publishConfig: { scripts: publishedScripts },
+      scripts: build.scriptMap(),
     });
 
-    expect(result.scripts).toStrictEqual({ postinstall: 'echo done' });
+    expect(result.scripts).toStrictEqual(publishedScripts);
   });
 
   it('remaps publishConfig.bin to top-level bin', ({ expect }) => {
+    const publishedBin = build.binMap();
     const result = buildOutput({
-      publishConfig: {
-        bin: { gtb: './bin.js' },
-      },
+      publishConfig: { bin: publishedBin },
     });
 
-    expect(result['bin']).toStrictEqual({ gtb: './bin.js' });
+    expect(result['bin']).toStrictEqual(publishedBin);
   });
 
   it('remaps publishConfig.imports to top-level imports', ({ expect }) => {
+    const publishedImports = build.importsMap();
     const result = buildOutput({
-      imports: { '#src/*': './src/*' },
-      publishConfig: {
-        imports: { '#src/*.ts': './*.js' },
-      },
+      imports: build.importsMap(),
+      publishConfig: { imports: publishedImports },
     });
 
-    expect(result['imports']).toStrictEqual({ '#src/*.ts': './*.js' });
+    expect(result['imports']).toStrictEqual(publishedImports);
   });
 
   it('remaps publishConfig.os to top-level os', ({ expect }) => {
+    const os = build.platformList();
     const result = buildOutput({
-      publishConfig: {
-        os: ['android'],
-      },
+      publishConfig: { os },
     });
 
-    expect(result['os']).toStrictEqual(['android']);
+    expect(result['os']).toStrictEqual(os);
   });
 
   it('remaps publishConfig.cpu to top-level cpu', ({ expect }) => {
+    const cpu = build.platformList();
     const result = buildOutput({
-      publishConfig: {
-        cpu: ['arm64'],
-      },
+      publishConfig: { cpu },
     });
 
-    expect(result['cpu']).toStrictEqual(['arm64']);
+    expect(result['cpu']).toStrictEqual(cpu);
   });
 
   it('remaps publishConfig.libc to top-level libc', ({ expect }) => {
+    const libc = build.platformList();
     const result = buildOutput({
-      publishConfig: {
-        libc: ['glibc'],
-      },
+      publishConfig: { libc },
     });
 
-    expect(result['libc']).toStrictEqual(['glibc']);
+    expect(result['libc']).toStrictEqual(libc);
   });
 
   it('strips publishConfig from output', ({ expect }) => {
     const result = buildOutput({
       publishConfig: {
-        directory: 'dist/source',
-        exports: { '.': './index.js' },
+        directory: build.publishDirectory(),
+        exports: build.exportsMap(),
       },
     });
 
@@ -99,51 +94,45 @@ describe.concurrent(buildOutput, () => {
   });
 
   it('preserves other fields via looseObject passthrough', ({ expect }) => {
-    const result = buildOutput({
-      dependencies: { valibot: '^1.0.0' },
-      name: '@test/pkg',
-      version: '1.0.0',
-    });
+    const dependencies = build.dependencyMap();
+    const name = build.scopedPackageName();
+    const version = build.semverVersion();
+    const result = buildOutput({ dependencies, name, version });
 
-    expect(result).toHaveProperty('name', '@test/pkg');
-    expect(result).toHaveProperty('version', '1.0.0');
-    expect(result).toHaveProperty('dependencies');
+    expect(result).toHaveProperty('dependencies', dependencies);
+    expect(result).toHaveProperty('name', name);
+    expect(result).toHaveProperty('version', version);
   });
 });
 
 describe.concurrent(buildRepoFields, () => {
   it('builds all fields from root manifest', ({ expect }) => {
-    const result = buildRepoFields({
-      bugs: 'https://github.com/test/repo/issues',
-      homepage: 'https://github.com/test/repo',
-      repository: {
-        type: 'git',
-        url: 'https://github.com/test/repo.git',
-      },
-    }, 'packages/foo');
+    const bugs = build.gitHubIssuesUrl();
+    const homepage = build.gitHubRepoUrl();
+    const repository = { type: 'git', url: build.gitHubGitUrl() };
+    const directory = build.packageDirectory();
+
+    const result = buildRepoFields({ bugs, homepage, repository }, directory);
 
     expect(result).toStrictEqual({
-      bugs: 'https://github.com/test/repo/issues',
-      homepage: 'https://github.com/test/repo/tree/main/packages/foo',
-      repository: {
-        directory: 'packages/foo',
-        type: 'git',
-        url: 'https://github.com/test/repo.git',
-      },
+      bugs,
+      homepage: `${homepage}/tree/main/${directory}`,
+      repository: { ...repository, directory },
     });
   });
 
   it('returns empty object when root has no fields', ({ expect }) => {
-    expect(buildRepoFields({}, 'packages/foo')).toStrictEqual({});
+    expect(buildRepoFields({}, build.packageDirectory())).toStrictEqual({});
   });
 
   it('includes only fields present in root', ({ expect }) => {
-    const result = buildRepoFields({
-      homepage: 'https://github.com/test/repo',
-    }, 'packages/bar');
+    const homepage = build.gitHubRepoUrl();
+    const directory = build.packageDirectory();
+
+    const result = buildRepoFields({ homepage }, directory);
 
     expect(result).toStrictEqual({
-      homepage: 'https://github.com/test/repo/tree/main/packages/bar',
+      homepage: `${homepage}/tree/main/${directory}`,
     });
   });
 });

--- a/packages/cli/test/prepack.test.ts
+++ b/packages/cli/test/prepack.test.ts
@@ -1,5 +1,6 @@
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
+import * as build from '@gtbuchanan/test-utils/builders';
 import { describe, it } from 'vitest';
 import { prepack } from '#src/commands/task/pack-npm.js';
 import { createTempDir } from './helpers.ts';
@@ -20,49 +21,47 @@ const readJson = (path: string): unknown =>
 describe.concurrent(prepack, () => {
   it('generates dist/source/package.json for publishable package', ({ expect }) => {
     const root = createTempDir();
+    const bugs = build.gitHubIssuesUrl();
+    const homepage = build.gitHubRepoUrl();
+    const repository = { type: 'git', url: build.gitHubGitUrl() };
+    const dependencies = build.dependencyMap();
+    const name = build.scopedPackageName();
+    const version = build.semverVersion();
+    const publishDir = build.publishDirectory();
+    const publishedExports = build.exportsMap();
+    const pkgBasename = build.packageName();
+    const pkgDirRelative = `packages/${pkgBasename}`;
+
     writeFileSync(
       path.join(root, 'pnpm-workspace.yaml'),
       "packages:\n  - 'packages/*'\n",
     );
-    writeFormattedJson(root, 'package.json', {
-      bugs: 'https://github.com/test/repo/issues',
-      homepage: 'https://github.com/test/repo',
-      repository: {
-        type: 'git',
-        url: 'https://github.com/test/repo.git',
-      },
-    });
-    const pkgDir = path.join(root, 'packages', 'my-lib');
+    writeFormattedJson(root, 'package.json', { bugs, homepage, repository });
+    const pkgDir = path.join(root, pkgDirRelative);
     mkdirSync(pkgDir, { recursive: true });
     writeFormattedJson(pkgDir, 'package.json', {
-      dependencies: { valibot: '^1.0.0' },
-      devDependencies: { vitest: '^4.0.0' },
-      exports: { '.': './src/index.ts' },
-      name: '@test/my-lib',
+      dependencies,
+      devDependencies: build.dependencyMap(),
+      exports: build.exportsMap(),
+      name,
       publishConfig: {
-        directory: 'dist/source',
-        exports: { '.': './index.js' },
+        directory: publishDir,
+        exports: publishedExports,
       },
-      scripts: { test: 'vitest' },
-      version: '1.0.0',
+      scripts: build.scriptMap(),
+      version,
     });
 
     prepack({ cwd: root });
-    const output = readJson(
-      path.join(pkgDir, 'dist', 'source', 'package.json'),
-    );
+    const output = readJson(path.join(pkgDir, publishDir, 'package.json'));
 
     expect(output).toMatchObject({
-      dependencies: { valibot: '^1.0.0' },
-      exports: { '.': './index.js' },
-      homepage: 'https://github.com/test/repo/tree/main/packages/my-lib',
-      name: '@test/my-lib',
-      repository: {
-        directory: 'packages/my-lib',
-        type: 'git',
-        url: 'https://github.com/test/repo.git',
-      },
-      version: '1.0.0',
+      dependencies,
+      exports: publishedExports,
+      homepage: `${homepage}/tree/main/${pkgDirRelative}`,
+      name,
+      repository: { ...repository, directory: pkgDirRelative },
+      version,
     });
     expect(output).not.toHaveProperty('devDependencies');
     expect(output).not.toHaveProperty('scripts');
@@ -71,22 +70,26 @@ describe.concurrent(prepack, () => {
 
   it('generates .npmignore', ({ expect }) => {
     const root = createTempDir();
+    const name = build.scopedPackageName();
+    const publishDir = build.publishDirectory();
+    const pkgBasename = build.packageName();
+
     writeFileSync(
       path.join(root, 'pnpm-workspace.yaml'),
       "packages:\n  - 'packages/*'\n",
     );
     writeFormattedJson(root, 'package.json', {});
-    const pkgDir = path.join(root, 'packages', 'my-lib');
+    const pkgDir = path.join(root, 'packages', pkgBasename);
     mkdirSync(pkgDir, { recursive: true });
     writeFormattedJson(pkgDir, 'package.json', {
-      name: '@test/my-lib',
-      publishConfig: { directory: 'dist/source' },
+      name,
+      publishConfig: { directory: publishDir },
     });
 
     prepack({ cwd: root });
 
     const npmignore = readFileSync(
-      path.join(pkgDir, 'dist', 'source', '.npmignore'),
+      path.join(pkgDir, publishDir, '.npmignore'),
       'utf8',
     );
 
@@ -95,64 +98,72 @@ describe.concurrent(prepack, () => {
 
   it('promotes publishConfig.bin', ({ expect }) => {
     const root = createTempDir();
+    const name = build.scopedPackageName();
+    const publishDir = build.publishDirectory();
+    const pkgBasename = build.packageName();
+    const publishedBin = build.binMap();
+
     writeFileSync(
       path.join(root, 'pnpm-workspace.yaml'),
       "packages:\n  - 'packages/*'\n",
     );
     writeFormattedJson(root, 'package.json', {});
-    const pkgDir = path.join(root, 'packages', 'cli');
+    const pkgDir = path.join(root, 'packages', pkgBasename);
     mkdirSync(pkgDir, { recursive: true });
     writeFormattedJson(pkgDir, 'package.json', {
-      bin: { mycli: './dist/source/bin.js' },
-      name: '@test/cli',
+      bin: build.binMap(),
+      name,
       publishConfig: {
-        bin: { mycli: './bin.js' },
-        directory: 'dist/source',
+        bin: publishedBin,
+        directory: publishDir,
       },
     });
 
     prepack({ cwd: root });
-    const output = readJson(
-      path.join(pkgDir, 'dist', 'source', 'package.json'),
-    );
+    const output = readJson(path.join(pkgDir, publishDir, 'package.json'));
 
-    expect(output).toHaveProperty('bin', { mycli: './bin.js' });
+    expect(output).toHaveProperty('bin', publishedBin);
   });
 
   it('skips private packages', ({ expect }) => {
     const root = createTempDir();
+    const name = build.scopedPackageName();
+    const publishDir = build.publishDirectory();
+    const pkgBasename = build.packageName();
+
     writeFileSync(
       path.join(root, 'pnpm-workspace.yaml'),
       "packages:\n  - 'packages/*'\n",
     );
     writeFormattedJson(root, 'package.json', {});
-    const pkgDir = path.join(root, 'packages', 'internal');
+    const pkgDir = path.join(root, 'packages', pkgBasename);
     mkdirSync(pkgDir, { recursive: true });
     writeFormattedJson(pkgDir, 'package.json', {
-      name: '@test/internal',
+      name,
       private: true,
-      publishConfig: { directory: 'dist/source' },
+      publishConfig: { directory: publishDir },
     });
 
     prepack({ cwd: root });
 
     expect(() =>
-      readFileSync(path.join(pkgDir, 'dist', 'source', 'package.json')),
+      readFileSync(path.join(pkgDir, publishDir, 'package.json')),
     ).toThrow(/ENOENT/v);
   });
 
   it('skips packages without publishConfig.directory', ({ expect }) => {
     const root = createTempDir();
+    const name = build.scopedPackageName();
+    const pkgBasename = build.packageName();
+
     writeFileSync(
       path.join(root, 'pnpm-workspace.yaml'),
       "packages:\n  - 'packages/*'\n",
     );
     writeFormattedJson(root, 'package.json', {});
-    const pkgDir = path.join(root, 'packages', 'no-publish');
+    const pkgDir = path.join(root, 'packages', pkgBasename);
     mkdirSync(pkgDir, { recursive: true });
-    writeFormattedJson(pkgDir, 'package.json', {
-      name: '@test/no-publish',
-    });
+    writeFormattedJson(pkgDir, 'package.json', { name });
 
     prepack({ cwd: root });
 
@@ -163,21 +174,23 @@ describe.concurrent(prepack, () => {
 
   it('works in single-package mode', ({ expect }) => {
     const root = createTempDir();
+    const name = build.scopedPackageName();
+    const publishDir = build.publishDirectory();
+    const publishedExports = build.exportsMap();
+
     writeFormattedJson(root, 'package.json', {
-      name: '@test/single',
+      name,
       publishConfig: {
-        directory: 'dist/source',
-        exports: { '.': './index.js' },
+        directory: publishDir,
+        exports: publishedExports,
       },
     });
 
     prepack({ cwd: root });
 
-    const output = readJson(
-      path.join(root, 'dist', 'source', 'package.json'),
-    );
+    const output = readJson(path.join(root, publishDir, 'package.json'));
 
-    expect(output).toHaveProperty('name', '@test/single');
-    expect(output).toHaveProperty('exports', { '.': './index.js' });
+    expect(output).toHaveProperty('name', name);
+    expect(output).toHaveProperty('exports', publishedExports);
   });
 });

--- a/packages/cli/test/skills-config.test.ts
+++ b/packages/cli/test/skills-config.test.ts
@@ -1,6 +1,7 @@
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
+import { faker } from '@faker-js/faker';
 import { describe, it } from 'vitest';
 import { loadConfiguredAgents, skillsConfigFilename } from '#src/lib/skills-config.js';
 
@@ -32,14 +33,15 @@ describe.concurrent('loadConfiguredAgents', () => {
 
   it('returns agents when config exports a default with an agents array', async ({ expect }) => {
     using fixture = createFixture();
+    const agents = [faker.lorem.slug({ min: 1, max: 2 }), faker.lorem.slug({ min: 1, max: 2 })];
     writeFileSync(
       fixture.configPath,
-      `export default { agents: ['claude-code', 'codex'] };\n`,
+      `export default { agents: ${JSON.stringify(agents)} };\n`,
     );
 
-    const agents = await loadConfiguredAgents(fixture.rootDir);
+    const result = await loadConfiguredAgents(fixture.rootDir);
 
-    expect(agents).toStrictEqual(['claude-code', 'codex']);
+    expect(result).toStrictEqual(agents);
   });
 
   it('returns empty array when default export has no agents', async ({ expect }) => {

--- a/packages/cli/test/sync.test.ts
+++ b/packages/cli/test/sync.test.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { Writable } from 'node:stream';
+import * as build from '@gtbuchanan/test-utils/builders';
 import * as v from 'valibot';
 import { describe, it } from 'vitest';
 import { runSync, syncCommand } from '#src/commands/root/sync.js';
@@ -22,61 +23,82 @@ const silentSink = new Writable({
 });
 const silentLogger = createLogger(silentSink, silentSink);
 
-const createConsumerProject = (): string => {
+interface ConsumerPackage {
+  readonly basename: string;
+  readonly dir: string;
+  readonly name: string;
+}
+
+interface ConsumerProject {
+  readonly app: ConsumerPackage;
+  readonly lib: ConsumerPackage;
+  readonly root: string;
+}
+
+const createConsumerProject = (): ConsumerProject => {
   const root = createTempDir();
+  const appBasename = build.packageName();
+  const appName = build.scopedPackageName();
+  const libBasename = build.packageName();
+  const libName = build.scopedPackageName();
+
   writeFileSync(
     path.join(root, 'pnpm-workspace.yaml'),
     "packages:\n  - 'packages/*'\n",
   );
   writeJson(root, 'package.json', {
     devDependencies: {
-      '@gtbuchanan/cli': '^0.1.0',
-      '@gtbuchanan/eslint-config': '^0.1.0',
-      '@gtbuchanan/tsconfig': '^0.1.0',
-      '@gtbuchanan/vitest-config': '^0.1.0',
+      '@gtbuchanan/cli': build.semverRange(),
+      '@gtbuchanan/eslint-config': build.semverRange(),
+      '@gtbuchanan/tsconfig': build.semverRange(),
+      '@gtbuchanan/vitest-config': build.semverRange(),
     },
-    name: 'consumer-app',
+    name: build.packageName(),
     private: true,
     scripts: { prepare: 'gtb prepare' },
   });
 
-  const app = path.join(root, 'packages', 'app');
-  mkdirSync(path.join(app, 'src'), { recursive: true });
-  mkdirSync(path.join(app, 'test'), { recursive: true });
-  writeJson(app, 'package.json', {
+  const appDir = path.join(root, 'packages', appBasename);
+  mkdirSync(path.join(appDir, 'src'), { recursive: true });
+  mkdirSync(path.join(appDir, 'test'), { recursive: true });
+  writeJson(appDir, 'package.json', {
     devDependencies: {
-      '@gtbuchanan/eslint-config': '^0.1.0',
-      '@gtbuchanan/tsconfig': '^0.1.0',
-      '@gtbuchanan/vitest-config': '^0.1.0',
+      '@gtbuchanan/eslint-config': build.semverRange(),
+      '@gtbuchanan/tsconfig': build.semverRange(),
+      '@gtbuchanan/vitest-config': build.semverRange(),
     },
-    name: '@consumer/app',
-    publishConfig: { directory: 'dist/source' },
-    version: '1.0.0',
+    name: appName,
+    publishConfig: { directory: build.publishDirectory() },
+    version: build.semverVersion(),
   });
-  writeFileSync(path.join(app, 'tsconfig.json'), '{}');
-  writeFileSync(path.join(app, 'eslint.config.ts'), '');
-  writeFileSync(path.join(app, 'vitest.config.ts'), '');
+  writeFileSync(path.join(appDir, 'tsconfig.json'), '{}');
+  writeFileSync(path.join(appDir, 'eslint.config.ts'), '');
+  writeFileSync(path.join(appDir, 'vitest.config.ts'), '');
 
-  const lib = path.join(root, 'packages', 'lib');
-  mkdirSync(path.join(lib, 'src'), { recursive: true });
-  writeJson(lib, 'package.json', {
+  const libDir = path.join(root, 'packages', libBasename);
+  mkdirSync(path.join(libDir, 'src'), { recursive: true });
+  writeJson(libDir, 'package.json', {
     devDependencies: {
-      '@gtbuchanan/eslint-config': '^0.1.0',
-      '@gtbuchanan/tsconfig': '^0.1.0',
+      '@gtbuchanan/eslint-config': build.semverRange(),
+      '@gtbuchanan/tsconfig': build.semverRange(),
     },
-    name: '@consumer/lib',
+    name: libName,
     private: true,
-    version: '1.0.0',
+    version: build.semverVersion(),
   });
-  writeFileSync(path.join(lib, 'tsconfig.json'), '{}');
-  writeFileSync(path.join(lib, 'eslint.config.ts'), '');
+  writeFileSync(path.join(libDir, 'tsconfig.json'), '{}');
+  writeFileSync(path.join(libDir, 'eslint.config.ts'), '');
 
-  return root;
+  return {
+    app: { basename: appBasename, dir: appDir, name: appName },
+    lib: { basename: libBasename, dir: libDir, name: libName },
+    root,
+  };
 };
 
 describe.concurrent('sync helpers', () => {
   it('generates turbo.json with correct tasks for consumer project', ({ expect }) => {
-    const root = createConsumerProject();
+    const { root } = createConsumerProject();
     const discovery = discoverWorkspace({ cwd: root });
 
     const turboJson = generateTurboJson(discovery);
@@ -90,11 +112,11 @@ describe.concurrent('sync helpers', () => {
   });
 
   it('generates per-package scripts with gtb task commands', ({ expect }) => {
-    const root = createConsumerProject();
+    const { app, root } = createConsumerProject();
     const discovery = discoverWorkspace({ cwd: root });
-    const app = discovery.packages.find(pkg => pkg.dir.endsWith('app'));
+    const appPkg = discovery.packages.find(pkg => pkg.dir === app.dir);
 
-    const scripts = generatePackageScripts(app!, discovery.isSelfHosted);
+    const scripts = generatePackageScripts(appPkg!, discovery.isSelfHosted);
 
     expect(scripts).toMatchObject({
       'compile:ts': 'gtb task compile:ts',
@@ -106,11 +128,11 @@ describe.concurrent('sync helpers', () => {
   });
 
   it('generates fewer scripts for private package without tests', ({ expect }) => {
-    const root = createConsumerProject();
+    const { lib, root } = createConsumerProject();
     const discovery = discoverWorkspace({ cwd: root });
-    const lib = discovery.packages.find(pkg => pkg.dir.endsWith('lib'));
+    const libPkg = discovery.packages.find(pkg => pkg.dir === lib.dir);
 
-    const scripts = generatePackageScripts(lib!, discovery.isSelfHosted);
+    const scripts = generatePackageScripts(libPkg!, discovery.isSelfHosted);
 
     expect(scripts).toHaveProperty('typecheck:ts');
     expect(scripts).toHaveProperty('lint:eslint');
@@ -119,7 +141,7 @@ describe.concurrent('sync helpers', () => {
   });
 
   it('generates root convenience scripts', ({ expect }) => {
-    const root = createConsumerProject();
+    const { root } = createConsumerProject();
     const discovery = discoverWorkspace({ cwd: root });
 
     const scripts = generateRootScripts(discovery);
@@ -135,7 +157,7 @@ describe.concurrent('sync helpers', () => {
   });
 
   it('writes turbo.json and merges scripts end-to-end', ({ expect }) => {
-    const root = createConsumerProject();
+    const { root } = createConsumerProject();
     const discovery = discoverWorkspace({ cwd: root });
 
     const turboPath = path.join(root, 'turbo.json');
@@ -150,7 +172,7 @@ describe.concurrent('sync helpers', () => {
   });
 
   it('merges scripts without overwriting existing', ({ expect }) => {
-    const root = createConsumerProject();
+    const { root } = createConsumerProject();
     const discovery = discoverWorkspace({ cwd: root });
     const rootScripts = generateRootScripts(discovery);
 
@@ -196,20 +218,20 @@ describe.concurrent('sync helpers', () => {
 
 describe.concurrent(runSync, () => {
   it('writes turbo.json and scripts', ({ expect }) => {
-    const root = createConsumerProject();
+    const { app, root } = createConsumerProject();
     runSync({ cwd: root, logger: silentLogger });
 
     expect(existsSync(path.join(root, 'turbo.json'))).toBe(true);
 
     const scripts: unknown = JSON.parse(
-      readFileSync(path.join(root, 'packages', 'app', 'package.json'), 'utf8'),
+      readFileSync(path.join(app.dir, 'package.json'), 'utf8'),
     );
 
     expect(scripts).toHaveProperty('scripts.typecheck:ts');
   });
 
   it('generates codecov.yml when packages have vitest tests', ({ expect }) => {
-    const root = createConsumerProject();
+    const { app, root } = createConsumerProject();
     runSync({ cwd: root, logger: silentLogger });
 
     const codecovPath = path.join(root, 'codecov.yml');
@@ -218,12 +240,12 @@ describe.concurrent(runSync, () => {
 
     const content = readFileSync(codecovPath, 'utf8');
 
-    expect(content).toContain('app:');
+    expect(content).toContain(`${app.basename}:`);
     expect(content).toContain('carryforward');
   });
 
   it('preserves existing codecov.yml user config', ({ expect }) => {
-    const root = createConsumerProject();
+    const { root } = createConsumerProject();
     writeFileSync(
       path.join(root, 'codecov.yml'),
       'codecov:\n  require_ci_to_pass: true\n',
@@ -238,19 +260,17 @@ describe.concurrent(runSync, () => {
   });
 
   it('force overwrites existing scripts', ({ expect }) => {
-    const root = createConsumerProject();
+    const { app, root } = createConsumerProject();
     runSync({ cwd: root, logger: silentLogger });
 
-    const appPkg = path.join(root, 'packages', 'app', 'package.json');
+    const appPkg = path.join(app.dir, 'package.json');
     const manifest = v.parse(ManifestSchema, readJsonFile(appPkg));
     const scripts = { ...manifest.scripts, 'typecheck:ts': 'custom-tsc' };
     writeJsonFile(appPkg, { ...manifest, scripts });
 
     runSync({ cwd: root, force: true, logger: silentLogger });
 
-    const result: unknown = JSON.parse(
-      readFileSync(path.join(root, 'packages', 'app', 'package.json'), 'utf8'),
-    );
+    const result: unknown = JSON.parse(readFileSync(appPkg, 'utf8'));
 
     expect(result).toHaveProperty('scripts.typecheck:ts', 'gtb task typecheck:ts');
   });
@@ -258,7 +278,7 @@ describe.concurrent(runSync, () => {
 
 describe.concurrent(syncCommand, () => {
   it('passes cwd from args through to runSync', ({ expect }) => {
-    const root = createConsumerProject();
+    const { root } = createConsumerProject();
     const { logger } = captureLogger();
 
     syncCommand({ cwd: root }, logger);
@@ -267,11 +287,11 @@ describe.concurrent(syncCommand, () => {
   });
 
   it('passes force from args through to runSync', ({ expect }) => {
-    const root = createConsumerProject();
+    const { app, root } = createConsumerProject();
     const { logger } = captureLogger();
     syncCommand({ cwd: root }, logger);
 
-    const appPkg = path.join(root, 'packages', 'app', 'package.json');
+    const appPkg = path.join(app.dir, 'package.json');
     const manifest = v.parse(ManifestSchema, readJsonFile(appPkg));
     writeJsonFile(appPkg, {
       ...manifest,
@@ -280,15 +300,13 @@ describe.concurrent(syncCommand, () => {
 
     syncCommand({ cwd: root, force: true }, logger);
 
-    const result: unknown = JSON.parse(
-      readFileSync(appPkg, 'utf8'),
-    );
+    const result: unknown = JSON.parse(readFileSync(appPkg, 'utf8'));
 
     expect(result).toHaveProperty('scripts.typecheck:ts', 'gtb task typecheck:ts');
   });
 
   it('routes progress messages through the injected logger', ({ expect }) => {
-    const root = createConsumerProject();
+    const { root } = createConsumerProject();
     const { logger, out } = captureLogger();
 
     syncCommand({ cwd: root }, logger);

--- a/packages/cli/test/verify.test.ts
+++ b/packages/cli/test/verify.test.ts
@@ -1,5 +1,7 @@
 import { mkdirSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
+import { faker } from '@faker-js/faker';
+import * as build from '@gtbuchanan/test-utils/builders';
 import { describe, it } from 'vitest';
 import { parseIgnoreArgs, runVerify, verifyCommand } from '#src/commands/root/verify.js';
 import { discoverWorkspace } from '#src/lib/discovery.js';
@@ -12,45 +14,53 @@ import {
   captureLogger, createTempDir, initProject, readScripts, readTurboTasks, writeJson,
 } from './helpers.ts';
 
-const createConsumerProject = (): string => {
+interface ConsumerProject {
+  readonly app: { basename: string; dir: string; name: string };
+  readonly root: string;
+}
+
+const createConsumerProject = (): ConsumerProject => {
   const root = createTempDir();
+  const appBasename = build.packageName();
+  const appName = build.scopedPackageName();
+
   writeFileSync(
     path.join(root, 'pnpm-workspace.yaml'),
     "packages:\n  - 'packages/*'\n",
   );
   writeJson(root, 'package.json', {
     devDependencies: {
-      '@gtbuchanan/eslint-config': '^0.1.0',
-      '@gtbuchanan/tsconfig': '^0.1.0',
-      '@gtbuchanan/vitest-config': '^0.1.0',
+      '@gtbuchanan/eslint-config': build.semverRange(),
+      '@gtbuchanan/tsconfig': build.semverRange(),
+      '@gtbuchanan/vitest-config': build.semverRange(),
     },
-    name: 'test-project',
+    name: build.packageName(),
     private: true,
     scripts: {},
   });
 
-  const pkg = path.join(root, 'packages', 'app');
-  mkdirSync(path.join(pkg, 'src'), { recursive: true });
-  mkdirSync(path.join(pkg, 'test'), { recursive: true });
-  writeJson(pkg, 'package.json', {
+  const appDir = path.join(root, 'packages', appBasename);
+  mkdirSync(path.join(appDir, 'src'), { recursive: true });
+  mkdirSync(path.join(appDir, 'test'), { recursive: true });
+  writeJson(appDir, 'package.json', {
     devDependencies: {
-      '@gtbuchanan/eslint-config': '^0.1.0',
-      '@gtbuchanan/tsconfig': '^0.1.0',
-      '@gtbuchanan/vitest-config': '^0.1.0',
+      '@gtbuchanan/eslint-config': build.semverRange(),
+      '@gtbuchanan/tsconfig': build.semverRange(),
+      '@gtbuchanan/vitest-config': build.semverRange(),
     },
-    name: '@test/app',
+    name: appName,
     scripts: {},
   });
-  writeFileSync(path.join(pkg, 'tsconfig.json'), '{}');
-  writeFileSync(path.join(pkg, 'eslint.config.ts'), '');
-  writeFileSync(path.join(pkg, 'vitest.config.ts'), '');
+  writeFileSync(path.join(appDir, 'tsconfig.json'), '{}');
+  writeFileSync(path.join(appDir, 'eslint.config.ts'), '');
+  writeFileSync(path.join(appDir, 'vitest.config.ts'), '');
 
-  return root;
+  return { app: { basename: appBasename, dir: appDir, name: appName }, root };
 };
 
 describe.concurrent('verify drift detection', () => {
   it('all expected tasks present after init', ({ expect }) => {
-    const root = createConsumerProject();
+    const { root } = createConsumerProject();
     initProject(root);
 
     const discovery = discoverWorkspace({ cwd: root });
@@ -63,7 +73,7 @@ describe.concurrent('verify drift detection', () => {
   });
 
   it('detects missing turbo.json task', ({ expect }) => {
-    const root = createConsumerProject();
+    const { root } = createConsumerProject();
     initProject(root);
 
     const tasks = readTurboTasks(root);
@@ -79,36 +89,34 @@ describe.concurrent('verify drift detection', () => {
   });
 
   it('detects missing package script', ({ expect }) => {
-    const root = createConsumerProject();
+    const { app, root } = createConsumerProject();
     initProject(root);
 
-    const pkgDir = path.join(root, 'packages', 'app');
-    const scripts = readScripts(pkgDir);
+    const scripts = readScripts(app.dir);
     delete scripts['typecheck:ts'];
-    writeJson(pkgDir, 'package.json', { name: '@test/app', scripts });
+    writeJson(app.dir, 'package.json', { name: app.name, scripts });
 
     const discovery = discoverWorkspace({ cwd: root });
     const pkg = discovery.packages[0]!;
     const expected = generatePackageScripts(pkg, discovery.isSelfHosted);
-    const actual = readScripts(pkgDir);
+    const actual = readScripts(app.dir);
     const missing = Object.keys(expected).filter(name => !(name in actual));
 
     expect(missing).toContain('typecheck:ts');
   });
 
   it('does not flag modified script values', ({ expect }) => {
-    const root = createConsumerProject();
+    const { app, root } = createConsumerProject();
     initProject(root);
 
-    const pkgDir = path.join(root, 'packages', 'app');
-    const scripts = readScripts(pkgDir);
-    scripts['typecheck:ts'] = 'vue-tsc --noEmit';
-    writeJson(pkgDir, 'package.json', { name: '@test/app', scripts });
+    const scripts = readScripts(app.dir);
+    scripts['typecheck:ts'] = faker.lorem.words({ min: 1, max: 3 });
+    writeJson(app.dir, 'package.json', { name: app.name, scripts });
 
     const discovery = discoverWorkspace({ cwd: root });
     const pkg = discovery.packages[0]!;
     const expected = generatePackageScripts(pkg, discovery.isSelfHosted);
-    const actual = readScripts(pkgDir);
+    const actual = readScripts(app.dir);
     const missing = Object.keys(expected).filter(name => !(name in actual));
 
     expect(missing).toHaveLength(0);
@@ -117,7 +125,7 @@ describe.concurrent('verify drift detection', () => {
 
 describe.concurrent(runVerify, () => {
   it('returns no drift when project is fully synced', ({ expect }) => {
-    const root = createConsumerProject();
+    const { root } = createConsumerProject();
     initProject(root);
 
     const drift = runVerify({ cwd: root });
@@ -126,7 +134,7 @@ describe.concurrent(runVerify, () => {
   });
 
   it('reports drift on missing turbo task', ({ expect }) => {
-    const root = createConsumerProject();
+    const { root } = createConsumerProject();
     initProject(root);
 
     const tasks = readTurboTasks(root);
@@ -139,7 +147,7 @@ describe.concurrent(runVerify, () => {
   });
 
   it('ignored set suppresses specific drift', ({ expect }) => {
-    const root = createConsumerProject();
+    const { root } = createConsumerProject();
     initProject(root);
 
     const tasks = readTurboTasks(root);
@@ -152,7 +160,7 @@ describe.concurrent(runVerify, () => {
   });
 
   it('reports drift when codecov.yml has invalid YAML', ({ expect }) => {
-    const root = createConsumerProject();
+    const { root } = createConsumerProject();
     initProject(root);
     writeFileSync(path.join(root, 'codecov.yml'), 'invalid: [}');
 
@@ -162,7 +170,7 @@ describe.concurrent(runVerify, () => {
   });
 
   it('reports drift when codecov.yml is empty', ({ expect }) => {
-    const root = createConsumerProject();
+    const { root } = createConsumerProject();
     initProject(root);
     writeFileSync(path.join(root, 'codecov.yml'), '');
 
@@ -172,7 +180,7 @@ describe.concurrent(runVerify, () => {
   });
 
   it('reports drift when a codecov flag is missing', ({ expect }) => {
-    const root = createConsumerProject();
+    const { app, root } = createConsumerProject();
     initProject(root);
     writeFileSync(
       path.join(root, 'codecov.yml'),
@@ -181,18 +189,18 @@ describe.concurrent(runVerify, () => {
 
     const drift = runVerify({ cwd: root });
 
-    expect(drift.some(msg => msg.includes("missing flag 'app'"))).toBe(true);
+    expect(drift.some(msg => msg.includes(`missing flag '${app.basename}'`))).toBe(true);
   });
 
   it('ignored set suppresses missing codecov flag drift', ({ expect }) => {
-    const root = createConsumerProject();
+    const { app, root } = createConsumerProject();
     initProject(root);
     writeFileSync(
       path.join(root, 'codecov.yml'),
       'flags: {}\ncomponent_management:\n  individual_components: []\n',
     );
 
-    const drift = runVerify({ cwd: root, ignored: new Set(['app']) });
+    const drift = runVerify({ cwd: root, ignored: new Set([app.basename]) });
 
     expect(drift).toHaveLength(0);
   });
@@ -230,7 +238,7 @@ describe.concurrent(parseIgnoreArgs, () => {
 
 describe.concurrent(verifyCommand, () => {
   it('returns 0 and logs success when there is no drift', ({ expect }) => {
-    const root = createConsumerProject();
+    const { root } = createConsumerProject();
     initProject(root);
     const { logger, out, err } = captureLogger();
 
@@ -242,7 +250,7 @@ describe.concurrent(verifyCommand, () => {
   });
 
   it('returns 1 and writes each drift message to stderr on drift', ({ expect }) => {
-    const root = createConsumerProject();
+    const { root } = createConsumerProject();
     initProject(root);
     const tasks = readTurboTasks(root);
     delete tasks['typecheck:ts'];
@@ -257,7 +265,7 @@ describe.concurrent(verifyCommand, () => {
   });
 
   it('forwards --ignore flags from rawArgs to runVerify', ({ expect }) => {
-    const root = createConsumerProject();
+    const { root } = createConsumerProject();
     initProject(root);
     const tasks = readTurboTasks(root);
     delete tasks['typecheck:ts'];

--- a/packages/cli/test/workspace.test.ts
+++ b/packages/cli/test/workspace.test.ts
@@ -1,5 +1,7 @@
 import { mkdirSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
+import { faker } from '@faker-js/faker';
+import * as build from '@gtbuchanan/test-utils/builders';
 import { describe, it } from 'vitest';
 import { resolveWorkspace } from '#src/lib/workspace.js';
 import { createTempDir } from './helpers.ts';
@@ -7,22 +9,24 @@ import { createTempDir } from './helpers.ts';
 describe.concurrent(resolveWorkspace, () => {
   it('detects monorepo with packages glob', ({ expect }) => {
     const root = createTempDir();
+    const alphaName = build.packageName();
+    const betaName = build.packageName();
     writeFileSync(
       path.join(root, 'pnpm-workspace.yaml'),
       "packages:\n  - 'packages/*'\n",
     );
-    mkdirSync(path.join(root, 'packages', 'alpha'), { recursive: true });
-    mkdirSync(path.join(root, 'packages', 'beta'), { recursive: true });
+    mkdirSync(path.join(root, 'packages', alphaName), { recursive: true });
+    mkdirSync(path.join(root, 'packages', betaName), { recursive: true });
 
     const result = resolveWorkspace({ cwd: root });
 
     expect(result.rootDir).toBe(root);
     expect(result.packageDirs).toHaveLength(2);
     expect(result.packageDirs).toContainEqual(
-      path.join(root, 'packages', 'alpha'),
+      path.join(root, 'packages', alphaName),
     );
     expect(result.packageDirs).toContainEqual(
-      path.join(root, 'packages', 'beta'),
+      path.join(root, 'packages', betaName),
     );
   });
 
@@ -63,28 +67,30 @@ describe.concurrent(resolveWorkspace, () => {
 
   it('ignores files in packages directory', ({ expect }) => {
     const root = createTempDir();
+    const pkgName = build.packageName();
     writeFileSync(
       path.join(root, 'pnpm-workspace.yaml'),
       "packages:\n  - 'packages/*'\n",
     );
     mkdirSync(path.join(root, 'packages'), { recursive: true });
-    writeFileSync(path.join(root, 'packages', 'not-a-package.txt'), '');
-    mkdirSync(path.join(root, 'packages', 'real-pkg'), { recursive: true });
+    writeFileSync(path.join(root, 'packages', faker.system.commonFileName('txt')), '');
+    mkdirSync(path.join(root, 'packages', pkgName), { recursive: true });
 
     const result = resolveWorkspace({ cwd: root });
 
     expect(result.packageDirs).toStrictEqual([
-      path.join(root, 'packages', 'real-pkg'),
+      path.join(root, 'packages', pkgName),
     ]);
   });
 
   it('resolves from a subdirectory', ({ expect }) => {
     const root = createTempDir();
+    const pkgName = build.packageName();
     writeFileSync(
       path.join(root, 'pnpm-workspace.yaml'),
       "packages:\n  - 'packages/*'\n",
     );
-    const subDir = path.join(root, 'packages', 'alpha');
+    const subDir = path.join(root, 'packages', pkgName);
     mkdirSync(subDir, { recursive: true });
 
     const result = resolveWorkspace({ cwd: subDir });
@@ -95,63 +101,68 @@ describe.concurrent(resolveWorkspace, () => {
 
   it('handles double-quoted globs', ({ expect }) => {
     const root = createTempDir();
+    const pkgName = build.packageName();
     writeFileSync(
       path.join(root, 'pnpm-workspace.yaml'),
       'packages:\n  - "apps/*"\n',
     );
-    mkdirSync(path.join(root, 'apps', 'web'), { recursive: true });
+    mkdirSync(path.join(root, 'apps', pkgName), { recursive: true });
 
     const result = resolveWorkspace({ cwd: root });
 
-    expect(result.packageDirs).toStrictEqual([path.join(root, 'apps', 'web')]);
+    expect(result.packageDirs).toStrictEqual([path.join(root, 'apps', pkgName)]);
   });
 
   it('handles bare (unquoted) globs', ({ expect }) => {
     const root = createTempDir();
+    const pkgName = build.packageName();
     writeFileSync(
       path.join(root, 'pnpm-workspace.yaml'),
       'packages:\n  - packages/*\n',
     );
-    mkdirSync(path.join(root, 'packages', 'lib'), { recursive: true });
+    mkdirSync(path.join(root, 'packages', pkgName), { recursive: true });
 
     const result = resolveWorkspace({ cwd: root });
 
     expect(result.packageDirs).toStrictEqual([
-      path.join(root, 'packages', 'lib'),
+      path.join(root, 'packages', pkgName),
     ]);
   });
 
   it('handles multiple glob patterns', ({ expect }) => {
     const root = createTempDir();
+    const libName = build.packageName();
+    const webName = build.packageName();
     writeFileSync(
       path.join(root, 'pnpm-workspace.yaml'),
       "packages:\n  - 'packages/*'\n  - 'apps/*'\n",
     );
-    mkdirSync(path.join(root, 'packages', 'lib'), { recursive: true });
-    mkdirSync(path.join(root, 'apps', 'web'), { recursive: true });
+    mkdirSync(path.join(root, 'packages', libName), { recursive: true });
+    mkdirSync(path.join(root, 'apps', webName), { recursive: true });
 
     const result = resolveWorkspace({ cwd: root });
 
     expect(result.packageDirs).toHaveLength(2);
     expect(result.packageDirs).toContainEqual(
-      path.join(root, 'packages', 'lib'),
+      path.join(root, 'packages', libName),
     );
     expect(result.packageDirs).toContainEqual(
-      path.join(root, 'apps', 'web'),
+      path.join(root, 'apps', webName),
     );
   });
 
   it('handles literal directory (no wildcard)', ({ expect }) => {
     const root = createTempDir();
+    const pkgName = build.packageName();
     writeFileSync(
       path.join(root, 'pnpm-workspace.yaml'),
-      "packages:\n  - 'tooling'\n",
+      `packages:\n  - '${pkgName}'\n`,
     );
-    mkdirSync(path.join(root, 'tooling'), { recursive: true });
+    mkdirSync(path.join(root, pkgName), { recursive: true });
 
     const result = resolveWorkspace({ cwd: root });
 
-    expect(result.packageDirs).toStrictEqual([path.join(root, 'tooling')]);
+    expect(result.packageDirs).toStrictEqual([path.join(root, pkgName)]);
   });
 
   it('returns empty when glob directory does not exist', ({ expect }) => {

--- a/packages/eslint-config/e2e/skill.test.ts
+++ b/packages/eslint-config/e2e/skill.test.ts
@@ -1,3 +1,4 @@
+import { faker } from '@faker-js/faker';
 import { it as base, describe } from 'vitest';
 import { type Fixture, createFixture } from './fixture.ts';
 
@@ -15,18 +16,21 @@ const it = base.extend<{ fixture: Fixture }>({
 const skill = (frontmatter: readonly string[], body: readonly string[] = ['# Body', '']) =>
   ['---', ...frontmatter, '---', '', ...body].join('\n');
 
+const skillName = (): string => faker.lorem.slug({ min: 1, max: 2 });
+
 describe.concurrent('SKILL.md validation', () => {
   it('passes for a valid SKILL.md', async ({ fixture, expect }) => {
+    const name = skillName();
     const result = await fixture.run({
       files: {
-        'skills/example-skill/SKILL.md': skill(
+        [`skills/${name}/SKILL.md`]: skill(
           [
-            'name: example-skill',
-            'description: A description that is descriptive enough.',
+            `name: ${name}`,
+            `description: ${faker.lorem.sentence()}`,
           ],
           ['# Example skill', '', 'Body content.', ''],
         ),
-        'skills/example-skill/evals/evals.json': `${JSON.stringify({
+        [`skills/${name}/evals/evals.json`]: `${JSON.stringify({
           evals: [{
             expectations: ['Activates skill'],
             expected_output: 'Example output',
@@ -34,7 +38,7 @@ describe.concurrent('SKILL.md validation', () => {
             id: 1,
             prompt: 'Example prompt',
           }],
-          skill_name: 'example-skill',
+          skill_name: name,
         }, undefined, 2)}\n`,
       },
     });
@@ -44,9 +48,10 @@ describe.concurrent('SKILL.md validation', () => {
   });
 
   it('flags missing required frontmatter fields', async ({ fixture, expect }) => {
+    const name = skillName();
     const result = await fixture.run({
       files: {
-        'skills/example-skill/SKILL.md': skill(['name: example-skill']),
+        [`skills/${name}/SKILL.md`]: skill([`name: ${name}`]),
       },
     });
 
@@ -55,11 +60,12 @@ describe.concurrent('SKILL.md validation', () => {
   });
 
   it('flags non-kebab-case name', async ({ fixture, expect }) => {
+    const name = skillName();
     const result = await fixture.run({
       files: {
-        'skills/example-skill/SKILL.md': skill([
+        [`skills/${name}/SKILL.md`]: skill([
           'name: ExampleSkill',
-          'description: A description that is descriptive enough.',
+          `description: ${faker.lorem.sentence()}`,
         ]),
       },
     });
@@ -69,11 +75,12 @@ describe.concurrent('SKILL.md validation', () => {
   });
 
   it('flags unknown frontmatter fields', async ({ fixture, expect }) => {
+    const name = skillName();
     const result = await fixture.run({
       files: {
-        'skills/example-skill/SKILL.md': skill([
-          'name: example-skill',
-          'description: A description that is descriptive enough.',
+        [`skills/${name}/SKILL.md`]: skill([
+          `name: ${name}`,
+          `description: ${faker.lorem.sentence()}`,
           'unknown: value',
         ]),
       },
@@ -84,26 +91,30 @@ describe.concurrent('SKILL.md validation', () => {
   });
 
   it('flags name not matching parent directory', async ({ fixture, expect }) => {
+    const name = skillName();
     const result = await fixture.run({
       files: {
-        'skills/example-skill/SKILL.md': skill([
+        [`skills/${name}/SKILL.md`]: skill([
           'name: wrong-name',
-          'description: A description that is descriptive enough.',
+          `description: ${faker.lorem.sentence()}`,
         ]),
       },
     });
 
     expect(result.stdout).toMatch(/agent-skills\/name-matches-dir/v);
-    expect(result.stdout).toMatch(/expected `example-skill`, got `wrong-name`/v);
+    expect(result.stdout).toMatch(
+      new RegExp(`expected \`${name}\`, got \`wrong-name\``, 'v'),
+    );
   });
 
   it('passes when referenced files exist within the skill root', async ({ fixture, expect }) => {
+    const name = skillName();
     const result = await fixture.run({
       files: {
-        'skills/example-skill/SKILL.md': skill(
+        [`skills/${name}/SKILL.md`]: skill(
           [
-            'name: example-skill',
-            'description: A description that is descriptive enough.',
+            `name: ${name}`,
+            `description: ${faker.lorem.sentence()}`,
           ],
           [
             '# Example skill',
@@ -112,7 +123,7 @@ describe.concurrent('SKILL.md validation', () => {
             '',
           ],
         ),
-        'skills/example-skill/references/REFERENCE.md': '# Reference\n\nStub.\n',
+        [`skills/${name}/references/REFERENCE.md`]: '# Reference\n\nStub.\n',
       },
     });
 
@@ -121,12 +132,13 @@ describe.concurrent('SKILL.md validation', () => {
   });
 
   it('flags references to files that do not exist', async ({ fixture, expect }) => {
+    const name = skillName();
     const result = await fixture.run({
       files: {
-        'skills/example-skill/SKILL.md': skill(
+        [`skills/${name}/SKILL.md`]: skill(
           [
-            'name: example-skill',
-            'description: A description that is descriptive enough.',
+            `name: ${name}`,
+            `description: ${faker.lorem.sentence()}`,
           ],
           [
             '# Example skill',
@@ -143,16 +155,17 @@ describe.concurrent('SKILL.md validation', () => {
   });
 
   it('caps file at 500 lines per the spec', async ({ fixture, expect }) => {
+    const name = skillName();
     const lines = Array.from(
       { length: 600 },
       (_unused, index) => `Line ${String(index + 1)}`,
     );
     const result = await fixture.run({
       files: {
-        'skills/example-skill/SKILL.md': skill(
+        [`skills/${name}/SKILL.md`]: skill(
           [
-            'name: example-skill',
-            'description: A description that is descriptive enough.',
+            `name: ${name}`,
+            `description: ${faker.lorem.sentence()}`,
           ],
           [...lines, ''],
         ),

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -52,6 +52,7 @@
     "typescript-eslint": "catalog:"
   },
   "devDependencies": {
+    "@faker-js/faker": "catalog:",
     "@gtbuchanan/test-utils": "workspace:*",
     "@gtbuchanan/vitest-config": "workspace:*"
   },

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -7,7 +7,8 @@
     "#src/*": "./src/*"
   },
   "exports": {
-    ".": "./src/fixture.ts"
+    ".": "./src/fixture.ts",
+    "./builders": "./src/builders.ts"
   },
   "scripts": {
     "coverage:codecov:upload": "pnpm run gtb task coverage:codecov:upload",
@@ -19,6 +20,7 @@
     "typecheck:ts": "pnpm run gtb task typecheck:ts"
   },
   "dependencies": {
+    "@faker-js/faker": "catalog:",
     "cross-spawn": "catalog:",
     "find-up-simple": "catalog:",
     "valibot": "catalog:"

--- a/packages/test-utils/src/builders.ts
+++ b/packages/test-utils/src/builders.ts
@@ -1,0 +1,75 @@
+import { faker } from '@faker-js/faker';
+
+const arbitraryRecord = <V>(
+  keyFn: () => string,
+  valueFn: () => V,
+): Record<string, V> =>
+  Object.fromEntries(
+    faker.helpers.multiple(() => [keyFn(), valueFn()], {
+      count: { min: 1, max: 3 },
+    }),
+  );
+
+const exportSubpath = (): string => `./${faker.lorem.slug()}`;
+
+const importSubpath = (): string => `#${faker.lorem.slug()}/*`;
+
+/** Arbitrary `bin` map (executable name → relative script path). */
+export const binMap = (): Record<string, string> =>
+  arbitraryRecord(packageName, relativePath);
+
+/** Arbitrary `dependencies` / `devDependencies` map (package name → semver range). */
+export const dependencyMap = (): Record<string, string> =>
+  arbitraryRecord(scopedPackageName, semverRange);
+
+/** Arbitrary `exports` map (subpath → relative file path). */
+export const exportsMap = (): Record<string, string> =>
+  arbitraryRecord(exportSubpath, relativePath);
+
+/** Arbitrary GitHub `https://...git` clone URL. */
+export const gitHubGitUrl = (): string => `${gitHubRepoUrl()}.git`;
+
+/** Arbitrary GitHub issues URL. */
+export const gitHubIssuesUrl = (): string => `${gitHubRepoUrl()}/issues`;
+
+/** Arbitrary GitHub repo homepage URL, e.g. `https://github.com/owner/repo`. */
+export const gitHubRepoUrl = (): string =>
+  `https://github.com/${faker.internet.domainWord()}/${faker.internet.domainWord()}`;
+
+/** Arbitrary `imports` map (`#`-prefixed subpath → relative file path). */
+export const importsMap = (): Record<string, string> =>
+  arbitraryRecord(importSubpath, relativePath);
+
+/** Arbitrary monorepo package directory, e.g. `packages/foo`. */
+export const packageDirectory = (): string =>
+  `packages/${faker.internet.domainWord()}`;
+
+/** Arbitrary unscoped npm package name. */
+export const packageName = (): string => faker.internet.domainWord();
+
+/** Arbitrary platform-tag list suitable for `os` / `cpu` / `libc`. */
+export const platformList = (): string[] => [faker.lorem.word()];
+
+/** Arbitrary `publishConfig.directory` value, e.g. `dist/source`. */
+export const publishDirectory = (): string =>
+  `dist/${faker.lorem.slug()}`;
+
+/** Arbitrary relative POSIX file path, e.g. `./foo.js`. */
+export const relativePath = (): string => `./${faker.lorem.slug()}.js`;
+
+/** Arbitrary scoped npm package name, e.g. `@scope/name`. */
+export const scopedPackageName = (): string =>
+  `@${faker.internet.domainWord()}/${faker.internet.domainWord()}`;
+
+/** Arbitrary `scripts` map (script name → shell command). */
+export const scriptMap = (): Record<string, string> =>
+  arbitraryRecord(
+    () => faker.lorem.word(),
+    () => faker.lorem.words({ min: 1, max: 3 }),
+  );
+
+/** Arbitrary semver range prefixed with `^`, e.g. `^1.2.3`. */
+export const semverRange = (): string => `^${faker.system.semver()}`;
+
+/** Arbitrary semver version with no range prefix, e.g. `1.2.3`. */
+export const semverVersion = (): string => faker.system.semver();

--- a/packages/test-utils/test/fixture.test.ts
+++ b/packages/test-utils/test/fixture.test.ts
@@ -1,3 +1,4 @@
+import { faker } from '@faker-js/faker';
 import { describe, it } from 'vitest';
 import { createGitEnv, matchTarball, pinned, runCommand } from '#src/fixture.js';
 
@@ -69,12 +70,14 @@ describe.concurrent(createGitEnv, () => {
   });
 
   it('includes identity when provided', ({ expect }) => {
-    const env = createGitEnv({ email: 'test@example.com', name: 'Test' });
+    const email = faker.internet.email();
+    const name = faker.person.firstName();
+    const env = createGitEnv({ email, name });
 
-    expect(env.GIT_AUTHOR_EMAIL).toBe('test@example.com');
-    expect(env.GIT_AUTHOR_NAME).toBe('Test');
-    expect(env.GIT_COMMITTER_EMAIL).toBe('test@example.com');
-    expect(env.GIT_COMMITTER_NAME).toBe('Test');
+    expect(env.GIT_AUTHOR_EMAIL).toBe(email);
+    expect(env.GIT_AUTHOR_NAME).toBe(name);
+    expect(env.GIT_COMMITTER_EMAIL).toBe(email);
+    expect(env.GIT_COMMITTER_NAME).toBe(name);
   });
 });
 

--- a/packages/vitest-config/package.json
+++ b/packages/vitest-config/package.json
@@ -30,6 +30,7 @@
     "find-up-simple": "catalog:"
   },
   "devDependencies": {
+    "@faker-js/faker": "catalog:",
     "@gtbuchanan/test-utils": "workspace:*"
   },
   "peerDependencies": {

--- a/packages/vitest-config/test/configure.test.ts
+++ b/packages/vitest-config/test/configure.test.ts
@@ -1,3 +1,4 @@
+import * as build from '@gtbuchanan/test-utils/builders';
 import { describe, it } from 'vitest';
 import {
   buildWorkspaceEntry,
@@ -239,33 +240,39 @@ describe.concurrent(resolveCoverageInclude, () => {
   });
 });
 
+const createWorkspaceEntryFixture = () => {
+  const basename = build.packageName();
+  const dir = `/path/to/${basename}`;
+  return { basename, dir, entry: buildWorkspaceEntry(dir, configureProject) };
+};
+
 describe.concurrent(buildWorkspaceEntry, () => {
   it('adds name from directory basename', ({ expect }) => {
-    const entry = buildWorkspaceEntry('/path/to/my-package', configureProject);
+    const { basename, entry } = createWorkspaceEntryFixture();
 
-    expect(entry.test?.name).toBe('my-package');
+    expect(entry.test?.name).toBe(basename);
   });
 
   it('adds root from directory path', ({ expect }) => {
-    const entry = buildWorkspaceEntry('/path/to/my-package', configureProject);
+    const { dir, entry } = createWorkspaceEntryFixture();
 
-    expect(entry.test?.root).toBe('/path/to/my-package');
+    expect(entry.test?.root).toBe(dir);
   });
 
   it('does not include resolve alias', ({ expect }) => {
-    const entry = buildWorkspaceEntry('/path/to/my-package', configureProject);
+    const { entry } = createWorkspaceEntryFixture();
 
     expect(entry.resolve).toBeUndefined();
   });
 
   it('preserves includes from configure function', ({ expect }) => {
-    const entry = buildWorkspaceEntry('/path/to/my-package', configureProject);
+    const { entry } = createWorkspaceEntryFixture();
 
     expect(entry.test?.include).toStrictEqual(expectedUnitTestInclude);
   });
 
   it('preserves excludes from configure function', ({ expect }) => {
-    const entry = buildWorkspaceEntry('/path/to/my-package', configureProject);
+    const { entry } = createWorkspaceEntryFixture();
 
     expect(entry.test?.exclude).toStrictEqual([...excludeDefault]);
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ catalogs:
     '@eslint/markdown':
       specifier: 8.0.1
       version: 8.0.1
+    '@faker-js/faker':
+      specifier: ^10.4.0
+      version: 10.4.0
     '@j178/prek':
       specifier: ^0.3.11
       version: 0.3.11
@@ -443,6 +446,9 @@ importers:
 
   packages/test-utils:
     dependencies:
+      '@faker-js/faker':
+        specifier: 'catalog:'
+        version: 10.4.0
       cross-spawn:
         specifier: 'catalog:'
         version: 7.0.6
@@ -663,6 +669,10 @@ packages:
   '@eslint/plugin-kit@0.6.1':
     resolution: {integrity: sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@faker-js/faker@10.4.0':
+    resolution: {integrity: sha512-sDBWI3yLy8EcDzgobvJTWq1MJYzAkQdpjXuPukga9wXonhpMRvd1Izuo2Qgwey2OiEoRIBr35RMU9HJRoOHzpw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || ^23.5.0 || >=24.0.0, npm: '>=10'}
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -3675,6 +3685,8 @@ snapshots:
     dependencies:
       '@eslint/core': 1.1.1
       levn: 0.4.1
+
+  '@faker-js/faker@10.4.0': {}
 
   '@humanfs/core@0.19.1': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -254,6 +254,9 @@ importers:
         specifier: 'catalog:'
         version: 2.8.3
     devDependencies:
+      '@faker-js/faker':
+        specifier: 'catalog:'
+        version: 10.4.0
       '@gtbuchanan/eslint-config':
         specifier: workspace:*
         version: link:../eslint-config
@@ -352,6 +355,9 @@ importers:
         specifier: 'catalog:'
         version: 8.58.0(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)
     devDependencies:
+      '@faker-js/faker':
+        specifier: 'catalog:'
+        version: 10.4.0
       '@gtbuchanan/test-utils':
         specifier: workspace:*
         version: link:../test-utils
@@ -491,6 +497,9 @@ importers:
         specifier: ^4.0.0
         version: 4.1.2(@types/node@25.5.2)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(jiti@2.6.1)(yaml@2.8.3))
     devDependencies:
+      '@faker-js/faker':
+        specifier: 'catalog:'
+        version: 10.4.0
       '@gtbuchanan/test-utils':
         specifier: workspace:*
         version: link:../test-utils

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,7 @@ catalog:
   '@eslint-community/eslint-plugin-eslint-comments': 4.7.1
   '@eslint/json': 1.2.0
   '@eslint/markdown': 8.0.1
+  '@faker-js/faker': ^10.4.0
   '@j178/prek': ^0.3.11
   '@pnpm/lockfile.types': ^1100.0.5
   '@pnpm/types': ^1101.1.0


### PR DESCRIPTION
## Summary

Adds a `./builders` subpath export on `@gtbuchanan/test-utils` wrapping `@faker-js/faker` in domain-shaped factory functions (`scopedPackageName`, `dependencyMap`, `exportsMap`, `gitHubRepoUrl`, etc.). Tests capture each builder's result in a local and assert against the captured value, so a reader can tell at a glance which inputs are load-bearing for the assertion and which are arbitrary.

Convention (documented under `## Conventions` in `AGENTS.md`):

- `import * as build from '@gtbuchanan/test-utils/builders'`
- `const name = build.scopedPackageName()` → `expect(result).toHaveProperty('name', name)`
- Hard-code a literal only when the SUT branches on the specific string (reserved keys, known enums)
- Add a builder when the value has a domain shape worth centralizing (scoped name, semver range, GitHub URL, …); inline `@faker-js/faker` is fine for raw primitives where the shape is exactly what faker already returns

`packages/cli/test/manifest.test.ts` refactored as the reference adoption example.

No published-package impact: `@gtbuchanan/test-utils` is `private: true` and test files are excluded from published artifacts. No changeset.

## Test plan

- [x] \`pnpm exec turbo run typecheck:ts lint:eslint test:vitest:fast\` — 36/36 tasks green
- [x] \`packages/cli/test/manifest.test.ts\` — 13/13 tests pass with the new builder-backed inputs
- [x] Smoke-test in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)