### PR TITLE
Ship README and LICENSE in published npm packages

### DIFF
--- a/.changeset/publish-readme-license.md
+++ b/.changeset/publish-readme-license.md
@@ -1,0 +1,20 @@
+---
+'@gtbuchanan/cli': patch
+'@gtbuchanan/eslint-config': patch
+'@gtbuchanan/eslint-plugin-agent-skills': patch
+'@gtbuchanan/eslint-plugin-markdownlint': patch
+'@gtbuchanan/eslint-plugin-md-frontmatter': patch
+'@gtbuchanan/eslint-plugin-yamllint': patch
+'@gtbuchanan/pnpm-termux-shim': patch
+'@gtbuchanan/tsconfig': patch
+'@gtbuchanan/vitest-config': patch
+---
+
+Ship README and LICENSE in published npm tarballs
+
+`pack:npm` now copies each package's `README.md` and the workspace-root
+`LICENSE` into `dist/source/` (the directory `publishConfig.directory`
+redirects publishing to), and the published `package.json` carries a
+`license` field. A package-level `README`/`LICENSE`/`license` overrides the
+shared root one. Re-publishes every package so the first release's missing
+docs are corrected.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) George Taylor Buchanan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "type": "git",
     "url": "https://github.com/gtbuchanan/tooling.git"
   },
+  "license": "MIT",
   "type": "module",
   "scripts": {
     "build": "pnpm run gtb turbo run build",

--- a/packages/cli/skills/gtb-build-pipeline/SKILL.md
+++ b/packages/cli/skills/gtb-build-pipeline/SKILL.md
@@ -50,7 +50,11 @@ Leaf tasks, per-package, run via `gtb task <name>`:
 - `typecheck:ts` — TypeScript type checking
 - `compile:ts` — TypeScript compilation to `dist/source/`
 - `lint:eslint` — ESLint with cache + zero-warning threshold
-- `pack:npm` — npm tarball creation (publishable packages only)
+- `pack:npm` — npm tarball creation (publishable packages only). Writes the
+  cleaned `dist/source/package.json` and copies the package `README.md` plus
+  the workspace-root `LICENSE` (a package-level copy of either wins) into
+  `dist/source/` so the tarball ships them — npm only auto-includes them from
+  the publish directory that `publishConfig.directory` redirects to
 - `test:vitest:fast` — fast unit/integration tests with coverage
 - `test:vitest:slow` — slow tests (testcontainers, etc.) with coverage
 - `test:vitest:e2e` — e2e tests against packed tarballs, no coverage

--- a/packages/cli/skills/gtb-build-pipeline/SKILL.md
+++ b/packages/cli/skills/gtb-build-pipeline/SKILL.md
@@ -50,11 +50,9 @@ Leaf tasks, per-package, run via `gtb task <name>`:
 - `typecheck:ts` — TypeScript type checking
 - `compile:ts` — TypeScript compilation to `dist/source/`
 - `lint:eslint` — ESLint with cache + zero-warning threshold
-- `pack:npm` — npm tarball creation (publishable packages only). Writes the
-  cleaned `dist/source/package.json` and copies the package `README.md` plus
-  the workspace-root `LICENSE` (a package-level copy of either wins) into
-  `dist/source/` so the tarball ships them — npm only auto-includes them from
-  the publish directory that `publishConfig.directory` redirects to
+- `pack:npm` — npm tarball creation (publishable packages only); also copies
+  the package `README.md` and its `LICENSE` (the package's own, else the
+  workspace-root one) into `dist/source/` so the tarball ships them
 - `test:vitest:fast` — fast unit/integration tests with coverage
 - `test:vitest:slow` — slow tests (testcontainers, etc.) with coverage
 - `test:vitest:e2e` — e2e tests against packed tarballs, no coverage

--- a/packages/cli/src/commands/task/pack-npm.ts
+++ b/packages/cli/src/commands/task/pack-npm.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { cpSync, existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { defineCommand } from 'citty';
 import crossSpawn from 'cross-spawn';
@@ -9,6 +9,7 @@ import {
   RootManifestSchema,
   buildOutput,
   buildRepoFields,
+  resolveLicense,
 } from '../../lib/manifest.ts';
 import { toPosixRelative } from '../../lib/paths.ts';
 import {
@@ -44,13 +45,52 @@ const writeSourceManifest = (
   directory: string,
 ): void => {
   mkdirSync(target, { recursive: true });
+  const license = resolveLicense(manifest, root);
   const json = JSON.stringify(
-    { ...buildOutput(manifest), ...buildRepoFields(root, directory) },
+    {
+      ...buildOutput(manifest),
+      ...buildRepoFields(root, directory),
+      ...(license !== undefined && { license }),
+    },
     undefined,
     jsonIndent,
   );
   writeFileSync(path.join(target, 'package.json'), `${json}\n`);
   writeFileSync(path.join(target, '.npmignore'), npmignoreContent);
+};
+
+/**
+ * Resolves a doc file by package-then-root precedence: a package-level copy
+ * overrides the shared workspace-root one. Returns `undefined` when neither
+ * exists.
+ */
+const resolveDoc = (
+  rootDir: string,
+  pkgDir: string,
+  name: string,
+): string | undefined =>
+  [path.join(pkgDir, name), path.join(rootDir, name)].find(file =>
+    existsSync(file),
+  );
+
+/*
+ * npm auto-includes README/LICENSE only from the package directory, which
+ * `publishConfig.directory` redirects to `dist/source/` — so they must be
+ * copied there. A package-level README/LICENSE wins over the shared
+ * workspace-root file. In single-package mode `rootDir === pkgDir`, so both
+ * resolve to the same root.
+ */
+const copyPackageDocs = (
+  rootDir: string,
+  pkgDir: string,
+  target: string,
+): void => {
+  for (const name of ['README.md', 'LICENSE']) {
+    const source = resolveDoc(rootDir, pkgDir, name);
+    if (source !== undefined) {
+      cpSync(source, path.join(target, name));
+    }
+  }
 };
 
 const preparePackage = (
@@ -67,6 +107,7 @@ const preparePackage = (
   const target = path.join(pkgDir, dir);
   const directory = toPosixRelative(rootDir, pkgDir);
   writeSourceManifest(manifest, root, target, directory);
+  copyPackageDocs(rootDir, pkgDir, target);
 };
 
 const execPnpmPack = (pkgDir: string, destination: string): void => {
@@ -102,6 +143,7 @@ const prepareAndPack = (
   const target = path.join(pkgDir, dir);
   const directory = toPosixRelative(rootDir, pkgDir);
   writeSourceManifest(manifest, root, target, directory);
+  copyPackageDocs(rootDir, pkgDir, target);
   execPnpmPack(pkgDir, path.join(pkgDir, packDestination));
 };
 

--- a/packages/cli/src/commands/task/pack-npm.ts
+++ b/packages/cli/src/commands/task/pack-npm.ts
@@ -59,37 +59,38 @@ const writeSourceManifest = (
   writeFileSync(path.join(target, '.npmignore'), npmignoreContent);
 };
 
-/**
- * Resolves a doc file by package-then-root precedence: a package-level copy
- * overrides the shared workspace-root one. Returns `undefined` when neither
- * exists.
- */
-const resolveDoc = (
-  rootDir: string,
-  pkgDir: string,
-  name: string,
-): string | undefined =>
-  [path.join(pkgDir, name), path.join(rootDir, name)].find(file =>
-    existsSync(file),
-  );
+/** Returns the first candidate path that exists, or `undefined`. */
+const firstExisting = (...candidates: string[]): string | undefined =>
+  candidates.find(file => existsSync(file));
 
 /*
  * npm auto-includes README/LICENSE only from the package directory, which
  * `publishConfig.directory` redirects to `dist/source/` — so they must be
- * copied there. A package-level README/LICENSE wins over the shared
- * workspace-root file. In single-package mode `rootDir === pkgDir`, so both
- * resolve to the same root.
+ * copied there. A README is package-specific (only the package's own), while
+ * a LICENSE is repo-wide and falls back to the workspace-root copy when the
+ * package has none. In single-package mode `rootDir === pkgDir`, so both
+ * resolve to the root.
  */
 const copyPackageDocs = (
   rootDir: string,
   pkgDir: string,
   target: string,
 ): void => {
-  for (const name of ['README.md', 'LICENSE']) {
-    const source = resolveDoc(rootDir, pkgDir, name);
-    if (source !== undefined) {
-      cpSync(source, path.join(target, name));
+  const docs: readonly (readonly [name: string, source: string | undefined])[] = [
+    ['README.md', firstExisting(path.join(pkgDir, 'README.md'))],
+    ['LICENSE', firstExisting(path.join(pkgDir, 'LICENSE'), path.join(rootDir, 'LICENSE'))],
+  ];
+  for (const [name, source] of docs) {
+    const destination = path.join(target, name);
+    if (source === undefined) {
+      /*
+       * Drop a copy left by a prior run so a since-deleted doc isn't
+       * republished from a stale dist/source.
+       */
+      rmSync(destination, { force: true });
+      continue;
     }
+    cpSync(source, destination);
   }
 };
 

--- a/packages/cli/src/lib/manifest.ts
+++ b/packages/cli/src/lib/manifest.ts
@@ -24,6 +24,7 @@ export const RepositorySchema = v.object({
 export const RootManifestSchema = v.object({
   bugs: v.optional(v.string()),
   homepage: v.optional(v.string()),
+  license: v.optional(v.string()),
   repository: v.optional(RepositorySchema),
 });
 
@@ -34,6 +35,7 @@ export type RootManifest = v.InferOutput<typeof RootManifestSchema>;
 export const ManifestSchema = v.looseObject({
   dependencies: v.optional(v.record(v.string(), v.string())),
   devDependencies: v.optional(v.record(v.string(), v.string())),
+  license: v.optional(v.string()),
   name: v.optional(v.string()),
   private: v.optional(v.boolean()),
   publishConfig: v.optional(PublishConfigSchema),
@@ -46,7 +48,10 @@ export type Manifest = v.InferOutput<typeof ManifestSchema>;
 
 /**
  * Copies `bugs`, `homepage`, and `repository` from the root manifest,
- * scoping `homepage` and `repository.directory` to the given path.
+ * scoping `homepage` and `repository.directory` to the given path. These
+ * are repo coordinates and intentionally override any package-level value.
+ * `license` is handled separately ({@link resolveLicense}) because a
+ * package's own declaration takes precedence over the root default.
  */
 export const buildRepoFields = (
   root: RootManifest,
@@ -60,6 +65,15 @@ export const buildRepoFields = (
     repository: { ...root.repository, directory },
   }),
 });
+
+/**
+ * Resolves the published `license`, preferring a package's own declaration
+ * over the workspace-root default. Returns `undefined` when neither sets one.
+ */
+export const resolveLicense = (
+  manifest: Manifest,
+  root: RootManifest,
+): string | undefined => manifest.license ?? root.license;
 
 /**
  * `publishConfig` fields hoisted to top-level on packed manifests.

--- a/packages/cli/src/lib/turbo-config.ts
+++ b/packages/cli/src/lib/turbo-config.ts
@@ -192,15 +192,15 @@ const packTasks = (flags: ToolFlags): readonly ConditionalEntry<TurboTask>[] => 
         ...(flags.hasSkills ? [taskNames.compileSkills] : []),
       ],
       /*
-       * pack:npm copies the package README and the root (or package-level)
-       * LICENSE into dist/source so the published tarball ships them, and
-       * writes dist/source/package.json. Those self-generated files are
-       * excluded from the dist/source input glob — like the manifest, an
-       * input whose presence depends on a prior run salts the hash and
-       * prevents cache hits across fresh worktrees. Their sources (the repo
-       * LICENSE and per-package README/LICENSE) are inputs so an edit
-       * invalidates the cache, and the copies are outputs so a cache-hit
-       * publish restores them.
+       * pack:npm copies the package README and the package-or-root LICENSE
+       * into dist/source so the published tarball ships them, and writes
+       * dist/source/package.json. Those self-generated files are excluded
+       * from the dist/source input glob — like the manifest, an input whose
+       * presence depends on a prior run salts the hash and prevents cache
+       * hits across fresh worktrees. Their sources (the root LICENSE and
+       * per-package README/LICENSE) are inputs so an edit invalidates the
+       * cache, and the copies are outputs so a cache-hit publish restores
+       * them.
        */
       inputs: [
         '$TURBO_ROOT$/LICENSE',

--- a/packages/cli/src/lib/turbo-config.ts
+++ b/packages/cli/src/lib/turbo-config.ts
@@ -192,18 +192,28 @@ const packTasks = (flags: ToolFlags): readonly ConditionalEntry<TurboTask>[] => 
         ...(flags.hasSkills ? [taskNames.compileSkills] : []),
       ],
       /*
-       * Exclude the generated manifest from inputs: pack:npm writes
-       * `dist/source/package.json` as one of its outputs, and including it
-       * in the input glob makes the task's hash depend on whether a prior
-       * run left the file on disk. That prevents cache hits across fresh
-       * worktrees even when the source inputs are identical.
+       * pack:npm copies the package README and the root (or package-level)
+       * LICENSE into dist/source so the published tarball ships them, and
+       * writes dist/source/package.json. Those self-generated files are
+       * excluded from the dist/source input glob — like the manifest, an
+       * input whose presence depends on a prior run salts the hash and
+       * prevents cache hits across fresh worktrees. Their sources (the repo
+       * LICENSE and per-package README/LICENSE) are inputs so an edit
+       * invalidates the cache, and the copies are outputs so a cache-hit
+       * publish restores them.
        */
       inputs: [
+        '$TURBO_ROOT$/LICENSE',
         '$TURBO_ROOT$/package.json',
-        'dist/source/**', '!dist/source/package.json',
+        'LICENSE', 'README.md',
+        'dist/source/**',
+        '!dist/source/LICENSE', '!dist/source/README.md', '!dist/source/package.json',
         'package.json',
       ],
-      outputs: ['dist/packages/npm/**', 'dist/source/package.json'],
+      outputs: [
+        'dist/packages/npm/**',
+        'dist/source/LICENSE', 'dist/source/README.md', 'dist/source/package.json',
+      ],
     },
   },
 ];

--- a/packages/cli/test/manifest.test.ts
+++ b/packages/cli/test/manifest.test.ts
@@ -1,6 +1,11 @@
+import { faker } from '@faker-js/faker';
 import * as build from '@gtbuchanan/test-utils/builders';
 import { describe, it } from 'vitest';
-import { buildOutput, buildRepoFields } from '#src/lib/manifest.js';
+import {
+  buildOutput,
+  buildRepoFields,
+  resolveLicense,
+} from '#src/lib/manifest.js';
 
 describe.concurrent(buildOutput, () => {
   it('strips devDependencies and scripts', ({ expect }) => {
@@ -134,5 +139,34 @@ describe.concurrent(buildRepoFields, () => {
     expect(result).toStrictEqual({
       homepage: `${homepage}/tree/main/${directory}`,
     });
+  });
+
+  it('omits license (resolved separately)', ({ expect }) => {
+    const result = buildRepoFields(
+      { license: faker.lorem.word() },
+      build.packageDirectory(),
+    );
+
+    expect(result).not.toHaveProperty('license');
+  });
+});
+
+describe.concurrent(resolveLicense, () => {
+  it('prefers the package license over the root', ({ expect }) => {
+    const license = faker.lorem.word();
+
+    expect(resolveLicense({ license }, { license: faker.lorem.word() })).toBe(
+      license,
+    );
+  });
+
+  it('falls back to the root license', ({ expect }) => {
+    const license = faker.lorem.word();
+
+    expect(resolveLicense({}, { license })).toBe(license);
+  });
+
+  it('returns undefined when neither sets a license', ({ expect }) => {
+    expect(resolveLicense({}, {})).toBeUndefined();
   });
 });

--- a/packages/cli/test/prepack.test.ts
+++ b/packages/cli/test/prepack.test.ts
@@ -1,11 +1,36 @@
-import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
+import { faker } from '@faker-js/faker';
 import * as build from '@gtbuchanan/test-utils/builders';
 import { describe, it } from 'vitest';
 import { prepack } from '#src/commands/task/pack-npm.js';
 import { createTempDir } from './helpers.ts';
 
 const jsonIndent = 2;
+
+/** Scaffolds a workspace with one publishable package, returning its dirs. */
+const scaffoldPackage = (
+  root: string,
+  overrides: {
+    pkgManifest?: Record<string, unknown>;
+    rootManifest?: Record<string, unknown>;
+  } = {},
+): { publishDir: string; pkgDir: string } => {
+  const publishDir = build.publishDirectory();
+  const pkgDir = path.join(root, 'packages', build.packageName());
+  writeFileSync(
+    path.join(root, 'pnpm-workspace.yaml'),
+    "packages:\n  - 'packages/*'\n",
+  );
+  writeFormattedJson(root, 'package.json', { ...overrides.rootManifest });
+  mkdirSync(pkgDir, { recursive: true });
+  writeFormattedJson(pkgDir, 'package.json', {
+    name: build.scopedPackageName(),
+    publishConfig: { directory: publishDir },
+    ...overrides.pkgManifest,
+  });
+  return { pkgDir, publishDir };
+};
 
 /** Writes formatted JSON (matches prepack output for assertion). */
 const writeFormattedJson = (dir: string, name: string, data: unknown): void => {
@@ -170,6 +195,87 @@ describe.concurrent(prepack, () => {
     expect(() =>
       readFileSync(path.join(pkgDir, 'dist', 'source', 'package.json')),
     ).toThrow(/ENOENT/v);
+  });
+
+  it('copies the package README into the publish directory', ({ expect }) => {
+    const root = createTempDir();
+    const { pkgDir, publishDir } = scaffoldPackage(root);
+    const readme = faker.lorem.paragraph();
+    writeFileSync(path.join(pkgDir, 'README.md'), readme);
+
+    prepack({ cwd: root });
+
+    expect(
+      readFileSync(path.join(pkgDir, publishDir, 'README.md'), 'utf8'),
+    ).toBe(readme);
+  });
+
+  it('copies the root LICENSE into the publish directory', ({ expect }) => {
+    const root = createTempDir();
+    const { pkgDir, publishDir } = scaffoldPackage(root);
+    const license = faker.lorem.paragraph();
+    writeFileSync(path.join(root, 'LICENSE'), license);
+
+    prepack({ cwd: root });
+
+    expect(readFileSync(path.join(pkgDir, publishDir, 'LICENSE'), 'utf8')).toBe(
+      license,
+    );
+  });
+
+  it('prefers a package-level LICENSE over the root', ({ expect }) => {
+    const root = createTempDir();
+    const { pkgDir, publishDir } = scaffoldPackage(root);
+    const pkgLicense = faker.lorem.paragraph();
+    writeFileSync(path.join(root, 'LICENSE'), faker.lorem.paragraph());
+    writeFileSync(path.join(pkgDir, 'LICENSE'), pkgLicense);
+
+    prepack({ cwd: root });
+
+    expect(readFileSync(path.join(pkgDir, publishDir, 'LICENSE'), 'utf8')).toBe(
+      pkgLicense,
+    );
+  });
+
+  it('omits docs absent from both package and root', ({ expect }) => {
+    const root = createTempDir();
+    const { pkgDir, publishDir } = scaffoldPackage(root);
+
+    prepack({ cwd: root });
+
+    expect(existsSync(path.join(pkgDir, publishDir, 'README.md'))).toBe(false);
+    expect(existsSync(path.join(pkgDir, publishDir, 'LICENSE'))).toBe(false);
+  });
+
+  it('writes the license field from the root manifest', ({ expect }) => {
+    const root = createTempDir();
+    const license = faker.lorem.word();
+    const { pkgDir, publishDir } = scaffoldPackage(root, {
+      rootManifest: { license },
+    });
+
+    prepack({ cwd: root });
+
+    expect(readJson(path.join(pkgDir, publishDir, 'package.json'))).toHaveProperty(
+      'license',
+      license,
+    );
+  });
+
+  it('prefers the package license field over the root', ({ expect }) => {
+    const root = createTempDir();
+    const license = faker.lorem.word();
+    const { pkgDir, publishDir } = scaffoldPackage(root, {
+      pkgManifest: { license },
+      rootManifest: { license: faker.lorem.word() },
+    });
+
+    prepack({ cwd: root });
+
+    expect(readJson(path.join(pkgDir, publishDir, 'package.json'))).toHaveProperty(
+      'license',
+      license,
+    );
   });
 
   it('works in single-package mode', ({ expect }) => {

--- a/packages/cli/test/prepack.test.ts
+++ b/packages/cli/test/prepack.test.ts
@@ -8,13 +8,15 @@ import { createTempDir } from './helpers.ts';
 
 const jsonIndent = 2;
 
+interface ScaffoldPackageOverrides {
+  pkgManifest?: Record<string, unknown>;
+  rootManifest?: Record<string, unknown>;
+}
+
 /** Scaffolds a workspace with one publishable package, returning its dirs. */
 const scaffoldPackage = (
   root: string,
-  overrides: {
-    pkgManifest?: Record<string, unknown>;
-    rootManifest?: Record<string, unknown>;
-  } = {},
+  overrides: ScaffoldPackageOverrides = {},
 ): { publishDir: string; pkgDir: string } => {
   const publishDir = build.publishDirectory();
   const pkgDir = path.join(root, 'packages', build.packageName());
@@ -223,6 +225,18 @@ describe.concurrent(prepack, () => {
     );
   });
 
+  it('does not fall back to the root README (README is package-specific)', ({
+    expect,
+  }) => {
+    const root = createTempDir();
+    const { pkgDir, publishDir } = scaffoldPackage(root);
+    writeFileSync(path.join(root, 'README.md'), faker.lorem.paragraph());
+
+    prepack({ cwd: root });
+
+    expect(existsSync(path.join(pkgDir, publishDir, 'README.md'))).toBe(false);
+  });
+
   it('prefers a package-level LICENSE over the root', ({ expect }) => {
     const root = createTempDir();
     const { pkgDir, publishDir } = scaffoldPackage(root);
@@ -245,6 +259,20 @@ describe.concurrent(prepack, () => {
 
     expect(existsSync(path.join(pkgDir, publishDir, 'README.md'))).toBe(false);
     expect(existsSync(path.join(pkgDir, publishDir, 'LICENSE'))).toBe(false);
+  });
+
+  it('removes a stale doc left by a prior run when the source disappears', ({
+    expect,
+  }) => {
+    const root = createTempDir();
+    const { pkgDir, publishDir } = scaffoldPackage(root);
+    const stale = path.join(pkgDir, publishDir, 'README.md');
+    mkdirSync(path.dirname(stale), { recursive: true });
+    writeFileSync(stale, faker.lorem.paragraph());
+
+    prepack({ cwd: root });
+
+    expect(existsSync(stale)).toBe(false);
   });
 
   it('writes the license field from the root manifest', ({ expect }) => {

--- a/turbo.json
+++ b/turbo.json
@@ -142,13 +142,20 @@
         "compile:skills"
       ],
       "inputs": [
+        "$TURBO_ROOT$/LICENSE",
         "$TURBO_ROOT$/package.json",
+        "LICENSE",
+        "README.md",
         "dist/source/**",
+        "!dist/source/LICENSE",
+        "!dist/source/README.md",
         "!dist/source/package.json",
         "package.json"
       ],
       "outputs": [
         "dist/packages/npm/**",
+        "dist/source/LICENSE",
+        "dist/source/README.md",
         "dist/source/package.json"
       ]
     },


### PR DESCRIPTION
## Summary

The packages were published for the first time missing their `README` and `LICENSE`. npm only auto-includes those files from the *publish directory*, which `publishConfig.directory` redirects to `dist/source/` — but `pack:npm` only copied the generated manifest and `skills/` there. There was also no `LICENSE` file or `license` field anywhere in the repo.

- Add an MIT `LICENSE` (no copyright year, to avoid drift) and a root `license` field.
- `pack:npm` now copies each package's `README.md` and the workspace-root `LICENSE` into `dist/source/`, and the published `package.json` carries a `license` field.
- A package-level `README` / `LICENSE` / `license` overrides the shared root one (`resolveDoc` / `resolveLicense`, package-then-root precedence). `buildRepoFields` keeps root-precedence for the scoped repo coordinates; license is handled separately since the package should win.
- Wire the doc copies as `pack:npm` turbo inputs (cache invalidates on edit) and outputs (cache-hit publishes restore them), excluding the self-generated copies from the input glob like the existing `package.json` exclusion.
- Patch-bump every npm-published package so the next release re-publishes them with the corrected docs.

## Testing

- New `resolveLicense` units + `prepack` integration tests (README/LICENSE copy, package-over-root override, absent-docs, license-field precedence).
- `pnpm build` green (67/67 tasks, incl. e2e against packed tarballs); `gtb verify` reports no drift; lint clean.
- Verified end-to-end by packing `@gtbuchanan/eslint-config`: tarball ships `package/README.md` + `package/LICENSE`, manifest has `"license": "MIT"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)