### PR TITLE
Add 3-day minimum release age to pnpm and mise

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -4,6 +4,10 @@
 # Keeps the pnpm pin in one place instead of mirroring it in mise.toml.
 idiomatic_version_file_enable_tools = ["pnpm"]
 lockfile = true
+# Matches the Renovate/pnpm 3-day quarantine. Only filters fuzzy/`latest`
+# resolution (e.g. manual `mise up --bump`); install of the exact pins
+# below bypasses it, and Renovate already gates automated bumps at 3 days.
+minimum_release_age = "3d"
 
 [tools]
 node = "24.16.0"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -55,6 +55,8 @@ hoist: false
 
 lockfileIncludeTarballUrl: false
 
+# 4320 minutes = 3 days, matching the shared Renovate preset's quarantine.
+minimumReleaseAge: 4320
 minimumReleaseAgeExclude:
   - '@gtbuchanan/*'
 


### PR DESCRIPTION
## Summary

Adds a 3-day minimum release age at the package-manager and tool-manager layers so newly published versions sit in quarantine before they can be installed, matching the shared Renovate preset''s existing `minimumReleaseAge: "3 days"`. Layered defense: Renovate gates *direct-dep update PRs*, while pnpm gates the *entire transitive tree* at install/resolution time.

- **pnpm** (`pnpm-workspace.yaml`): `minimumReleaseAge: 4320` (3 days, in minutes), extending pnpm 11''s 1-day default. The pre-existing `minimumReleaseAgeExclude: ['"'"'@gtbuchanan/*'"'"']` mirrors the preset''s own-package carve-out.
- **mise** (`mise.toml`): `minimum_release_age = "3d"`. Only filters fuzzy/`latest` resolution (e.g. a manual `mise up --bump`); installs of the exact pins are unaffected, and Renovate already gates automated tool bumps at 3 days. Included mainly for parity/intent.

## Transient CI

The lockfile is intentionally left unchanged. Tightening pnpm to 3 days means any transitive dep published within the last 3 days fails the install-time check until it ages out — currently `tinyglobby@0.2.17` (published 2026-05-30 19:54 UTC), which clears the window at **2026-06-02 19:54 UTC**. The `ci` job will be red until then, after which it passes with no lockfile changes needed. `dependency-review` is unaffected (no dependency diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
