### PR TITLE
Fix reusable workflow action refs for consumers

### DIFF
--- a/.github/actions/turbo-run/action.yml
+++ b/.github/actions/turbo-run/action.yml
@@ -12,7 +12,7 @@ outputs:
 runs:
   steps:
     - id: turbo-version
-      uses: ./.github/actions/pnpm-resolve-pinned
+      uses: gtbuchanan/tooling/.github/actions/pnpm-resolve-pinned@main
       with:
         package: turbo
 
@@ -45,7 +45,7 @@ runs:
       shell: bash
 
     - if: steps.cache-check.outputs.hit != 'true'
-      uses: ./.github/actions/pnpm-tasks
+      uses: gtbuchanan/tooling/.github/actions/pnpm-tasks@main
 
     - env:
         TURBO_GLOBAL_WARNING_DISABLED: '1'

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -16,9 +16,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: ./.github/actions/mise-setup
+      - uses: gtbuchanan/tooling/.github/actions/mise-setup@main
 
-      - uses: ./.github/actions/turbo-run
+      - uses: gtbuchanan/tooling/.github/actions/turbo-run@main
         with:
           task: pack
 
@@ -38,7 +38,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: ./.github/actions/mise-setup
+      - uses: gtbuchanan/tooling/.github/actions/mise-setup@main
 
       - id: app-token
         uses: actions/create-github-app-token@v3
@@ -47,7 +47,7 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - id: changesets
-        uses: ./.github/actions/pnpm-resolve-pinned
+        uses: gtbuchanan/tooling/.github/actions/pnpm-resolve-pinned@main
         with:
           package: '@changesets/cli'
 

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -12,10 +12,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: ./.github/actions/mise-setup
+      - uses: gtbuchanan/tooling/.github/actions/mise-setup@main
 
       - id: changesets
-        uses: ./.github/actions/pnpm-resolve-pinned
+        uses: gtbuchanan/tooling/.github/actions/pnpm-resolve-pinned@main
         with:
           package: '@changesets/cli'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: ./.github/actions/mise-setup
+      - uses: gtbuchanan/tooling/.github/actions/mise-setup@main
 
-      - uses: ./.github/actions/turbo-run
+      - uses: gtbuchanan/tooling/.github/actions/turbo-run@main
         with:
           task: build:ci
 
@@ -42,7 +42,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: ./.github/actions/mise-setup
+      - uses: gtbuchanan/tooling/.github/actions/mise-setup@main
 
       - uses: actions/download-artifact@v8
         with:
@@ -63,7 +63,7 @@ jobs:
 
       - env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        uses: ./.github/actions/turbo-run
+        uses: gtbuchanan/tooling/.github/actions/turbo-run@main
         with:
           task: coverage:codecov:upload
 
@@ -73,9 +73,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: ./.github/actions/mise-setup
+      - uses: gtbuchanan/tooling/.github/actions/mise-setup@main
 
-      - uses: ./.github/actions/pnpm-tasks
+      - uses: gtbuchanan/tooling/.github/actions/pnpm-tasks@main
 
       - name: Check config drift
         run: pnpm verify
@@ -88,9 +88,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: ./.github/actions/mise-setup
+      - uses: gtbuchanan/tooling/.github/actions/mise-setup@main
 
-      - uses: ./.github/actions/turbo-run
+      - uses: gtbuchanan/tooling/.github/actions/turbo-run@main
         with:
           task: coverage:merge
 
@@ -108,9 +108,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: ./.github/actions/mise-setup
+      - uses: gtbuchanan/tooling/.github/actions/mise-setup@main
 
-      - uses: ./.github/actions/turbo-run
+      - uses: gtbuchanan/tooling/.github/actions/turbo-run@main
         with:
           task: test:e2e
 
@@ -121,9 +121,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: ./.github/actions/mise-setup
+      - uses: gtbuchanan/tooling/.github/actions/mise-setup@main
 
-      - uses: ./.github/actions/turbo-run
+      - uses: gtbuchanan/tooling/.github/actions/turbo-run@main
         with:
           task: test:slow
 

--- a/.github/workflows/pre-commit-seed.yml
+++ b/.github/workflows/pre-commit-seed.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: ./.github/actions/mise-setup
+      - uses: gtbuchanan/tooling/.github/actions/mise-setup@main
 
       # mise.lock is in the cache key because prek bakes absolute Node
       # binary paths into its cached hook environments (j178/prek#1993);

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -15,13 +15,13 @@ jobs:
       - name: Fetch branch refs for diff
         run: git fetch --no-tags --depth=1 origin +refs/heads/*:refs/remotes/origin/*
 
-      - uses: ./.github/actions/mise-setup
+      - uses: gtbuchanan/tooling/.github/actions/mise-setup@main
 
       # The local eslint hook is `language: system` (entry `pnpm exec
       # eslint`), so it needs node_modules. Node-free consumers set
       # `use-pnpm: false` to skip this and run prek (from mise) alone.
       - if: inputs.use-pnpm
-        uses: ./.github/actions/pnpm-tasks
+        uses: gtbuchanan/tooling/.github/actions/pnpm-tasks@main
 
       # mise.lock is in the cache key because prek bakes absolute Node
       # binary paths into its cached hook environments (j178/prek#1993);

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,6 +177,23 @@ populates. Permissions narrow down the call chain but never elevate, so
 the pipeline grants the superset its jobs need (`pull-requests: write`
 for Dependencies; `contents: write` + `id-token: write` for CD).
 
+**Why the reusables reference actions by full path, not `./`.** Every
+`uses:` for an in-repo composite action is written
+`gtbuchanan/tooling/.github/actions/<name>@main`, never
+`./.github/actions/<name>`. A relative `./` action ref resolves against
+`GITHUB_WORKSPACE` — the **caller's** checkout — not the repo that owns
+the workflow. It works when tooling calls its own reusables (the
+workspace _is_ tooling) but 404s for every external consumer, since
+their checkout has no `.github/actions/`. The same trap applies one
+level deeper: a `./` ref _inside_ a composite action also resolves to
+`GITHUB_WORKSPACE` (actions/runner#1348), so `turbo-run` references
+`pnpm-resolve-pinned` / `pnpm-tasks` by full path too. The cost is that
+tooling's own PRs exercise the `@main` action, not the PR's edited copy
+— action changes aren't self-tested until merged. There is no clean
+dynamic alternative (`uses:` can't interpolate a ref; GitHub's
+same-SHA `$/` syntax isn't GA). Do **not** "simplify" these back to
+`./`.
+
 Every job that needs Node, pnpm, or prek prepends `mise-setup`, which
 installs the exact versions pinned in `mise.toml` / `mise.lock`. Tool
 caching is owned by `mise-setup` (mise data dir) and `pnpm-tasks`


### PR DESCRIPTION
## Problem

Every reusable workflow referenced its in-repo composite actions with a relative path, e.g. `uses: ./.github/actions/mise-setup`. A `./` action ref resolves against `GITHUB_WORKSPACE` — the **caller's** checkout — not the repo that owns the workflow. It works when tooling calls its own reusables (the workspace _is_ tooling), but **404s for every external consumer**, whose checkout has no `.github/actions/`:

> Can't find 'action.yml'… under `.../.github/actions/mise-setup`. Did you forget to run actions/checkout before running your local action?

This first surfaced on the `Pre-Commit Run` check from an external consumer, but it affected `ci.yml`, `cd.yml`, and `changeset-check.yml` identically — they just hadn't been exercised externally yet.

The same trap applies one level deeper: a `./` ref **inside** a composite action also resolves to `GITHUB_WORKSPACE` ([actions/runner#1348](https://github.com/actions/runner/issues/1348)), so `turbo-run`'s nested `pnpm-resolve-pinned` / `pnpm-tasks` refs had to be fixed too.

## Change

Reference every in-repo action by full path — `gtbuchanan/tooling/.github/actions/<name>@main` — across:

- `ci.yml`, `cd.yml`, `changeset-check.yml`, `pre-commit.yml`, `pre-commit-seed.yml`
- `turbo-run/action.yml` (nested refs)

`AGENTS.md` gains a "Why the reusables reference actions by full path" note so this isn't "simplified" back to `./`.

## Tradeoff

Full-path `@main` refs mean tooling's own PRs exercise the `@main` action, not the PR's edited copy — action changes aren't self-tested until merged. There's no clean dynamic alternative (`uses:` can't interpolate a ref; GitHub's same-SHA `$/` syntax isn't GA).

🤖 Generated with [Claude Code](https://claude.com/claude-code)