### PR TITLE
Allow CC-BY/Python-2.0 licenses, waive lightningcss MPL

### DIFF
--- a/.github/dependency-review-config.yml
+++ b/.github/dependency-review-config.yml
@@ -1,4 +1,20 @@
 ---
+allow-dependencies-licenses:
+  # lightningcss MPL-2.0 (dev-only build tool): excluded by name rather
+  # than allow-listing MPL globally, so future MPL deps still get gated.
+  # All platform binaries enumerated (no wildcard support).
+  - pkg:npm/lightningcss
+  - pkg:npm/lightningcss-android-arm64
+  - pkg:npm/lightningcss-darwin-arm64
+  - pkg:npm/lightningcss-darwin-x64
+  - pkg:npm/lightningcss-freebsd-x64
+  - pkg:npm/lightningcss-linux-arm-gnueabihf
+  - pkg:npm/lightningcss-linux-arm64-gnu
+  - pkg:npm/lightningcss-linux-arm64-musl
+  - pkg:npm/lightningcss-linux-x64-gnu
+  - pkg:npm/lightningcss-linux-x64-musl
+  - pkg:npm/lightningcss-win32-arm64-msvc
+  - pkg:npm/lightningcss-win32-x64-msvc
 # Permissive OSS licenses accepted for direct + transitive dependencies.
 # SPDX identifiers — see https://spdx.org/licenses/.
 # Add new entries with care; license terms vary materially.
@@ -8,7 +24,12 @@ allow-licenses:
   - BlueOak-1.0.0
   - BSD-2-Clause
   - BSD-3-Clause
+  # Attribution-only data licenses (no copyleft, no share-alike).
+  - CC-BY-3.0
+  - CC-BY-4.0
   - CC0-1.0
   - ISC
   - MIT
+  # BSD-class permissive (CPython's license).
+  - Python-2.0
   - Unlicense


### PR DESCRIPTION
## Summary

Audited the license of every installed dependency against the shared dependency-review allowlist (`.github/dependency-review-config.yml`) and reconciled the gaps. All flagged packages are dev-only transitive dependencies — none ship in published runtime artifacts.

### `allow-licenses` additions

| License | Class | Seen via (dev-only transitive) |
|---|---|---|
| `CC-BY-3.0` | Attribution-only data license, no copyleft | `spdx-exceptions` |
| `CC-BY-4.0` | Attribution-only data license, no copyleft | `caniuse-lite` |
| `Python-2.0` | BSD-class permissive (CPython's license) | `argparse` |

### `allow-dependencies-licenses` (new section)

`lightningcss` is **MPL-2.0** (file-level copyleft), pulled transitively through vite/vitest as a dev-only build tool. Rather than allow-listing MPL-2.0 globally — which would silently pass any *future* MPL dependency, including a runtime one — it's waived by name. This preserves the CI gate for other MPL deps. All 11 platform binaries are enumerated since the action has no wildcard support.

### Not changed

- `spawndamnit` reports as `Unknown` only because it declares `SEE LICENSE IN LICENSE`; its LICENSE file is MIT. No action needed.
- The compound `(MIT OR CC0-1.0)` entries already pass — both disjuncts are allowed.

## Scope note

This is the shared policy file. Consumers inherit it through the `config-file` default in the reusable `dependency-review.yml` workflow, so the license additions and the lightningcss waiver apply downstream too. That's intentional — consumers pull lightningcss through the same shared vitest/vite stack, so sharing the waiver avoids every consumer having to duplicate the exception.

## Note

No changeset included (CI-config-only change). `changeset-check` will fail unless an empty changeset is added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)