### PR TITLE
Group hk Renovate updates into one PR

### DIFF
--- a/default.json
+++ b/default.json
@@ -30,6 +30,13 @@
   "osvVulnerabilityAlerts": true,
   "packageRules": [
     {
+      "description": "Group hk updates (mise tool + .pkl package URLs share one release)",
+      "groupName": "hk",
+      "matchSourceUrls": [
+        "https://github.com/jdx/hk"
+      ]
+    },
+    {
       "description": "Group playwright-cli monorepo",
       "groupName": "playwright-cli monorepo",
       "matchSourceUrls": [


### PR DESCRIPTION
The mise manager (`mise.toml`) and the `.pkl` `customManager` both track the same hk release but under different dependency names (`hk` vs `jdx/hk`) and datasources, so Renovate files two separate PRs for every bump (e.g. #166 and #167 for 1.46.0 → 1.48.0).

This adds a `groupName: "hk"` `packageRule` to the shared `default.json` preset, matching the common source URL (`github.com/jdx/hk`), so both updates land in a single PR going forward.

Placed in `default.json` (not the repo-local config) intentionally — it is coupled to the `customManager` that lives in the same preset, so consumers inheriting both get the grouping too. On its next run, Renovate will close the two standalone hk PRs and re-open them as one grouped PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)