### PR TITLE
Force codecov require_ci_to_pass false in gtb sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,11 @@ jobs:
 To customize coverage targets, add a `codecov.yml` to your repo root.
 
 **Drift risk:** The Codecov job uses `continue-on-error` so upload
-failures never block PRs. Flags use `carryforward: true` because
+failures never block PRs, and `gtb sync` forces
+`codecov.require_ci_to_pass: false` so Codecov's status and PR comment —
+informational here, never a merge gate — still post when an unrelated
+check fails (e.g. a missing changeset) instead of being withheld. Flags
+use `carryforward: true` because
 Codecov treats missing flags as 0% coverage, which would cause false
 failures on PRs that only touch a subset of packages. The tradeoff is
 that a failed upload carries forward stale data. In practice this

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,6 @@
 ---
 codecov:
-  require_ci_to_pass: true
+  require_ci_to_pass: false
 comment:
   layout: condensed_header, condensed_files, condensed_footer
   require_changes: true

--- a/packages/cli/src/commands/root/verify.ts
+++ b/packages/cli/src/commands/root/verify.ts
@@ -145,6 +145,9 @@ const checkTsconfigs = (
 
 const CodecovYamlSchema = v.nullable(
   v.looseObject({
+    codecov: v.optional(
+      v.looseObject({ require_ci_to_pass: v.optional(v.boolean()) }),
+    ),
     component_management: v.optional(
       v.looseObject({
         individual_components: v.optional(
@@ -155,6 +158,8 @@ const CodecovYamlSchema = v.nullable(
     flags: v.optional(v.record(v.string(), v.unknown())),
   }),
 );
+
+interface ActualCodecov { readonly require_ci_to_pass?: boolean | undefined }
 
 interface ActualComponent { readonly component_id?: string | undefined }
 
@@ -183,6 +188,14 @@ const checkCodecovFlags = (
     .filter(name => actualFlags === undefined || !(name in actualFlags))
     .map(name => `codecov.yml: missing flag '${name}'`);
 
+const checkCodecovSettings = (
+  actualCodecov: ActualCodecov | undefined,
+  expected: CodecovSections,
+): readonly string[] =>
+  actualCodecov?.require_ci_to_pass === expected.codecov.require_ci_to_pass
+    ? []
+    : ['codecov.yml: codecov.require_ci_to_pass must be false (run gtb sync)'];
+
 const checkCodecovComponents = (
   actualComponents: readonly ActualComponent[],
   expected: CodecovSections,
@@ -209,9 +222,14 @@ const checkCodecovSections = (
   if (!parseResult.success || parseResult.output === null) {
     return ['codecov.yml: failed to parse'];
   }
-  const { flags: actualFlags, component_management: actualCm } = parseResult.output;
+  const {
+    codecov: actualCodecov,
+    flags: actualFlags,
+    component_management: actualCm,
+  } = parseResult.output;
   const expected = generateCodecovSections(discovery);
   return [
+    ...checkCodecovSettings(actualCodecov, expected),
     ...checkCodecovFlags(actualFlags, expected, ignored),
     ...checkCodecovComponents(actualCm?.individual_components ?? [], expected, ignored),
   ];

--- a/packages/cli/src/lib/codecov-config.ts
+++ b/packages/cli/src/lib/codecov-config.ts
@@ -20,8 +20,27 @@ export interface CodecovComponent {
   readonly paths: readonly string[];
 }
 
-/** Derived sections of codecov.yml that are generated from workspace discovery. */
+/** Top-level codecov settings managed by tooling. */
+export interface CodecovSettings {
+  /**
+   * Forced false. Coverage here is informational, not a merge gate: the
+   * Codecov upload job runs `continue-on-error` (never blocks PRs) and
+   * drift self-corrects when release.yml re-runs on main. The default
+   * (`require_ci_to_pass: true`) only earns its keep when the Codecov
+   * status is itself a gate and you want to avoid acting on coverage from
+   * an incomplete CI run. With coverage non-blocking, leaving it true just
+   * suppresses the (still useful) coverage status and PR comment whenever
+   * an unrelated check fails — e.g. a missing changeset — for no
+   * offsetting benefit. False keeps coverage visible regardless of other
+   * CI. See README "Coverage".
+   */
+  readonly require_ci_to_pass: false;
+}
+
+/** Derived and managed sections of codecov.yml that gtb sync owns. */
 export interface CodecovSections {
+  /** Top-level codecov settings (authoritative). */
+  readonly codecov: CodecovSettings;
   /** Per-package upload flags. */
   readonly flags: Readonly<Record<string, CodecovFlag>>;
   /** Component management block (only individual_components is generated). */
@@ -29,6 +48,9 @@ export interface CodecovSections {
     readonly individual_components: readonly CodecovComponent[];
   };
 }
+
+/** Tooling-owned top-level codecov settings, written authoritatively by sync. */
+export const codecovSettings: CodecovSettings = { require_ci_to_pass: false };
 
 const buildComponentPaths = (
   pkg: PackageCapabilities,
@@ -71,8 +93,9 @@ const buildCoverageEntries = (
 };
 
 /**
- * Generates the derived `flags` and `component_management.individual_components`
- * sections of `codecov.yml` from workspace discovery.
+ * Generates the managed sections of `codecov.yml`: the authoritative
+ * top-level `codecov` settings, plus the derived `flags` and
+ * `component_management.individual_components` from workspace discovery.
  * Only packages with Vitest tests (`hasVitestTests`) are included.
  * Throws if any two coverage packages share the same directory basename,
  * as Codecov uses the basename as the flag name.
@@ -82,5 +105,9 @@ export const generateCodecovSections = (discovery: WorkspaceDiscovery): CodecovS
   const names = coveragePackages.map(pkg => path.basename(pkg.dir));
   checkForDuplicateBasenames(names);
   const { flags, components } = buildCoverageEntries(coveragePackages, discovery.rootDir);
-  return { component_management: { individual_components: components }, flags };
+  return {
+    codecov: codecovSettings,
+    component_management: { individual_components: components },
+    flags,
+  };
 };

--- a/packages/cli/src/lib/file-writer.ts
+++ b/packages/cli/src/lib/file-writer.ts
@@ -98,10 +98,11 @@ export const writeYamlFile = (path: string, data: unknown): void => {
   writeFileSync(path, stringifyYaml(data, { directives: true, singleQuote: true }));
 };
 
+/* Non-object values (e.g. `codecov: true`) fall back to `{}` so sync repairs them. */
 const ExistingCodecovSchema = v.nullable(
   v.looseObject({
-    codecov: v.optional(v.nullable(v.looseObject({}))),
-    component_management: v.optional(v.nullable(v.looseObject({}))),
+    codecov: v.optional(v.fallback(v.looseObject({}), {})),
+    component_management: v.optional(v.fallback(v.looseObject({}), {})),
   }),
 );
 

--- a/packages/cli/src/lib/file-writer.ts
+++ b/packages/cli/src/lib/file-writer.ts
@@ -100,15 +100,17 @@ export const writeYamlFile = (path: string, data: unknown): void => {
 
 const ExistingCodecovSchema = v.nullable(
   v.looseObject({
+    codecov: v.optional(v.nullable(v.looseObject({}))),
     component_management: v.optional(v.nullable(v.looseObject({}))),
   }),
 );
 
 /**
  * Merges generated codecov sections into a `codecov.yml` file.
- * Overwrites `flags` and `component_management.individual_components`
+ * Overwrites `flags`, `component_management.individual_components`, and the
+ * tooling-owned top-level `codecov` settings (e.g. `require_ci_to_pass`)
  * with the generated values. Preserves all other keys, including
- * `component_management.default_rules`.
+ * `component_management.default_rules` and any other `codecov.*` subkeys.
  * Creates the file if it does not exist.
  * Throws if the existing file contains invalid YAML.
  */
@@ -122,10 +124,15 @@ export const mergeCodecovSections = (path: string, sections: CodecovSections): v
     }
   }
   const existing = v.parse(v.optional(ExistingCodecovSchema), rawYaml) ?? {};
+  const existingCodecov = existing.codecov ?? {};
   const existingComponentMgmt = existing.component_management ?? {};
 
   const merged = {
     ...existing,
+    codecov: {
+      ...existingCodecov,
+      ...sections.codecov,
+    },
     component_management: {
       ...existingComponentMgmt,
       individual_components: sections.component_management.individual_components,

--- a/packages/cli/test/codecov-config.test.ts
+++ b/packages/cli/test/codecov-config.test.ts
@@ -54,6 +54,15 @@ const createMonorepo = (): CodecovMonorepo => {
 };
 
 describe.concurrent(generateCodecovSections, () => {
+  it('forces codecov.require_ci_to_pass false', ({ expect }) => {
+    const { root } = createMonorepo();
+    const discovery = discoverWorkspace({ cwd: root });
+
+    const { codecov } = generateCodecovSections(discovery);
+
+    expect(codecov).toStrictEqual({ require_ci_to_pass: false });
+  });
+
   it('generates a flag per coverage package', ({ expect }) => {
     const { alpha, beta, gamma, root } = createMonorepo();
     const discovery = discoverWorkspace({ cwd: root });

--- a/packages/cli/test/file-writer.test.ts
+++ b/packages/cli/test/file-writer.test.ts
@@ -190,6 +190,7 @@ describe.concurrent(sortKeysDeep, () => {
 
 describe.concurrent(mergeCodecovSections, () => {
   const sections = {
+    codecov: { require_ci_to_pass: false },
     component_management: {
       individual_components: [
         { component_id: 'app', name: 'app', paths: ['packages/app/src/**'] },
@@ -198,7 +199,7 @@ describe.concurrent(mergeCodecovSections, () => {
     flags: {
       app: { carryforward: true, paths: ['packages/app/'] },
     },
-  };
+  } as const;
 
   it('throws on malformed YAML in existing file', ({ expect }) => {
     const dir = createTempDir();
@@ -240,13 +241,27 @@ describe.concurrent(mergeCodecovSections, () => {
   it('preserves user-configured keys', ({ expect }) => {
     const dir = createTempDir();
     const filePath = path.join(dir, 'codecov.yml');
-    writeFileSync(filePath, 'codecov:\n  require_ci_to_pass: true\nflags: {}\n');
+    writeFileSync(filePath, "comment:\n  layout: 'condensed_header'\nflags: {}\n");
 
     mergeCodecovSections(filePath, sections);
 
     const parsed: unknown = parseYaml(readFileSync(filePath, 'utf8'));
 
-    expect(parsed).toHaveProperty('codecov');
+    expect(parsed).toHaveProperty('comment.layout', 'condensed_header');
+  });
+
+  it('forces codecov.require_ci_to_pass false, overwriting user value', ({ expect }) => {
+    const dir = createTempDir();
+    const filePath = path.join(dir, 'codecov.yml');
+    writeFileSync(filePath, 'codecov:\n  require_ci_to_pass: true\n  max_report_age: 24\n');
+
+    mergeCodecovSections(filePath, sections);
+
+    const parsed: unknown = parseYaml(readFileSync(filePath, 'utf8'));
+
+    expect(parsed).toHaveProperty('codecov.require_ci_to_pass', false);
+    // Other codecov.* subkeys are preserved.
+    expect(parsed).toHaveProperty('codecov.max_report_age', 24);
   });
 
   it('sorts keys and uses single quotes', ({ expect }) => {

--- a/packages/cli/test/file-writer.test.ts
+++ b/packages/cli/test/file-writer.test.ts
@@ -264,6 +264,18 @@ describe.concurrent(mergeCodecovSections, () => {
     expect(parsed).toHaveProperty('codecov.max_report_age', 24);
   });
 
+  it('repairs a non-object codecov value instead of throwing', ({ expect }) => {
+    const dir = createTempDir();
+    const filePath = path.join(dir, 'codecov.yml');
+    writeFileSync(filePath, 'codecov: true\n');
+
+    mergeCodecovSections(filePath, sections);
+
+    const parsed: unknown = parseYaml(readFileSync(filePath, 'utf8'));
+
+    expect(parsed).toHaveProperty('codecov.require_ci_to_pass', false);
+  });
+
   it('sorts keys and uses single quotes', ({ expect }) => {
     const dir = createTempDir();
     const filePath = path.join(dir, 'codecov.yml');

--- a/packages/cli/test/sync.test.ts
+++ b/packages/cli/test/sync.test.ts
@@ -4,6 +4,7 @@ import { Writable } from 'node:stream';
 import * as build from '@gtbuchanan/test-utils/builders';
 import * as v from 'valibot';
 import { describe, it } from 'vitest';
+import { parse as parseYaml } from 'yaml';
 import { runSync, syncCommand } from '#src/commands/root/sync.js';
 import { discoverWorkspace } from '#src/lib/discovery.js';
 import { mergePackageScripts, readJsonFile, writeJsonFile } from '#src/lib/file-writer.js';
@@ -244,19 +245,19 @@ describe.concurrent(runSync, () => {
     expect(content).toContain('carryforward');
   });
 
-  it('preserves existing codecov.yml user config', ({ expect }) => {
+  it('preserves user config but forces require_ci_to_pass false', ({ expect }) => {
     const { root } = createConsumerProject();
     writeFileSync(
       path.join(root, 'codecov.yml'),
-      'codecov:\n  require_ci_to_pass: true\n',
+      'codecov:\n  require_ci_to_pass: true\ncomment:\n  require_changes: true\n',
     );
 
     runSync({ cwd: root, logger: silentLogger });
 
-    const content = readFileSync(path.join(root, 'codecov.yml'), 'utf8');
+    const parsed: unknown = parseYaml(readFileSync(path.join(root, 'codecov.yml'), 'utf8'));
 
-    expect(content).toContain('require_ci_to_pass');
-    expect(content).toContain('carryforward');
+    expect(parsed).toHaveProperty('codecov.require_ci_to_pass', false);
+    expect(parsed).toHaveProperty('comment.require_changes', true);
   });
 
   it('force overwrites existing scripts', ({ expect }) => {

--- a/packages/cli/test/verify.test.ts
+++ b/packages/cli/test/verify.test.ts
@@ -197,12 +197,29 @@ describe.concurrent(runVerify, () => {
     initProject(root);
     writeFileSync(
       path.join(root, 'codecov.yml'),
+      'codecov:\n  require_ci_to_pass: false\n' +
       'flags: {}\ncomponent_management:\n  individual_components: []\n',
     );
 
     const drift = runVerify({ cwd: root, ignored: new Set([app.basename]) });
 
     expect(drift).toHaveLength(0);
+  });
+
+  it('reports drift when codecov.require_ci_to_pass is true', ({ expect }) => {
+    const { app, root } = createConsumerProject();
+    initProject(root);
+    writeFileSync(
+      path.join(root, 'codecov.yml'),
+      'codecov:\n  require_ci_to_pass: true\n' +
+      'flags: {}\ncomponent_management:\n  individual_components: []\n',
+    );
+
+    const drift = runVerify({ cwd: root, ignored: new Set([app.basename]) });
+
+    expect(drift).toStrictEqual([
+      'codecov.yml: codecov.require_ci_to_pass must be false (run gtb sync)',
+    ]);
   });
 });
 


### PR DESCRIPTION
## What

`gtb sync` now manages `codecov.require_ci_to_pass`, writing `false` authoritatively (overwriting any existing value while preserving other `codecov.*` subkeys). `gtb verify` reports drift when it isn't `false`. This repo's `codecov.yml` is flipped to match.

## Why

Coverage is informational in this pipeline — the Codecov upload job runs `continue-on-error` (never blocks PRs) and its statuses aren't merge gates. The Codecov default `require_ci_to_pass: true` only *withheld* Codecov's coverage status and PR comment whenever an unrelated check failed (e.g. a missing changeset), with no offsetting benefit. `false` keeps coverage visible regardless of other CI.

Reasoning is documented durably in the `CodecovSettings` JSDoc (`packages/cli/src/lib/codecov-config.ts`) and the README "Coverage" section.

## Verification

- `gtb verify`: no drift
- cli tests: 63/63 pass (new coverage for generator / merge / verify drift-check)
- typecheck: clean

## Heads up

No changeset, so `Changeset / Changeset Check` will fail by design. This branch changes published `@gtbuchanan/cli` behavior — add a changeset before merge if it should be released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)