### PR TITLE
Pin import-x node resolver via resolver-next

### DIFF
--- a/packages/eslint-config/src/plugins/import-x.ts
+++ b/packages/eslint-config/src/plugins/import-x.ts
@@ -1,5 +1,5 @@
 import type { Linter } from 'eslint';
-import importPlugin from 'eslint-plugin-import-x';
+import importPlugin, { createNodeResolver } from 'eslint-plugin-import-x';
 import { scriptFiles } from '../files.ts';
 import type { PluginFactory } from '../index.ts';
 
@@ -23,6 +23,11 @@ const importConfig: Linter.Config = {
       },
     ],
   },
+  /*
+   * Pin the bundled node resolver so we don't depend on the optional peer
+   * `eslint-import-resolver-node` being kept in the install graph by pnpm.
+   */
+  settings: { 'import-x/resolver-next': [createNodeResolver()] },
 };
 
 const plugin: PluginFactory = () => [importConfig];


### PR DESCRIPTION
## Summary

- `eslint-plugin-import-x` declares `eslint-import-resolver-node` as an optional peer, so pnpm only kept it in the install graph opportunistically. When Renovate re-resolved the lockfile on unrelated dep bumps, the resolver got pruned — and `import-x/order` fell through to the legacy fallback, warning `node with invalid interface loaded as resolver` on every script file. `--max-warnings=0` then failed Build on #97, #100, and #103.
- Configure `settings['import-x/resolver-next']` with the bundled `createNodeResolver()` (re-exported by `eslint-plugin-import-x` itself, backed by the same `unrs-resolver` the legacy path delegates to anyway). The rule no longer depends on the optional peer being installed.

## Test plan

- [x] `pnpm build --concurrency=1` — 63/63 turbo tasks pass locally
- [x] `pnpm -C packages/tsconfig run lint:eslint` — clean (this was the package that surfaced the warnings in CI)
- [x] `pnpm -C packages/eslint-config run test:vitest:fast` — 23/23 pass
- [ ] Rebase #97, #100, #103 after merge and confirm Build passes