### PR TITLE
Support node-free repos in prek workflows

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,7 +19,11 @@ jobs:
 
   pre-commit:
     name: Pre-Commit
+    # This repo's eslint hook is `language: system` (pnpm exec eslint),
+    # so prek needs the project's deps installed.
     uses: ./.github/workflows/pre-commit.yml
+    with:
+      use-pnpm: true
 
 name: PR
 

--- a/.github/workflows/pre-commit-seed.yml
+++ b/.github/workflows/pre-commit-seed.yml
@@ -13,8 +13,6 @@ jobs:
 
       - uses: ./.github/actions/mise-setup
 
-      - uses: ./.github/actions/pnpm-tasks
-
       # mise.lock is in the cache key because prek bakes absolute Node
       # binary paths into its cached hook environments (j178/prek#1993);
       # a Node bump must invalidate the cache. The restore-keys
@@ -32,11 +30,11 @@ jobs:
             prek-${{ runner.os }}-${{ hashFiles('mise.lock') }}-
 
       - name: Install hook environments
-        run: pnpm exec prek prepare-hooks
+        run: prek prepare-hooks
 
       - if: steps.prek-cache.outputs.cache-hit != 'true'
         name: Prune stale environments
-        run: pnpm exec prek cache gc
+        run: prek cache gc
 
 name: Pre-Commit
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -17,7 +17,11 @@ jobs:
 
       - uses: ./.github/actions/mise-setup
 
-      - uses: ./.github/actions/pnpm-tasks
+      # The local eslint hook is `language: system` (entry `pnpm exec
+      # eslint`), so it needs node_modules. Node-free consumers set
+      # `use-pnpm: false` to skip this and run prek (from mise) alone.
+      - if: inputs.use-pnpm
+        uses: ./.github/actions/pnpm-tasks
 
       # mise.lock is in the cache key because prek bakes absolute Node
       # binary paths into its cached hook environments (j178/prek#1993);
@@ -37,7 +41,7 @@ jobs:
 
       - name: Run pre-commit hooks
         run: |
-          pnpm exec prek run \
+          prek run \
             --color=always \
             --show-diff-on-failure \
             --verbose \
@@ -46,12 +50,20 @@ jobs:
 
       - if: steps.prek-cache.outputs.cache-hit != 'true'
         name: Prune stale environments
-        run: pnpm exec prek cache gc
+        run: prek cache gc
 
 name: Pre-Commit
 
 on:
-  workflow_call: {}
+  workflow_call:
+    inputs:
+      use-pnpm:
+        default: false
+        description: >-
+          Run `pnpm install` so prek hooks that shell out to the
+          project's pnpm deps (e.g. a `language: system` eslint hook)
+          can resolve them. Leave false when no hook needs them.
+        type: boolean
 
 permissions:
   contents: read

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,9 +210,14 @@ through `package.json` scripts backed by `gtb` leaf commands.
   ecosystems it indexes (npm + Actions here), so mise tools and
   `.pre-commit-config.yaml` hooks aren't covered — Renovate's
   managers handle those independently.
-- **`pre-commit.yml`** — Runs prek hooks against PR changed files.
-- **`pre-commit-seed.yml`** — Warms the prek hook environment cache so
-  PR builds get cache hits.
+- **`pre-commit.yml`** — Runs prek hooks against PR changed files via
+  bare `prek` (resolved from mise, no pnpm needed to invoke it). The
+  `use-pnpm` input (default `false`) opts into `pnpm install` for hooks
+  that shell out to the project's deps — this repo's `language: system`
+  eslint hook sets it `true`; everything else runs prek alone.
+- **`pre-commit-seed.yml`** — Warms the prek hook environment cache on
+  push so PR builds get cache hits. Uses only mise + bare prek
+  (`prepare-hooks`); each hook's env is isolated, so no `pnpm install`.
 
 Composite actions:
 


### PR DESCRIPTION
Makes the reusable pre-commit workflows usable by repos that install prek via mise with no Node toolchain. Follows up the workflow restructure in #135.

- **Bare `prek`** in `pre-commit.yml` and `pre-commit-seed.yml` instead of `pnpm exec prek` — mise puts prek on PATH, so pnpm isn't needed to invoke it.
- **`pre-commit.yml`** gains a **`use-pnpm`** input (default `false`) gating the `pnpm install` step. Installing the project's deps is the exception — only hooks that shell out to them need it — so it's opt-in. This repo's `pr.yml` sets `use-pnpm: true` because its eslint hook is `language: system` (`pnpm exec eslint`).
- **`pre-commit-seed.yml`** drops the `pnpm install` step entirely: `prek prepare-hooks` builds each hook's isolated environment and never touches the project's `node_modules`.

A node-free consumer can now call these workflows with only mise providing prek.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
