### PR TITLE
Exclude @gtbuchanan/* from mise release-age quarantine

### DIFF
--- a/.changeset/mise-release-age-excludes.md
+++ b/.changeset/mise-release-age-excludes.md
@@ -1,0 +1,10 @@
+---
+---
+
+Exclude `@gtbuchanan/*` from mise's release-age quarantine
+
+Set a soft mise `min_version` of 2026.6.2 (the floor that supports
+`minimum_release_age_excludes`) and pin the `mise-setup` action to mise
+2026.6.11, then set `minimum_release_age_excludes = ["npm:@gtbuchanan/*"]`
+so fuzzy/`latest` resolution picks up our own just-cut releases without
+waiting out the 3-day supply-chain quarantine.

--- a/.github/actions/mise-setup/action.yml
+++ b/.github/actions/mise-setup/action.yml
@@ -35,7 +35,7 @@ runs:
     - uses: jdx/mise-action@v4.1.0
       with:
         cache: false
-        version: 2026.5.15
+        version: 2026.6.11
 
     # Prune unreferenced tool versions on inexact cache restore so the
     # re-saved cache does not grow unbounded across mise.lock changes

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,7 @@
+# Soft floor for minimum_release_age_excludes (below): older mise warns and
+# ignores the field instead of failing.
+min_version = { soft = "2026.6.2" }
+
 [env]
 # hk wraps hook steps in `mise x` so mise-managed tools resolve without
 # activation.
@@ -19,6 +23,9 @@ lockfile = true
 # in `[tools]` bypasses it, and Renovate already gates automated bumps at
 # 3 days.
 minimum_release_age = "3d"
+# Self-published packages never need the supply-chain quarantine — exclude
+# them so fuzzy/`latest` resolution picks up our own just-cut releases.
+minimum_release_age_excludes = ["npm:@gtbuchanan/*"]
 
 # mise.tasks.toml is generated and owned by `gtb sync`; this include is
 # the one manual hookup (gtb verify checks it).


### PR DESCRIPTION
## Summary

mise's `minimum_release_age = "3d"` quarantine also hides our own
just-published `@gtbuchanan/*` packages from fuzzy/`latest` resolution
(e.g. `mise up --bump`), so a freshly cut release can't be picked up for
3 days. Self-published packages never need the supply-chain quarantine.

## Changes

- `mise.toml`: add `minimum_release_age_excludes = ["npm:@gtbuchanan/*"]`
  and set top-level `min_version = "2026.6.2"` (the release that
  introduced the setting).
- `.github/actions/mise-setup/action.yml`: pin `jdx/mise-action` to mise
  `2026.6.11` (latest), satisfying the new `min_version` floor.

## Notes

- The exact glob form matters: mise honors the bare-backend wildcard and
  full IDs; `npm:@gtbuchanan/*` matches `npm:@gtbuchanan/cli` (the `*`
  covers the single name segment).
- mise caches the filtered remote version list and the cache key does
  **not** include `minimum_release_age_excludes`, so toggling the setting
  won't take effect until the cache expires or is cleared — worth knowing
  when verifying locally.
