### PR TITLE
Add shared Renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>gtbuchanan/tooling"
+  ]
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,6 +18,16 @@ repos:
         name: '[*] No Trailing Whitespace'
     repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
+  - hooks:
+      - args: [--strict]
+        files: ^default\.json$
+        id: renovate-config-validator
+        name: '[Renovate] Lint Preset'
+      - args: [--strict]
+        id: renovate-config-validator
+        name: '[Renovate] Lint'
+    repo: https://github.com/renovatebot/pre-commit-hooks
+    rev: 43.150.0
   # language: system because the config packages aren't published yet.
   # Consumers should use language: node with additional_dependencies.
   - hooks:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,14 +7,16 @@ TypeScript, Vitest configuration, and a shared build CLI.
 
 ```text
 README.md              — Consumer-facing documentation
-mise.toml              — Pin Node, pnpm, prek versions for local + CI
+default.json           — Shareable Renovate preset (consumed via `github>gtbuchanan/tooling`)
 mise.lock              — Per-platform binary checksums + download URLs
+mise.toml              — Pin Node, pnpm, prek versions for local + CI
 .github/
   actions/
     mise-setup/          — Composite action: install + cache mise tools
     pnpm-resolve-pinned/ — Composite action: resolve locked version without install
     pnpm-tasks/          — Composite action: cache pnpm store, install deps
     turbo-run/           — Composite action: run turbo task, skip install on cache hit
+  renovate.json        — Repo-local Renovate config (extends the shared preset)
   workflows/
     cd.yml               — Calls CI, then version + publish on main
     changeset-check.yml  — Verify changeset exists on PR
@@ -144,6 +146,38 @@ Composite actions:
 - **`pnpm-resolve-pinned`** — Resolves a package's exact version from the
   lockfile without install. Used to pin `pnpm dlx` invocations to the
   locked version.
+
+### Renovate preset
+
+The repo ships a shareable Renovate config at `default.json` for
+consumer repos and uses it on itself via `.github/renovate.json`.
+Beyond `config:recommended`, the preset overrides these defaults:
+
+- `labels: ["dependencies"]` — tag every Renovate PR for filtering.
+- `minimumReleaseAge: "3 days"` — supply-chain quarantine on new
+  releases.
+- `osvVulnerabilityAlerts: true` — opt into OSV-based alerts, separate
+  from GitHub's GHSA feed.
+- `platformCommit: "enabled"` — force commits via GitHub App API so the
+  bot's commits show the verified checkmark.
+- `postUpdateOptions: ["pnpmDedupe"]` — run `pnpm dedupe` after each
+  update to keep the lockfile lean.
+- `pre-commit.enabled: true` — Renovate's pre-commit manager is off by
+  default; enable so `.pre-commit-config.yaml` hooks get bumped.
+- `rebaseWhen: "conflicted"` — fewer no-op CI runs at the cost of
+  staler PRs (default `"auto"` rebases on every base-branch move).
+- `semanticCommits: "disabled"` — overrides
+  `:semanticPrefixFixDepsChoreOthers` from `config:recommended` to
+  match this repo's sentence-case commit style.
+- `timezone: "America/Chicago"` — anchors the weekly
+  `lockFileMaintenance` schedule inherited from
+  `:maintainLockFilesWeekly`.
+
+Plus a single `packageRules` entry to cap
+`renovatebot/pre-commit-hooks` updates at bi-monthly (`1,15`) — Renovate
+releases multiple times per week, so without throttling we'd get a
+hook-bump PR every few days. The rule clears `minimumReleaseAge` so the
+3-day quarantine doesn't push releases past the schedule window.
 
 ### Turbo cache miss on workspace edits
 

--- a/README.md
+++ b/README.md
@@ -119,6 +119,25 @@ CD requires:
 - Repo variable `APP_ID` and repo secret `APP_PRIVATE_KEY` from the App
 - `@changesets/cli` as a devDependency
 
+## Renovate preset
+
+The repo publishes a shareable Renovate config as `default.json`.
+Extend it from a consuming repo's Renovate config
+(e.g., `.github/renovate.json`):
+
+```json
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>gtbuchanan/tooling"]
+}
+```
+
+This pulls in `config:recommended` plus a small set of repo-wide
+opinions: 3-day release-age quarantine, OSV vulnerability alerts,
+`pnpm dedupe` after updates, verified-commit platform API, pre-commit
+manager enabled, and `America/Chicago` timezone for the weekly
+lockfile maintenance schedule.
+
 ## Consumer setup
 
 Run `gtb sync` to generate `turbo.json`, tsconfigs, per-package scripts,

--- a/default.json
+++ b/default.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": [
+    "Shared Renovate config for @gtbuchanan repositories"
+  ],
+  "extends": [
+    "config:recommended"
+  ],
+  "labels": [
+    "dependencies"
+  ],
+  "minimumReleaseAge": "3 days",
+  "osvVulnerabilityAlerts": true,
+  "packageRules": [
+    {
+      "description": "Restrict noisy pre-commit hook updates to bi-monthly",
+      "matchSourceUrls": [
+        "https://github.com/renovatebot/pre-commit-hooks"
+      ],
+      "minimumReleaseAge": "",
+      "schedule": [
+        "* * 1,15 * *"
+      ]
+    }
+  ],
+  "platformCommit": "enabled",
+  "postUpdateOptions": [
+    "pnpmDedupe"
+  ],
+  "pre-commit": {
+    "enabled": true
+  },
+  "rebaseWhen": "conflicted",
+  "semanticCommits": "disabled",
+  "timezone": "America/Chicago"
+}


### PR DESCRIPTION
## Summary

- Ships `default.json` at the repo root as a shareable Renovate preset, consumed elsewhere via `extends: ["github>gtbuchanan/tooling"]`. Extends `config:recommended` and overrides defaults for: `labels`, `minimumReleaseAge` (3-day supply-chain quarantine), `osvVulnerabilityAlerts`, `platformCommit` (verified-commit GitHub App API), `postUpdateOptions: ["pnpmDedupe"]`, `pre-commit` manager enabled, `rebaseWhen: "conflicted"`, `semanticCommits: "disabled"` (overrides `:semanticPrefixFixDepsChoreOthers` from `config:recommended` to match this repo's sentence-case commit style), and `America/Chicago` timezone for the inherited weekly `lockFileMaintenance` schedule.
- Adds `.github/renovate.json` so this repo dogfoods its own preset.
- Adds a single `packageRules` entry capping `renovatebot/pre-commit-hooks` updates at bi-monthly (`* * 1,15 * *`) with `minimumReleaseAge: ""` so the 3-day global quarantine doesn't push releases past the schedule window — Renovate releases multiple times per week and would otherwise dominate the PR queue.
- Wires the official `renovate-config-validator` pre-commit hook (from `renovatebot/pre-commit-hooks@43.150.0`) into `.pre-commit-config.yaml`. Two entries: one with `files: ^default\.json$` for the preset (the hook's default regex doesn't match `default.json`), and one with the default pattern for `renovate.json` variants.
- Documents the preset in `AGENTS.md` (structure tree + new `### Renovate preset` subsection in Architecture with rationale per override) and `README.md` (new `## Renovate preset` section with the consumer extends example).

## Test plan

- [x] `default.json` and `.github/renovate.json` parse as valid JSON
- [x] `pnpm exec prek run renovate-config-validator --files default.json .github/renovate.json` passes (both hook entries)
- [x] Pre-commit hooks ran and passed during commit (dogfooded the new validator)
- [ ] Renovate Mend bot picks up `.github/renovate.json` on next run and opens the onboarding PR / dependency dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)