### PR TITLE
Skip mise.lock in pre-commit and mark it linguist-generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 * text=auto eol=lf
+mise.lock linguist-generated
 pnpm-lock.yaml linguist-generated

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 ---
-exclude: '[-.]lock\.'
+exclude: '[-.]lock(\.|$)'
 repos:
   - hooks:
       - id: check-added-large-files


### PR DESCRIPTION
## What

- Widen the pre-commit `exclude` regex from `[-.]lock\.` to `[-.]lock(\.|$)` so a `.lock` suffix at the end of a filename (e.g. `mise.lock`) is skipped, not just embedded-`lock.` names like `pnpm-lock.yaml`.
- Mark `mise.lock` as `linguist-generated` in `.gitattributes` so it's collapsed in diffs, matching `pnpm-lock.yaml`.

## Why

The old regex required a character after `lock`, so `mise.lock` slipped through pre-commit file hygiene hooks.