### PR TITLE
Fix Codecov upload targeting PR merge commit

### DIFF
--- a/packages/cli/src/commands/task/coverage-codecov-upload.ts
+++ b/packages/cli/src/commands/task/coverage-codecov-upload.ts
@@ -1,8 +1,17 @@
-import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { defineCommand } from 'citty';
 import { findUpSync } from 'find-up-simple';
+import * as v from 'valibot';
 import { run } from '../../lib/process.ts';
+
+const PullRequestEventSchema = v.object({
+  pull_request: v.object({
+    head: v.object({
+      sha: v.string(),
+    }),
+  }),
+});
 
 const mergedLcov = 'dist/coverage/vitest/merged/lcov.info';
 const fastLcov = 'dist/coverage/vitest/fast/lcov.info';
@@ -38,6 +47,37 @@ const resolveLcov = (): string | undefined => {
   return undefined;
 };
 
+/*
+ * On GitHub Actions `pull_request` events, GITHUB_SHA is the ephemeral
+ * merge commit (refs/pull/N/merge), not the PR head. The Codecov CLI
+ * defaults to that merge SHA, so its commit statuses land on a commit
+ * the PR never renders — no checks, no comment. Pull the real head SHA
+ * from the event payload and pass it via -C, mirroring what
+ * codecov/codecov-action does. See codecov/codecov-cli#474.
+ */
+const resolveCommitSha = (): string | undefined => {
+  const eventPath = process.env['GITHUB_EVENT_PATH'];
+  if (eventPath !== undefined && eventPath !== '' && existsSync(eventPath)) {
+    try {
+      const result = v.safeParse(
+        PullRequestEventSchema,
+        JSON.parse(readFileSync(eventPath, 'utf8')),
+      );
+      if (result.success) {
+        return result.output.pull_request.head.sha;
+      }
+    } catch {
+      /*
+       * Unreadable or non-JSON event payloads shouldn't fail the
+       * upload — fall through to GITHUB_SHA (push events land here too,
+       * where GITHUB_SHA is already the real commit).
+       */
+    }
+  }
+  const sha = process.env['GITHUB_SHA'];
+  return sha === undefined || sha === '' ? undefined : sha;
+};
+
 /** Uploads coverage to Codecov. No-ops outside CI. */
 export const coverageCodecovUpload = defineCommand({
   meta: {
@@ -56,11 +96,14 @@ export const coverageCodecovUpload = defineCommand({
       return;
     }
 
+    const sha = resolveCommitSha();
+
     await run('codecov', {
       args: [
         'upload-process',
         '--disable-search',
         '--network-root-folder', resolveNetworkRoot(),
+        ...(sha === undefined ? [] : ['-C', sha]),
         '-f', file,
         '-F', path.basename(process.cwd()),
         ...rawArgs,

--- a/packages/cli/test/coverage-codecov-upload.test.ts
+++ b/packages/cli/test/coverage-codecov-upload.test.ts
@@ -1,10 +1,22 @@
 import path from 'node:path';
+import { faker } from '@faker-js/faker';
 import { runCommand } from 'citty';
 import { describe, it, vi } from 'vitest';
 
 vi.mock(import('node:fs'), async (importOriginal) => {
   const actual = await importOriginal();
-  return { ...actual, existsSync: vi.fn<typeof actual.existsSync>(() => false) };
+  return {
+    ...actual,
+    existsSync: vi.fn<typeof actual.existsSync>(() => false),
+    mkdirSync: vi.fn<typeof actual.mkdirSync>(),
+    /*
+     * `typeof readFileSync` is too wide for one of its overloads under
+     * the strict typed factory; `() => never` is assignable to every
+     * overload. The real return is supplied per-test via mockReturnValue.
+     */
+    readFileSync: vi.fn<() => never>(),
+    writeFileSync: vi.fn<typeof actual.writeFileSync>(),
+  };
 });
 
 vi.mock(import('find-up-simple'), () => ({
@@ -16,13 +28,14 @@ vi.mock(import('#src/lib/process.js'), async (importOriginal) => {
   return { ...actual, run: vi.fn<typeof actual.run>() };
 });
 
-const { existsSync } = await import('node:fs');
+const { existsSync, readFileSync } = await import('node:fs');
 const { run } = await import('#src/lib/process.js');
 const { coverageCodecovUpload } = await import(
   '#src/commands/task/coverage-codecov-upload.js',
 );
 
 const mockExistsSync = vi.mocked(existsSync);
+const mockReadFileSync = vi.mocked(readFileSync);
 const mockRun = vi.mocked(run);
 
 const getRunArgs = (): readonly string[] => {
@@ -119,5 +132,45 @@ describe('coverage:codecov:upload', () => {
 
     expect(getRunArgs()).toContain('--verbose');
     expect(getRunArgs()).toContain('--dry-run');
+  });
+
+  it('passes the PR head sha from the event payload', async ({ expect }) => {
+    vi.stubEnv('CI', 'true');
+    vi.stubEnv('GITHUB_EVENT_PATH', '/ci/event.json');
+    const headSha = faker.git.commitSha();
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify({ pull_request: { head: { sha: headSha } } }),
+    );
+
+    await invoke([]);
+
+    expect(getRunArgs()).toContain('-C');
+    expect(getRunArgs()).toContain(headSha);
+  });
+
+  it('falls back to GITHUB_SHA when not a pull request', async ({ expect }) => {
+    vi.stubEnv('CI', 'true');
+    vi.stubEnv('GITHUB_EVENT_PATH', '/ci/event.json');
+    const sha = faker.git.commitSha();
+    vi.stubEnv('GITHUB_SHA', sha);
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(JSON.stringify({ ref: 'refs/heads/main' }));
+
+    await invoke([]);
+
+    expect(getRunArgs()).toContain('-C');
+    expect(getRunArgs()).toContain(sha);
+  });
+
+  it('omits -C when no commit sha is resolvable', async ({ expect }) => {
+    vi.stubEnv('CI', 'true');
+    vi.stubEnv('GITHUB_EVENT_PATH', '');
+    vi.stubEnv('GITHUB_SHA', '');
+    mockExistsSync.mockReturnValue(true);
+
+    await invoke([]);
+
+    expect(getRunArgs()).not.toContain('-C');
   });
 });

--- a/packages/cli/test/coverage-codecov-upload.test.ts
+++ b/packages/cli/test/coverage-codecov-upload.test.ts
@@ -163,6 +163,24 @@ describe('coverage:codecov:upload', () => {
     expect(getRunArgs()).toContain(sha);
   });
 
+  it('falls back to GITHUB_SHA when the event payload is unreadable', async ({
+    expect,
+  }) => {
+    vi.stubEnv('CI', 'true');
+    vi.stubEnv('GITHUB_EVENT_PATH', '/ci/event.json');
+    const sha = faker.git.commitSha();
+    vi.stubEnv('GITHUB_SHA', sha);
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockImplementation(() => {
+      throw new Error('boom');
+    });
+
+    await invoke([]);
+
+    expect(getRunArgs()).toContain('-C');
+    expect(getRunArgs()).toContain(sha);
+  });
+
   it('omits -C when no commit sha is resolvable', async ({ expect }) => {
     vi.stubEnv('CI', 'true');
     vi.stubEnv('GITHUB_EVENT_PATH', '');


### PR DESCRIPTION
## Problem

Codecov posts no `codecov/project` / `codecov/patch` checks or coverage comment on PRs.

The `coverage:codecov:upload` task invokes the Codecov CLI bare, so on `pull_request` events the CLI falls back to `GITHUB_SHA` — the ephemeral `refs/pull/N/merge` commit `actions/checkout` synthesizes, **not** the PR head. Codecov attaches its commit statuses to that orphan merge commit, which GitHub never renders on the PR, so nothing shows up.

Verified on #138:

- PR head: `e321280`
- Codecov uploaded to `33964c0` = *"Merge e321280 into 8499276"* (the merge ref), which has `state: pending, statuses: []`
- `e321280` (what GitHub renders) had no Codecov statuses at all

## Fix

Resolve the real head SHA from `GITHUB_EVENT_PATH` (`pull_request.head.sha`, valibot-parsed), fall back to `GITHUB_SHA` for push events, and pass it to the CLI via `-C`. This mirrors what `codecov/codecov-action` injects and works around [codecov/codecov-cli#474](https://github.com/codecov/codecov-cli/pull/474) — **without** changing the checkout ref (per the `energyworldnet/js-gulp-recipe` precedent, which does the same `-C <head-sha>` override on Azure).

The SHA is read at runtime, so it is **not** a turbo input — the cache key is untouched. Cached (unchanged) packages still skip the upload, and Codecov flag `carryforward` fills them in against the now-correct head-commit report. The bug was precisely that the *fresh* uploads landed on the merge commit, leaving no head report for carryforward to attach to.

## Tests

Added coverage for: head SHA from the event payload, fallback to `GITHUB_SHA` on non-PR events, and `-C` omitted when nothing resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)