### PR TITLE
Add CODEOWNERS requiring maintainer review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Require review from the repository maintainer on all changes.
+* @gtbuchanan


### PR DESCRIPTION
Adds `.github/CODEOWNERS` assigning `@gtbuchanan` as the owner of every
path, so the existing `require_code_owner_review` rule in the `Default`
branch ruleset has an owner to enforce against.

No published-package impact, so no changeset.