### PR TITLE
Add dependency review workflow

### DIFF
--- a/.github/dependency-review-config.yml
+++ b/.github/dependency-review-config.yml
@@ -1,0 +1,14 @@
+---
+# Permissive OSS licenses accepted for direct + transitive dependencies.
+# SPDX identifiers — see https://spdx.org/licenses/.
+# Add new entries with care; license terms vary materially.
+allow-licenses:
+  - 0BSD
+  - Apache-2.0
+  - BlueOak-1.0.0
+  - BSD-2-Clause
+  - BSD-3-Clause
+  - CC0-1.0
+  - ISC
+  - MIT
+  - Unlicense

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -17,6 +17,98 @@ jobs:
           config-file: ${{ inputs.config-file || '.github/dependency-review-config.yml' }}
           fail-on-severity: ${{ inputs.fail-on-severity || 'moderate' }}
 
+  version-check:
+    name: Version Check
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        name: Check newly-added deps are at latest version
+        run: |
+          set -euo pipefail
+
+          if [ -z "${BASE_SHA:-}" ] || [ -z "${HEAD_SHA:-}" ]; then
+            echo "::warning::No PR context; skipping version check."
+            exit 0
+          fi
+
+          added=$(gh api \
+            "/repos/${GITHUB_REPOSITORY}/dependency-graph/compare/${BASE_SHA}...${HEAD_SHA}" \
+            --jq '[.[] | select(.change_type == "added")]')
+
+          count=$(jq 'length' <<<"$added")
+          if [ "$count" -eq 0 ]; then
+            echo "No new dependencies added."
+            exit 0
+          fi
+
+          echo "Checking $count newly-added dependencies..."
+
+          stale=0
+          while IFS=$'\t' read -r ecosystem name version; do
+            case "$ecosystem" in
+              actions)
+                # SHA pins are intentional immutable pinning.
+                if [[ "$version" =~ ^[a-f0-9]{40}$ ]]; then
+                  echo "OK  $ecosystem:$name@$version (SHA pin)"
+                  continue
+                fi
+                # Strip any sub-action path (actions/cache/save → actions/cache).
+                repo=$(awk -F/ '{print $1"/"$2}' <<<"$name")
+                latest=$(gh api "repos/${repo}/releases/latest" --jq '.tag_name' 2>/dev/null) || latest=""
+                ;;
+              npm|pip|maven|nuget|rubygems|go|cargo)
+                case "$ecosystem" in
+                  pip) system=pypi ;;
+                  *)   system=$ecosystem ;;
+                esac
+                encoded=$(jq -nr --arg n "$name" '$n | @uri')
+                latest=$(
+                  curl -sf "https://api.deps.dev/v3/systems/${system}/packages/${encoded}" \
+                    | jq -r '.versions | map(select(.isDefault == true)) | .[0].versionKey.version // empty'
+                ) || latest=""
+                ;;
+              *)
+                echo "::warning::Skipping $ecosystem:$name (unsupported ecosystem)"
+                continue
+                ;;
+            esac
+
+            if [ -z "$latest" ]; then
+              echo "::warning::Could not resolve latest version for $ecosystem:$name"
+              continue
+            fi
+
+            # GitHub's dep-graph normalizes major/minor tags to semver
+            # wildcards (e.g. `@v6` -> `6.*.*`, `@v6.0` -> `6.0.*`).
+            # Strip leading 'v' from latest, drop the wildcard suffix
+            # from pinned, and accept any latest that matches the
+            # constrained prefix.
+            norm_v=${version#v}
+            norm_l=${latest#v}
+            constrained=${norm_v%%[*]*}
+            constrained=${constrained%.}
+            if [ "$norm_v" = "$norm_l" ] \
+              || { [[ "$constrained" =~ ^[0-9]+(\.[0-9]+)*$ ]] \
+                   && { [ "$constrained" = "$norm_l" ] || [[ "$norm_l" == "$constrained".* ]]; }; }; then
+              echo "OK  $ecosystem:$name@$version (latest $latest)"
+            else
+              echo "::error title=Stale dependency::$ecosystem:$name pinned to $version, latest is $latest"
+              stale=$((stale + 1))
+            fi
+          done < <(jq -r '.[] | [.ecosystem, .name, .version] | @tsv' <<<"$added")
+
+          if [ "$stale" -gt 0 ]; then
+            echo
+            echo "::error::$stale newly-added dependencies are not at their latest version."
+            exit 1
+          fi
+        shell: bash
+
 name: Dependency Review
 
 on:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,51 @@
+---
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  review:
+    name: Dependency Review
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      # workflow_call input defaults don't apply on pull_request
+      # events, so this repo's own PRs need explicit fallbacks.
+      - uses: actions/dependency-review-action@v5
+        with:
+          comment-summary-in-pr: ${{ inputs.comment-summary-in-pr || 'on-failure' }}
+          config-file: ${{ inputs.config-file || '.github/dependency-review-config.yml' }}
+          fail-on-severity: ${{ inputs.fail-on-severity || 'moderate' }}
+
+name: Dependency Review
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_call:
+    inputs:
+      comment-summary-in-pr:
+        default: on-failure
+        description: >-
+          When to post a PR summary comment
+          (always, never, on-failure).
+        type: string
+      config-file:
+        default: gtbuchanan/tooling/.github/dependency-review-config.yml@main
+        description: >-
+          Dependency-review config file. Either a path in
+          the calling repo or `<owner>/<repo>/<path>@<ref>`
+          for a remote file. Defaults to this repo's
+          shared license policy.
+        required: false
+        type: string
+      fail-on-severity:
+        default: moderate
+        description: >-
+          Minimum advisory severity that fails the check
+          (low, moderate, high, critical).
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: write

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,14 +126,21 @@ backed by `gtb` leaf commands. `ci.yml` also accepts workflow inputs
   (npm trusted publishing via OIDC). Publish uses `turbo-run` for pack.
 - **`changeset-check.yml`** — Verifies a changeset exists on every PR.
   Use `pnpm changeset --empty` for PRs that don't need a version bump.
-- **`dependency-review.yml`** — Scans PR dep changes with
-  `actions/dependency-review-action`. Fails on advisories at
-  `fail-on-severity` (default `moderate`) and on non-permissive
-  licenses per `.github/dependency-review-config.yml`. Consumer
-  wrappers inherit the shared license policy by default — the
-  `config-file` input defaults to a remote ref pointing at this
-  repo's config. Posts a PR summary comment on failure; the caller
-  must grant `pull-requests: write`.
+- **`dependency-review.yml`** — Two PR gates on newly-changed deps.
+  `review` runs `actions/dependency-review-action` (fails on
+  advisories at `fail-on-severity`, default `moderate`, and on
+  non-permissive licenses per `.github/dependency-review-config.yml`).
+  `version-check` fails if any newly-added dep isn't at its latest
+  version. Resolves the change set via GitHub's dep-graph compare
+  API; looks up latest via deps.dev (npm, pip, maven, nuget,
+  rubygems, go, cargo) or GitHub Releases (Actions). Consumer wrappers inherit the shared license
+  policy by default — the `config-file` input defaults to a remote
+  ref pointing at this repo's config. Posts a PR summary comment on
+  failure; caller must grant `pull-requests: write`. Both jobs
+  require GitHub's Dependency Graph enabled; coverage is limited to
+  ecosystems it indexes (npm + Actions here), so mise tools and
+  `.pre-commit-config.yaml` hooks aren't covered — Renovate's
+  managers handle those independently.
 - **`pre-commit.yml`** — Runs prek hooks against PR changed files.
 - **`pre-commit-seed.yml`** — Warms the prek hook environment cache so
   PR builds get cache hits.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,13 +16,15 @@ mise.toml              — Pin Node, pnpm, prek versions for local + CI
     pnpm-resolve-pinned/ — Composite action: resolve locked version without install
     pnpm-tasks/          — Composite action: cache pnpm store, install deps
     turbo-run/           — Composite action: run turbo task, skip install on cache hit
-  renovate.json        — Repo-local Renovate config (extends the shared preset)
+  dependency-review-config.yml — License allowlist for dependency-review.yml
+  renovate.json                — Repo-local Renovate config (extends the shared preset)
   workflows/
-    cd.yml               — Calls CI, then version + publish on main
-    changeset-check.yml  — Verify changeset exists on PR
-    ci.yml               — Build + slow + e2e + coverage (PR + reusable)
-    pre-commit.yml       — Run prek hooks on PR changed files
-    pre-commit-seed.yml  — Seed prek cache on push to main
+    cd.yml                 — Calls CI, then version + publish on main
+    changeset-check.yml    — Verify changeset exists on PR
+    ci.yml                 — Build + slow + e2e + coverage (PR + reusable)
+    dependency-review.yml  — Scan PR dep changes (vulns + licenses)
+    pre-commit.yml         — Run prek hooks on PR changed files
+    pre-commit-seed.yml    — Seed prek cache on push to main
 packages/
   cli/                          — @gtbuchanan/cli (gtb build CLI for consumers)
     skills/                     — Authored Agent Skills deployed by `gtb task deploy:skills`
@@ -124,6 +126,14 @@ backed by `gtb` leaf commands. `ci.yml` also accepts workflow inputs
   (npm trusted publishing via OIDC). Publish uses `turbo-run` for pack.
 - **`changeset-check.yml`** — Verifies a changeset exists on every PR.
   Use `pnpm changeset --empty` for PRs that don't need a version bump.
+- **`dependency-review.yml`** — Scans PR dep changes with
+  `actions/dependency-review-action`. Fails on advisories at
+  `fail-on-severity` (default `moderate`) and on non-permissive
+  licenses per `.github/dependency-review-config.yml`. Consumer
+  wrappers inherit the shared license policy by default — the
+  `config-file` input defaults to a remote ref pointing at this
+  repo's config. Posts a PR summary comment on failure; the caller
+  must grant `pull-requests: write`.
 - **`pre-commit.yml`** — Runs prek hooks against PR changed files.
 - **`pre-commit-seed.yml`** — Warms the prek hook environment cache so
   PR builds get cache hits.

--- a/README.md
+++ b/README.md
@@ -34,13 +34,14 @@ jobs:
 Each workflow follows this same pattern — only the filename and trigger
 differ:
 
-| Workflow              | Trigger      | Description                              |
-| --------------------- | ------------ | ---------------------------------------- |
-| `ci.yml`              | PR           | Build + e2e + optional slow tests        |
-| `cd.yml`              | Push to main | CI + changesets version + publish (OIDC) |
-| `changeset-check.yml` | PR           | Verify changeset exists                  |
-| `pre-commit.yml`      | PR           | Run prek hooks on changed files          |
-| `pre-commit-seed.yml` | Push to main | Warm prek cache for PR builds            |
+| Workflow                | Trigger      | Description                              |
+| ----------------------- | ------------ | ---------------------------------------- |
+| `ci.yml`                | PR           | Build + e2e + optional slow tests        |
+| `cd.yml`                | Push to main | CI + changesets version + publish (OIDC) |
+| `changeset-check.yml`   | PR           | Verify changeset exists                  |
+| `dependency-review.yml` | PR           | Scan PR dep changes for vulns + licenses |
+| `pre-commit.yml`        | PR           | Run prek hooks on changed files          |
+| `pre-commit-seed.yml`   | Push to main | Warm prek cache for PR builds            |
 
 ### Coverage
 
@@ -79,6 +80,43 @@ and consumers can replace script values to customize individual tools.
 `ci.yml` also accepts workflow inputs (`run-e2e`, `run-slow-tests`) for
 toggling test tiers. See the [CLI package](packages/cli) for available
 commands.
+
+### Dependency review
+
+`dependency-review.yml` scans PR dependency changes via
+[`actions/dependency-review-action`](https://github.com/actions/dependency-review-action).
+It fails on advisories at `moderate` severity or higher and on
+non-permissive licenses per this repo's shared policy
+(`.github/dependency-review-config.yml`). Consumer wrappers inherit
+the shared license policy automatically — the `config-file` input
+defaults to a remote ref pointing at this repo's config.
+
+A failure summary is posted as a PR comment, so callers must grant
+`pull-requests: write`:
+
+```yaml
+jobs:
+  dependency-review:
+    permissions:
+      contents: read
+      pull-requests: write
+    uses: gtbuchanan/tooling/.github/workflows/dependency-review.yml@main
+```
+
+Override defaults — e.g. a repo-local license policy or a stricter
+severity threshold — via workflow inputs:
+
+```yaml
+jobs:
+  dependency-review:
+    permissions:
+      contents: read
+      pull-requests: write
+    uses: gtbuchanan/tooling/.github/workflows/dependency-review.yml@main
+    with:
+      config-file: .github/dependency-review-config.yml
+      fail-on-severity: low
+```
 
 ### Build pipeline conventions
 

--- a/README.md
+++ b/README.md
@@ -83,13 +83,28 @@ commands.
 
 ### Dependency review
 
-`dependency-review.yml` scans PR dependency changes via
-[`actions/dependency-review-action`](https://github.com/actions/dependency-review-action).
-It fails on advisories at `moderate` severity or higher and on
-non-permissive licenses per this repo's shared policy
-(`.github/dependency-review-config.yml`). Consumer wrappers inherit
-the shared license policy automatically — the `config-file` input
-defaults to a remote ref pointing at this repo's config.
+`dependency-review.yml` runs two PR-time gates on newly-changed
+dependencies:
+
+- **Review** —
+  [`actions/dependency-review-action`](https://github.com/actions/dependency-review-action)
+  fails on advisories at `moderate` severity or higher and on
+  non-permissive licenses per this repo's shared policy
+  (`.github/dependency-review-config.yml`). Consumer wrappers inherit
+  the shared policy automatically — the `config-file` input defaults
+  to a remote ref pointing at this repo's config.
+- **Version check** — fails if any newly-added dep isn't at its
+  latest version. Resolves the change set via GitHub's
+  dependency-graph compare API; looks up latest versions via deps.dev
+  (npm, pip, maven, nuget, rubygems, go, cargo) and GitHub Releases
+  (Actions). SHA-pinned Actions are accepted as intentional.
+
+Both jobs require GitHub's Dependency Graph to be enabled at
+_Settings → Code security and analysis_. Coverage is limited to
+ecosystems the dep graph indexes — for JS/TS projects, that's npm and
+GitHub Actions. mise tools and `.pre-commit-config.yaml` hooks aren't
+covered; Renovate's managers handle those independently on their
+normal cadence.
 
 A failure summary is posted as a PR comment, so callers must grant
 `pull-requests: write`:


### PR DESCRIPTION
## Summary

Adds `dependency-review.yml` — a reusable workflow with two PR-time gates against newly-changed dependencies.

- **`review` job** — runs `actions/dependency-review-action`, fails on advisories at `moderate` or higher and on non-permissive licenses per `.github/dependency-review-config.yml`. Ships the config as a shared license allowlist (0BSD, Apache-2.0, BlueOak-1.0.0, BSD-2/3-Clause, CC0-1.0, ISC, MIT, Unlicense); consumer wrappers inherit it automatically via the `config-file` input's remote-ref default.
- **`version-check` job** — fails if any newly-added dep isn't at its latest version. Resolves the change set via GitHub's dependency-graph compare API; looks up latest versions via deps.dev (npm, pip, maven, nuget, rubygems, go, cargo) and GitHub Releases (Actions). Handles `@v6` → `6.*.*` wildcard ranges that dep-graph emits for major/minor tags. SHA-pinned Actions are accepted as intentional immutable pinning.

Both jobs require GitHub's **Dependency Graph** enabled (*Settings → Code security and analysis*). Coverage is limited to ecosystems the dep graph indexes — npm + GitHub Actions for JS/TS projects. mise tools and `.pre-commit-config.yaml` hooks aren't covered; Renovate's managers handle those independently.

Not wired into branch protection. Status checks show distinct red ✗ on failure; consumers opt into "required" per repo.

### Known limitation: "Unknown License" warnings on GitHub Actions

The dep-review action's summary will list GitHub Actions deps as `⚠️ Unknown License` because the dep graph doesn't expose license metadata for Action repos. These are informational only — they don't fail the check. The noise only appears in PR comments when the check is already failing for another reason (`comment-summary-in-pr: on-failure`). Source code review confirmed there's no config flag to globally accept null licenses; suppression would require an explicit `allow-dependencies-licenses` allowlist of every Action by PURL (no wildcards supported). Accepting the noise.

## Test plan

- [x] `Dependency Review` job runs and passes (no vulnerable deps, no disallowed licenses)
- [x] `Version Check` job runs and passes — dep-graph reported 2 added entries (`actions/checkout`, `actions/dependency-review-action`) from the new manifest; both validated against GitHub Releases as latest
- [x] Both jobs surfaced as separate status checks
- [x] `Changeset` check passes (no package source files modified, so `changesets status` exits 0 without a changeset file)
- [x] Manual stale-dep verification — temporary commit added `lodash@4.17.20` (latest 4.18.1 per deps.dev) and was reverted after confirming `Version Check` failed with `::error title=Stale dependency::npm:lodash pinned to 4.17.20, latest is 4.18.1` and exit code 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)