### PR TITLE
Upgrade pnpm to 11.4.0

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -33,36 +33,38 @@ checksum = "sha256:edaca9bd58ec8e92037dac4e877d52f6b8f430b81c18b57e264b4e2fb111c
 url = "https://nodejs.org/dist/v24.16.0/node-v24.16.0-win-x64.zip"
 
 [[tools.pnpm]]
-version = "10.32.1"
+version = "11.4.0"
 backend = "aqua:pnpm/pnpm"
 
 [tools.pnpm."platforms.linux-arm64"]
-checksum = "sha256:c0db0b837971fde6f9781af8914e54eb163721193a36d35cbcf1794b3474a407"
-url = "https://github.com/pnpm/pnpm/releases/download/v10.32.1/pnpm-linux-arm64"
+checksum = "sha256:cc38ebd5b2610a5744f84576b963c49e6609a8df5aed714ae3de749998d4478c"
+url = "https://github.com/pnpm/pnpm/releases/download/v11.4.0/pnpm-linux-arm64.tar.gz"
+provenance = "github-attestations"
 
 [tools.pnpm."platforms.linux-arm64-musl"]
-checksum = "sha256:c0db0b837971fde6f9781af8914e54eb163721193a36d35cbcf1794b3474a407"
-url = "https://github.com/pnpm/pnpm/releases/download/v10.32.1/pnpm-linux-arm64"
+checksum = "sha256:a1e2ec9123c709fd04b704227cfcf3b50cd2bbbc1bd39d2df414530b5697eb75"
+url = "https://github.com/pnpm/pnpm/releases/download/v11.4.0/pnpm-linux-arm64-musl.tar.gz"
+provenance = "github-attestations"
 
 [tools.pnpm."platforms.linux-x64"]
-checksum = "sha256:c5607a86bfb948297e96b393a53c90107766fe56329e62967b1f239d861d4363"
-url = "https://github.com/pnpm/pnpm/releases/download/v10.32.1/pnpm-linux-x64"
+checksum = "sha256:f3f8d1217eef013bbc71a24d52efb1f1041e4aff55edd80e0b08e25f409305a4"
+url = "https://github.com/pnpm/pnpm/releases/download/v11.4.0/pnpm-linux-x64.tar.gz"
+provenance = "github-attestations"
 
 [tools.pnpm."platforms.linux-x64-musl"]
-checksum = "sha256:c5607a86bfb948297e96b393a53c90107766fe56329e62967b1f239d861d4363"
-url = "https://github.com/pnpm/pnpm/releases/download/v10.32.1/pnpm-linux-x64"
+checksum = "sha256:60010ad00a96b71e20d1618acaca7a71395e710cbd5e88946c030a1d07c56916"
+url = "https://github.com/pnpm/pnpm/releases/download/v11.4.0/pnpm-linux-x64-musl.tar.gz"
+provenance = "github-attestations"
 
 [tools.pnpm."platforms.macos-arm64"]
-checksum = "sha256:b0904b4e0cf36704fcdc24bcdb5f03388799a631510d1fb0d459ea69c7b1e2d9"
-url = "https://github.com/pnpm/pnpm/releases/download/v10.32.1/pnpm-macos-arm64"
-
-[tools.pnpm."platforms.macos-x64"]
-checksum = "sha256:8b83277343bbc400fdb90608bd51b4f56e380e6624ac5fd0e11d6c08815e3f04"
-url = "https://github.com/pnpm/pnpm/releases/download/v10.32.1/pnpm-macos-x64"
+checksum = "sha256:ba59014c2c1ce8b76af9f559385206a2623de4ff2b694b5c91598a8f44abb4e2"
+url = "https://github.com/pnpm/pnpm/releases/download/v11.4.0/pnpm-darwin-arm64.tar.gz"
+provenance = "github-attestations"
 
 [tools.pnpm."platforms.windows-x64"]
-checksum = "sha256:849141504c83bcd08a3d84dc20d43cff2584d672138d28c33ad62bdac809e7f2"
-url = "https://github.com/pnpm/pnpm/releases/download/v10.32.1/pnpm-win-x64.exe"
+checksum = "sha256:84ce90e38bc0b1164173eb853a0fbffc7edcb050cb0d5c8ce4ca609f5c808e0a"
+url = "https://github.com/pnpm/pnpm/releases/download/v11.4.0/pnpm-win32-x64.zip"
+provenance = "github-attestations"
 
 [[tools.prek]]
 version = "0.4.2"

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   },
   "packageManager": "pnpm@11.4.0",
   "engines": {
-    "node": ">=24.0.0"
+    "node": ">=24.0.0",
+    "pnpm": ">=11.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "valibot": "catalog:",
     "vitest": "catalog:"
   },
-  "packageManager": "pnpm@10.32.1",
+  "packageManager": "pnpm@11.4.0",
   "engines": {
     "node": ">=24.0.0"
   }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,7 @@
+allowBuilds:
+  esbuild: true
+  unrs-resolver: false
+
 catalog:
   '@changesets/cli': ^2.29.4
   '@eslint-community/eslint-plugin-eslint-comments': 4.7.1
@@ -48,9 +52,6 @@ catalog:
 hoist: false
 
 lockfileIncludeTarballUrl: false
-
-onlyBuiltDependencies:
-  - esbuild
 
 packages:
   - 'packages/*'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -49,6 +49,8 @@ catalog:
   vitest: ^4.1.2
   yaml: ^2.8.3
 
+engineStrict: true
+
 hoist: false
 
 lockfileIncludeTarballUrl: false


### PR DESCRIPTION
## Summary

- Bump `packageManager` from `pnpm@10.32.1` to `pnpm@11.4.0`.
- Migrate `pnpm-workspace.yaml` from the removed `onlyBuiltDependencies` / `ignoredBuiltDependencies` settings to the unified `allowBuilds` map (`esbuild: true`, `unrs-resolver: false`).
- Refresh `mise.lock` for pnpm 11.4.0 (upstream dropped `pnpm-macos-x64`; Windows asset renamed to `pnpm-win32-x64.zip`).
- Enable `engineStrict: true` and add `engines.pnpm: ">=11.0.0"` so installs reject packages (or hosts) incompatible with the workspace's Node (>=24.0.0) or pnpm versions.

## Test plan

- [x] CI passes (Build, E2E, Codecov, Changeset, Config Check, Pre-Commit)
- [x] `mise run bootstrap` on Linux (CI) and Windows (local)
- [ ] `mise run bootstrap` on macOS
- [x] `pnpm build` aggregate (incl. `test:slow` + `test:e2e`) clean on pnpm 11 — Windows local