### PR TITLE
Adopt actionlint pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,11 @@ repos:
         name: '[Renovate] Lint'
     repo: https://github.com/renovatebot/pre-commit-hooks
     rev: 43.209.1
+  - hooks:
+      - id: actionlint
+        name: '[Actions] actionlint'
+    repo: https://github.com/rhysd/actionlint
+    rev: v1.7.12
   # language: system because the config packages aren't published yet.
   # Consumers should use language: node with additional_dependencies.
   - hooks:


### PR DESCRIPTION
Adds `rhysd/actionlint` to `.pre-commit-config.yaml`, matching the hook set in [`claude-code-termux`](https://github.com/gtbuchanan/claude-code-termux).

actionlint lints the workflow and composite-action files under `.github/` and runs ShellCheck on embedded `run:` scripts — neither of which the existing `language: system` ESLint hook covers.

No changeset by request: repo-local dev tooling, no published-package impact. The Changeset check will fail until one is added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)