### PR TITLE
Skip workspace specifiers in dependency Version Check

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -48,6 +48,17 @@ jobs:
 
           stale=0
           while IFS=$'\t' read -r ecosystem name version; do
+            # pnpm/yarn manifest specifiers (catalog:, workspace:, link:,
+            # file:, npm: aliases, ...) are not resolvable versions. The
+            # resolved version is reported as a separate lockfile entry and
+            # checked there, so skip the specifier to avoid false positives.
+            case "$version" in
+              catalog:*|workspace:*|link:*|file:*|npm:*|git:*|http:*|https:*)
+                echo "OK  $ecosystem:$name@$version (manifest specifier, skipped)"
+                continue
+                ;;
+            esac
+
             case "$ecosystem" in
               actions)
                 # SHA pins are intentional immutable pinning.


### PR DESCRIPTION
## Problem

The `Version Check` job iterates every newly-added dependency from GitHub's dependency-graph compare API. For pnpm catalog deps, the graph reports **two** entries per package: the manifest entry with version `catalog:` and the lockfile-resolved entry (e.g. `1.4.0`).

The script could not parse `catalog:` as a semver, so it compared `catalog:` against deps.dev's latest, failed the match, and flagged the dep as stale. Any PR adding a catalog dependency fails this check even when the resolved version is at latest — first hit by #148 (the first catalog dep added since this check landed).

## Fix

Skip pnpm/yarn manifest specifiers (`catalog:`, `workspace:`, `link:`, `file:`, `npm:` aliases, `git`/`http` URLs) before the version comparison. The resolved version is reported as a separate lockfile entry and is still checked, so coverage is unchanged for real versions and SHA-pinned actions.

Verified locally that `catalog:` entries are skipped while resolved versions and action SHA pins still route to their respective checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)