### PR TITLE
Exclude root vendor/ from hk-config file hygiene

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,7 +108,7 @@ coverage, setupFiles, and mock reset.
   - `eslint` / `no-commit-to-branch` — repo-specific, stay in `hk.pkl`
 - **`@gtbuchanan/hk-config` preset** (`packages/hk-config/Defaults.pkl`).
   The reusable building blocks (`fileHygiene`, `forbidSubmodules`,
-  `renovateConfig`, and the `lockfiles`/`batchFiles` primitives) ship as a
+  `renovateConfig`, and the `defaultExclude`/`batchFiles` primitives) ship as a
   Pkl package — private to npm, published as a **GitHub release** so
   consumers `package://`-import it with sha256 integrity (see CD below).
   Consumer import:

--- a/packages/hk-config/Defaults.pkl
+++ b/packages/hk-config/Defaults.pkl
@@ -1,7 +1,7 @@
 /// Shared hk building blocks for @gtbuchanan/tooling consumers. Import this
 /// and spread `fileHygiene` / add `forbidSubmodules` into your hooks; use
-/// `lockfiles` / `batchFiles` to wire the same exclude+batch onto your own
-/// tool steps (eslint, etc.).
+/// `defaultExclude` / `batchFiles` to wire the same exclude+batch onto your
+/// own tool steps (eslint, etc.).
 @ModuleInfo { minPklVersion = "0.27.2" }
 module gtbuchanan.hk.Defaults
 
@@ -9,7 +9,14 @@ import "package://github.com/jdx/hk/releases/download/v1.48.0/hk@1.48.0#/Config.
 import "package://github.com/jdx/hk/releases/download/v1.48.0/hk@1.48.0#/Builtins.pkl"
 
 /// Machine-generated lockfiles — exempt from the file-hygiene fixers.
-lockfiles: Regex = Regex(#"[-.]lock(\.|$)"#)
+lockfileExclude: Regex = Regex(#"[-.]lock(\.|$)"#)
+
+/// Vendored third-party sources under a root `vendor/` — not ours to fix.
+vendorExclude: Regex = Regex(#"^vendor/"#)
+
+/// Default exclude for file-hygiene (and consumer tool) steps: lockfiles plus
+/// vendored sources. Wire onto your own steps with `exclude = Defaults.defaultExclude`.
+defaultExclude: Regex = Regex("\(lockfileExclude.pattern)|\(vendorExclude.pattern)")
 
 /// `gtb hk all` exports HK_BATCH=1 so file-heavy steps chunk under Windows'
 /// cmd.exe 8191-char limit (jdx/hk#971). Off by default elsewhere so commits
@@ -18,10 +25,10 @@ batchFiles: Boolean = (read?("env:HK_BATCH") ?? "0") == "1"
 
 /// File-hygiene builtins with lockfile-exclude + batch already wired.
 fileHygiene: Mapping<String, Config.Step> = new {
-  ["check-added-large-files"] = (Builtins.check_added_large_files) { exclude = lockfiles; batch = batchFiles }
-  ["end-of-file-fixer"] = (Builtins.newlines) { exclude = lockfiles; batch = batchFiles }
-  ["fix-byte-order-marker"] = (Builtins.byte_order_marker) { exclude = lockfiles; batch = batchFiles }
-  ["trailing-whitespace"] = (Builtins.trailing_whitespace) { exclude = lockfiles; batch = batchFiles }
+  ["check-added-large-files"] = (Builtins.check_added_large_files) { exclude = defaultExclude; batch = batchFiles }
+  ["end-of-file-fixer"] = (Builtins.newlines) { exclude = defaultExclude; batch = batchFiles }
+  ["fix-byte-order-marker"] = (Builtins.byte_order_marker) { exclude = defaultExclude; batch = batchFiles }
+  ["trailing-whitespace"] = (Builtins.trailing_whitespace) { exclude = defaultExclude; batch = batchFiles }
 }
 
 // POSIX gitlink (submodule, mode 160000) guard; the cmd.exe variant lives

--- a/packages/hk-config/README.md
+++ b/packages/hk-config/README.md
@@ -37,11 +37,14 @@ only inside the `renovate` npm package — add `npm:renovate` to your mise
 ## Building Blocks
 
 - `fileHygiene` — large-file, end-of-file-newline, byte-order-marker, and
-  trailing-whitespace fixers, each pre-wired with a lockfile exclude and
+  trailing-whitespace fixers, each pre-wired with the default exclude and
   `HK_BATCH`-gated batching.
 - `forbidSubmodules` — a per-OS gitlink (submodule) guard.
 - `renovateConfig` — validates `.github/renovate.json` via
   `renovate-config-validator`. Amend its `glob` to target a different file
   (e.g. `default.json` for preset-authoring repos).
-- `lockfiles` / `batchFiles` — the exclude regex and batch toggle, exposed so
-  you can wire the same behavior onto your own tool steps.
+- `defaultExclude` / `batchFiles` — the default exclude regex (lockfiles plus
+  a root `vendor/`) and batch toggle, exposed so you can wire the same
+  behavior onto your own tool steps.
+- `lockfileExclude` / `vendorExclude` — the individual exclude regexes that
+  compose `defaultExclude`, for steps that need only one.


### PR DESCRIPTION
Vendored third-party sources under a root `vendor/` aren't ours to fix, so add them to the default file-hygiene exclude alongside lockfiles. Mirrors the `^vendor/` exclusion the claude-code-termux repo carries in its pre-commit config, adapted to hk's per-step `exclude` regex.

The exclude primitives in `@gtbuchanan/hk-config` are renamed for clarity at the consumer call site:

- `lockfiles` → `lockfileExclude`
- new `vendorExclude` (`^vendor/`)
- composed into `defaultExclude`, the regex `fileHygiene` now applies and that consumers wire onto their own tool steps (`exclude = Defaults.defaultExclude`)

`vendorExclude` is anchored at `^vendor/`, so only a root `vendor/` is excluded — nested `packages/*/vendor/` is not, matching the termux precedent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)