### PR TITLE
Add TOML linting to @gtbuchanan/eslint-config

### DIFF
--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -67,6 +67,7 @@ export default configure({
 - `eslint-plugin-n` — Node.js best practices
 - `eslint-plugin-pnpm` — pnpm workspace validation (opt-in)
 - `eslint-plugin-yml` — YAML linting and key sorting
+- `eslint-plugin-toml` — TOML linting and structural key/table ordering
 - `@eslint/markdown` — Official Markdown lint plugin (commonmark AST)
 - `@gtbuchanan/eslint-plugin-markdownlint` — Markdown structural linting via markdownlint (gap-filling rules not yet covered by `@eslint/markdown`)
 - `eslint-plugin-only-warn` — Downgrades errors to warnings (opt-in)

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -42,6 +42,7 @@
     "eslint-plugin-pnpm": "catalog:",
     "eslint-plugin-promise": "catalog:",
     "eslint-plugin-regexp": "catalog:",
+    "eslint-plugin-toml": "catalog:",
     "eslint-plugin-unicorn": "catalog:",
     "eslint-plugin-yml": "catalog:",
     "prettier": "catalog:",
@@ -49,6 +50,7 @@
     "prettier-plugin-multiline-arrays": "catalog:",
     "prettier-plugin-packagejson": "catalog:",
     "prettier-plugin-sort-json": "catalog:",
+    "prettier-plugin-toml": "catalog:",
     "typescript-eslint": "catalog:"
   },
   "devDependencies": {

--- a/packages/eslint-config/src/plugins/format.ts
+++ b/packages/eslint-config/src/plugins/format.ts
@@ -20,6 +20,7 @@ const cssOrderPlugin = resolvePlugin('prettier-plugin-css-order');
 const multilineArraysPlugin = resolvePlugin('prettier-plugin-multiline-arrays');
 const packageJsonPlugin = resolvePlugin('prettier-plugin-packagejson');
 const sortJsonPlugin = resolvePlugin('prettier-plugin-sort-json');
+const tomlPlugin = resolvePlugin('prettier-plugin-toml');
 const xmlPlugin = resolvePlugin('@prettier/plugin-xml');
 
 /*
@@ -102,6 +103,21 @@ const plugin: PluginFactory = () => [
       // HACK: YAML prose is not handled correctly yet
       // https://github.com/prettier/prettier/issues/16126#issuecomment-1987616924
       proseWrap: 'preserve',
+    }),
+  },
+  {
+    /*
+     * Prettier has no native TOML parser; prettier-plugin-toml (taplo)
+     * registers one. eslint-plugin-toml handles lint-only correctness
+     * rules (see toml.ts), so formatting is owned here.
+     */
+    files: ['**/*.toml'],
+    languageOptions: { parser: format.parserPlain },
+    plugins: { format },
+    rules: prettierRule('toml', {
+      plugins: [tomlPlugin],
+      // Justification: Alphabetical keys reduce merge conflicts, matching JSON/YAML
+      reorderKeys: true,
     }),
   },
   {

--- a/packages/eslint-config/src/plugins/index.ts
+++ b/packages/eslint-config/src/plugins/index.ts
@@ -13,6 +13,7 @@ import pnpm from './pnpm.ts';
 import promise from './promise.ts';
 import regexp from './regexp.ts';
 import stylistic from './stylistic.ts';
+import toml from './toml.ts';
 import typescript from './typescript.ts';
 import unicorn from './unicorn.ts';
 import vitest from './vitest.ts';
@@ -21,7 +22,7 @@ import yamllint from './yamllint.ts';
 
 /** Ordered plugin factories. Later entries override earlier ones for the same file. */
 export const plugins: readonly PluginFactory[] = [
-  typescript, unicorn, promise, regexp, jsdoc, json, yaml, yamllint, pnpm, node,
-  format, markdownlint, markdown, agentSkills, stylistic, eslintComments, importX,
-  core, vitest,
+  typescript, unicorn, promise, regexp, jsdoc, json, yaml, yamllint, toml, pnpm,
+  node, format, markdownlint, markdown, agentSkills, stylistic, eslintComments,
+  importX, core, vitest,
 ];

--- a/packages/eslint-config/src/plugins/toml.ts
+++ b/packages/eslint-config/src/plugins/toml.ts
@@ -1,0 +1,31 @@
+import { configs as tomlConfigs } from 'eslint-plugin-toml';
+import type { PluginFactory } from '../index.ts';
+
+// --- TOML ---
+
+/*
+ * TOML linting with structural key/table ordering. Whitespace/layout
+ * formatting is owned by Prettier (see format.ts) via prettier-plugin-toml,
+ * so we start from `flat/recommended` (correctness only) rather than
+ * `flat/standard` (which layers on indent/spacing rules that would fight
+ * Prettier). The two ordering rules below are the exception we pull from
+ * standard: they enforce that a table's keys and subtables stay contiguous
+ * (no `[a]`…`[b]`…`[a.c]` split definitions). That is orthogonal to the
+ * alphabetical key sort Prettier applies (`reorderKeys`, see format.ts),
+ * which orders keys within a block but never splits a table — so the two
+ * don't conflict.
+ */
+const plugin: PluginFactory = () => [
+  ...tomlConfigs['flat/recommended'],
+  {
+    files: ['**/*.toml'],
+    rules: {
+      // Justification: Keep a table's keys contiguous; split definitions obscure structure
+      'toml/keys-order': 'warn',
+      // Justification: Keep subtables under their parent; split definitions obscure structure
+      'toml/tables-order': 'warn',
+    },
+  },
+];
+
+export default plugin;

--- a/packages/eslint-config/test/configure.test.ts
+++ b/packages/eslint-config/test/configure.test.ts
@@ -171,7 +171,7 @@ describe.concurrent(configure, () => {
 
     expect(targetedFiles).toStrictEqual(expect.arrayContaining([
       '**/*.css', '**/*.json', '**/*.md',
-      '**/*.scss', '**/*.xml', '**/*.yaml',
+      '**/*.scss', '**/*.toml', '**/*.xml', '**/*.yaml',
       '**/package.json',
     ]));
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,9 @@ catalogs:
     eslint-plugin-regexp:
       specifier: 3.1.0
       version: 3.1.0
+    eslint-plugin-toml:
+      specifier: 1.4.0
+      version: 1.4.0
     eslint-plugin-unicorn:
       specifier: ^64.0.0
       version: 64.0.0
@@ -117,6 +120,9 @@ catalogs:
     prettier-plugin-sort-json:
       specifier: 4.2.0
       version: 4.2.0
+    prettier-plugin-toml:
+      specifier: 2.0.6
+      version: 2.0.6
     skills:
       specifier: 1.5.10
       version: 1.5.10
@@ -318,6 +324,9 @@ importers:
       eslint-plugin-regexp:
         specifier: 'catalog:'
         version: 3.1.0(eslint@10.4.1(jiti@2.7.0))
+      eslint-plugin-toml:
+        specifier: 'catalog:'
+        version: 1.4.0(eslint@10.4.1(jiti@2.7.0))
       eslint-plugin-unicorn:
         specifier: 'catalog:'
         version: 64.0.0(eslint@10.4.1(jiti@2.7.0))
@@ -339,6 +348,9 @@ importers:
       prettier-plugin-sort-json:
         specifier: 'catalog:'
         version: 4.2.0(prettier@3.8.3)
+      prettier-plugin-toml:
+        specifier: 'catalog:'
+        version: 2.0.6(prettier@3.8.3)
       typescript-eslint:
         specifier: 'catalog:'
         version: 8.60.1(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
@@ -1012,6 +1024,12 @@ packages:
     peerDependencies:
       eslint: ^9.0.0 || ^10.0.0
 
+  '@taplo/core@0.2.0':
+    resolution: {integrity: sha512-r8bl54Zj1In3QLkiW/ex694bVzpPJ9EhwqT9xkcUVODnVUGirdB1JTsmiIv0o1uwqZiwhi8xNnTOQBRQCpizrQ==}
+
+  '@taplo/lib@0.5.0':
+    resolution: {integrity: sha512-+xIqpQXJco3T+VGaTTwmhxLa51qpkQxCjRwezjFZgr+l21ExlywJFcDfTrNmL6lG6tqb0h8GyJKO3UPGPtSCWg==}
+
   '@tsconfig/strictest@2.0.8':
     resolution: {integrity: sha512-XnQ7vNz5HRN0r88GYf1J9JJjqtZPiHt2woGJOo2dYqyHGGcd6OLGqSlBB6p1j9mpzja6Oe5BoPqWmeDx6X9rLw==}
 
@@ -1649,6 +1667,12 @@ packages:
 
   eslint-plugin-regexp@3.1.0:
     resolution: {integrity: sha512-qGXIC3DIKZHcK1H9A9+Byz9gmndY6TTSRkSMTZpNXdyCw2ObSehRgccJv35n9AdUakEjQp5VFNLas6BMXizCZg==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+    peerDependencies:
+      eslint: '>=9.38.0'
+
+  eslint-plugin-toml@1.4.0:
+    resolution: {integrity: sha512-3ErTnfUjXq/23f72XeyRcE0Y4Sd/ME1lsZeezczqpn2R4tE7+Sgco/NUKDXm0xAMz15tzcRz/9RfJRm6AqRO+A==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
     peerDependencies:
       eslint: '>=9.38.0'
@@ -2444,6 +2468,12 @@ packages:
     peerDependencies:
       prettier: ^3.0.0
 
+  prettier-plugin-toml@2.0.6:
+    resolution: {integrity: sha512-12N/wBuHa9jd/KVy9pRP20NMKxQfQLMseQCt66lIbLaPLItvGUcSIryE1eZZMJ7loSws6Ig3M2Elc2EreNh76w==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      prettier: ^3.0.3
+
   prettier@2.8.8:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
     engines: {node: '>=10.13.0'}
@@ -2675,6 +2705,10 @@ packages:
   to-valid-identifier@1.0.0:
     resolution: {integrity: sha512-41wJyvKep3yT2tyPqX/4blcfybknGB4D+oETKLs7Q76UiPqRpUJK3hr1nxelyYO0PHKVzJwlu0aCeEAsGI6rpw==}
     engines: {node: '>=20'}
+
+  toml-eslint-parser@1.0.3:
+    resolution: {integrity: sha512-A5F0cM6+mDleacLIEUkmfpkBbnHJFV1d2rprHU2MXNk7mlxHq2zGojA+SRvQD1RoMo9gqjZPWEaKG4v1BQ48lw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
@@ -3410,6 +3444,12 @@ snapshots:
       estraverse: 5.3.0
       picomatch: 4.0.4
 
+  '@taplo/core@0.2.0': {}
+
+  '@taplo/lib@0.5.0':
+    dependencies:
+      '@taplo/core': 0.2.0
+
   '@tsconfig/strictest@2.0.8': {}
 
   '@turbo/darwin-64@2.9.16':
@@ -4008,6 +4048,17 @@ snapshots:
       refa: 0.12.1
       regexp-ast-analysis: 0.7.1
       scslre: 0.3.0
+
+  eslint-plugin-toml@1.4.0(eslint@10.4.1(jiti@2.7.0)):
+    dependencies:
+      '@eslint/core': 1.2.1
+      '@eslint/plugin-kit': 0.7.2
+      '@ota-meshi/ast-token-store': 0.3.0
+      debug: 4.4.3
+      eslint: 10.4.1(jiti@2.7.0)
+      toml-eslint-parser: 1.0.3
+    transitivePeerDependencies:
+      - supports-color
 
   eslint-plugin-unicorn@64.0.0(eslint@10.4.1(jiti@2.7.0)):
     dependencies:
@@ -4986,6 +5037,11 @@ snapshots:
     dependencies:
       prettier: 3.8.3
 
+  prettier-plugin-toml@2.0.6(prettier@3.8.3):
+    dependencies:
+      '@taplo/lib': 0.5.0
+      prettier: 3.8.3
+
   prettier@2.8.8: {}
 
   prettier@3.8.3: {}
@@ -5199,6 +5255,10 @@ snapshots:
     dependencies:
       '@sindresorhus/base62': 1.0.0
       reserved-identifiers: 1.2.0
+
+  toml-eslint-parser@1.0.3:
+    dependencies:
+      eslint-visitor-keys: 5.0.1
 
   ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -30,6 +30,7 @@ catalog:
   eslint-plugin-pnpm: 1.6.1
   eslint-plugin-promise: ^7.2.1
   eslint-plugin-regexp: 3.1.0
+  eslint-plugin-toml: 1.4.0
   eslint-plugin-unicorn: ^64.0.0
   eslint-plugin-yml: 3.4.0
   find-up-simple: ^1.0.1
@@ -40,6 +41,7 @@ catalog:
   prettier-plugin-multiline-arrays: 4.1.8
   prettier-plugin-packagejson: 3.0.2
   prettier-plugin-sort-json: 4.2.0
+  prettier-plugin-toml: 2.0.6
   skills: 1.5.10
   skills-npm: 1.1.1
   turbo: ^2.5.4


### PR DESCRIPTION
Routes TOML through the ESLint pipeline alongside JSON/YAML/Markdown, instead of a standalone pre-commit hook.

## What

- Adds `eslint-plugin-toml` to the bundled plugin set: `flat/recommended` correctness rules plus `keys-order`/`tables-order`. Those two enforce **structural** contiguity of a table's keys and subtables (no `[a]`…`[b]`…`[a.c]` split definitions) — not alphabetical sorting.
- Adds `prettier-plugin-toml` (taplo) to `format.ts` so Prettier formats TOML, since Prettier core has no TOML parser. `reorderKeys: true` gives alphabetical key sorting, matching the existing `json/sort-keys` and `yml/sort-keys` conventions.

## Notes

- New dependencies: `eslint-plugin-toml`, `prettier-plugin-toml`, `@taplo/lib` (wasm) — Dependency Review will surface these.
- Consumer impact: adopting this reformats consumers `.toml` files on the first `--fix` (alphabetical keys + taplo formatting).
- `mise.toml` is already valid and sorted, so no in-repo churn.
- No changeset by request; the Changeset check will fail until one is added (this touches the published `@gtbuchanan/eslint-config`, conventionally a `minor` bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)