### PR TITLE
Fix invalid empty minimumReleaseAge in Renovate preset

### DIFF
--- a/default.json
+++ b/default.json
@@ -17,7 +17,7 @@
       "matchSourceUrls": [
         "https://github.com/renovatebot/pre-commit-hooks"
       ],
-      "minimumReleaseAge": "",
+      "minimumReleaseAge": "0 days",
       "schedule": [
         "* * 1,15 * *"
       ]


### PR DESCRIPTION
## Summary

- The `packageRules` entry throttling `renovatebot/pre-commit-hooks` updates in `default.json` set `minimumReleaseAge: ""` to clear the inherited 3-day global quarantine. The [`ms`](https://github.com/vercel/ms) parser rejects empty strings as invalid time specifiers, so Renovate logs `Invalid time specifier: ''` at DEBUG and silently falls back to the parent value — defeating the rule.
- Replaces `""` with `"0 days"` (valid zero-duration) so the override actually takes effect.
- Without this fix, a release on day 13 would not be eligible until day 16, slipping past the 15th schedule window and waiting until the next 1st — a 16-day delay instead of the intended 3-day floor cleared away.

## Test plan

- [x] `mise exec -- prek run renovate-config-validator --files default.json` passes
- [ ] Next Renovate run logs no `Invalid time specifier` DEBUG message against `default.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)