### PR TITLE
Drop hk batching/diff workarounds fixed in hk 1.47

### DIFF
--- a/.changeset/hk-1-47-cleanup.md
+++ b/.changeset/hk-1-47-cleanup.md
@@ -1,0 +1,17 @@
+---
+'@gtbuchanan/hk-config': minor
+'@gtbuchanan/cli': patch
+---
+
+Drop hk batching/diff workarounds fixed upstream in hk 1.47
+
+hk 1.47 made auto-batching respect the platform command-line limit
+(cmd.exe on Windows) and added a no-merge-base fallback for ref diffs,
+so the local workarounds are no longer needed:
+
+- `@gtbuchanan/hk-config`: drop the `batchFiles` primitive and the
+  per-step `batch` wiring from `fileHygiene` — hk auto-batches under the
+  arg limit on its own.
+- `@gtbuchanan/cli`: `gtb hk all` no longer sets `HK_BATCH`, and
+  `gtb hk base` hands the range to hk as `--from-ref=<base> --to-ref=HEAD`
+  instead of pre-computing the changed-file list.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,7 +108,7 @@ coverage, setupFiles, and mock reset.
   - `eslint` / `no-commit-to-branch` — repo-specific, stay in `hk.pkl`
 - **`@gtbuchanan/hk-config` preset** (`packages/hk-config/Defaults.pkl`).
   The reusable building blocks (`fileHygiene`, `forbidSubmodules`,
-  `renovateConfig`, and the `defaultExclude`/`batchFiles` primitives) ship as a
+  `renovateConfig`, and the `defaultExclude` primitive) ship as a
   Pkl package — private to npm, published as a **GitHub release** so
   consumers `package://`-import it with sha256 integrity (see CD below).
   Consumer import:
@@ -161,7 +161,7 @@ coverage, setupFiles, and mock reset.
 `hk:all` / `hk:base` are mise tasks that run hk. They live in a generated,
 sync-owned `mise.tasks.toml` and call the `gtb hk` leaf command (ported
 from the old `mise-tasks/` bash: CI `check` vs local `fix`, shallow-clone
-base fetch, file diffing — see the `gtb-build-pipeline` skill).
+base fetch, base-ref diffing — see the `gtb-build-pipeline` skill).
 
 - **Generation.** `gtb sync` (or just `gtb sync mise`) writes
   `mise.tasks.toml`. It's loaded via a one-time manual
@@ -175,14 +175,6 @@ base fetch, file diffing — see the `gtb-build-pipeline` skill).
   `pnpm run gtb`; depends on `@gtbuchanan/cli` → `pnpm exec gtb`; neither
   (hk-only adopter) → bare `gtb` from mise's `npm:` backend (add
   `npm:@gtbuchanan/cli` to `[tools]`; no `node_modules` needed).
-- **Windows `cmd.exe` arg limit.** hk runs each step's command via
-  `cmd.exe` on Windows, whose 8191-char limit a full-repo run overflows;
-  hk's auto-batching is tuned for Unix `ARG_MAX`. `Defaults.fileHygiene`
-  (and the `eslint` step) gate batching on `HK_BATCH`, which `gtb hk all`
-  sets so hk chunks files (~one batch per core) under the limit. Commits
-  and `gtb hk base` leave it unset — batching splits small changesets into
-  one-file batches (repeated linter startup), so the common path stays
-  single-invocation. Tracked upstream: jdx/hk discussion #971.
 
 ### CI/CD workflows
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,7 +96,7 @@ coverage, setupFiles, and mock reset.
   2.54+ config-based hooks, wrapped in `mise x`). `hk.pkl` imports the
   shared `packages/hk-config/Defaults.pkl` preset and composes its steps:
   - File hygiene — `Defaults.fileHygiene` (large files, EOF newline, BOM,
-    trailing whitespace, each with the lockfile-exclude + batch pre-wired)
+    trailing whitespace, each with the lockfile-exclude pre-wired)
   - `actionlint` (`Builtins.actionlint`, binary via mise `aqua:rhysd/actionlint`)
   - `forbid-submodules` — `Defaults.forbidSubmodules`, a per-OS gitlink
     guard (no builtin)

--- a/hk.pkl
+++ b/hk.pkl
@@ -21,7 +21,6 @@ local allSteps = new Mapping<String, Step> {
     ["renovate-config"] = Defaults.renovateConfig
 
     ["eslint"] {
-        batch = Defaults.batchFiles
         check = "pnpm exec eslint \(eslintArgs)"
         fix = "pnpm exec eslint --fix \(eslintArgs)"
     }

--- a/packages/cli/skills/gtb-build-pipeline/SKILL.md
+++ b/packages/cli/skills/gtb-build-pipeline/SKILL.md
@@ -94,8 +94,8 @@ Run after adding packages, changing the task graph, or updating tooling. Without
 
 `gtb hk` runs the [hk](https://hk.jdx.dev) pre-commit hooks, and is what the generated `hk:all` / `hk:base` mise tasks call. It locally applies fixes and in CI runs a non-modifying check (keyed on the `CI` env var), mirroring prek's `run`.
 
-- `gtb hk base [ref] [-- <hk args>]` — runs hk on files changed from a base ref (default `origin/main`; pass a ref to override). On shallow clones it fetches the base first, then diffs `base..HEAD`. Forward args to hk after the ref, e.g. `gtb hk base -- -S eslint` targets a single hook.
-- `gtb hk all [-- <hk args>]` — runs hk across every file. Sets `HK_BATCH=1` so hk chunks the file list under Windows' `cmd.exe` 8191-char arg limit (the per-step commands hk shells out otherwise overflow). `base` and plain commits leave batching off so the common path stays single-invocation.
+- `gtb hk base [ref] [-- <hk args>]` — runs hk on files changed from a base ref (default `origin/main`; pass a ref to override). On shallow clones it fetches the base first, then hands the range to hk as `--from-ref=<base> --to-ref=HEAD`. Forward args to hk after the ref, e.g. `gtb hk base -- -S eslint` targets a single hook.
+- `gtb hk all [-- <hk args>]` — runs hk across every file.
 
 Invoked via mise (`mise run hk:base`) so hk and its tools resolve from mise. The mise task resolves `gtb` itself per repo shape — see the `mise.tasks.toml` notes above.
 

--- a/packages/cli/src/commands/root/hk.ts
+++ b/packages/cli/src/commands/root/hk.ts
@@ -88,11 +88,13 @@ export const executeHkBase = async (
 ): Promise<void> => {
   const { base, rest } = resolveBaseRef(rawArgs);
   // Shallow clones lack the base commit; fetch it so hk can diff against it.
-  // `git fetch origin` wants a remote branch name, so strip any `origin/`.
+  // A `<remote>/<branch>` base names the remote; a bare SHA/ref uses origin.
   const shallow = await deps.capture('git', ['rev-parse', '--is-shallow-repository']);
   if (shallow === 'true') {
-    const fetchRef = base.startsWith('origin/') ? base.slice('origin/'.length) : base;
-    await deps.run('git', { args: ['fetch', '--no-tags', '--depth=1', 'origin', fetchRef] });
+    const slash = base.indexOf('/');
+    const [remote, ref] =
+      slash === -1 ? ['origin', base] : [base.slice(0, slash), base.slice(slash + 1)];
+    await deps.run('git', { args: ['fetch', '--no-tags', '--depth=1', remote, ref] });
   }
   const plan = planHkBase({ base, mode: hkMode(deps.env), rest });
   await deps.run(plan.bin, { args: plan.args });

--- a/packages/cli/src/commands/root/hk.ts
+++ b/packages/cli/src/commands/root/hk.ts
@@ -81,6 +81,25 @@ export const executeHkAll = async (
   await deps.run(plan.bin, { args: plan.args });
 };
 
+/**
+ * Resolves the `git fetch` remote and ref for a base. Only a `<remote>/…`
+ * prefix that names a configured remote is split off (so `origin/main` →
+ * `origin main`); a bare SHA or a local branch with a slash (`feat/x`) is
+ * fetched from origin as-is.
+ */
+export const resolveFetchTarget = async (
+  base: string,
+  deps: HkRunnerDeps,
+): Promise<readonly [remote: string, ref: string]> => {
+  const slash = base.indexOf('/');
+  if (slash === -1) return ['origin', base];
+  const remote = base.slice(0, slash);
+  const configured = await deps.capture('git', ['remote']);
+  return configured.split('\n').includes(remote)
+    ? [remote, base.slice(slash + 1)]
+    : ['origin', base];
+};
+
 /** Runs hk over the files changed from the resolved base ref. */
 export const executeHkBase = async (
   rawArgs: readonly string[],
@@ -88,12 +107,9 @@ export const executeHkBase = async (
 ): Promise<void> => {
   const { base, rest } = resolveBaseRef(rawArgs);
   // Shallow clones lack the base commit; fetch it so hk can diff against it.
-  // A `<remote>/<branch>` base names the remote; a bare SHA/ref uses origin.
   const shallow = await deps.capture('git', ['rev-parse', '--is-shallow-repository']);
   if (shallow === 'true') {
-    const slash = base.indexOf('/');
-    const [remote, ref] =
-      slash === -1 ? ['origin', base] : [base.slice(0, slash), base.slice(slash + 1)];
+    const [remote, ref] = await resolveFetchTarget(base, deps);
     await deps.run('git', { args: ['fetch', '--no-tags', '--depth=1', remote, ref] });
   }
   const plan = planHkBase({ base, mode: hkMode(deps.env), rest });

--- a/packages/cli/src/commands/root/hk.ts
+++ b/packages/cli/src/commands/root/hk.ts
@@ -88,9 +88,11 @@ export const executeHkBase = async (
 ): Promise<void> => {
   const { base, rest } = resolveBaseRef(rawArgs);
   // Shallow clones lack the base commit; fetch it so hk can diff against it.
+  // `git fetch origin` wants a remote branch name, so strip any `origin/`.
   const shallow = await deps.capture('git', ['rev-parse', '--is-shallow-repository']);
   if (shallow === 'true') {
-    await deps.run('git', { args: ['fetch', '--no-tags', '--depth=1', 'origin', base] });
+    const fetchRef = base.startsWith('origin/') ? base.slice('origin/'.length) : base;
+    await deps.run('git', { args: ['fetch', '--no-tags', '--depth=1', 'origin', fetchRef] });
   }
   const plan = planHkBase({ base, mode: hkMode(deps.env), rest });
   await deps.run(plan.bin, { args: plan.args });

--- a/packages/cli/src/commands/root/hk.ts
+++ b/packages/cli/src/commands/root/hk.ts
@@ -29,10 +29,9 @@ export const resolveBaseRef = (argv: readonly string[]): BaseRef => {
 };
 
 /** A resolved hk invocation. */
-export interface HkSpawn {
+export interface HkInvocation {
   readonly args: readonly string[];
   readonly bin: 'hk';
-  readonly env: NodeJS.ProcessEnv;
 }
 
 /** Inputs to {@link planHkAll}. */
@@ -41,45 +40,29 @@ export interface PlanHkAllOptions {
   readonly rawArgs: readonly string[];
 }
 
-/**
- * Plans a full-repo hk run. Forces `HK_BATCH=1` so file-heavy steps
- * chunk under Windows' cmd.exe 8191-char limit — hk shells each step's
- * command through cmd.exe, and a full-repo file list overflows it
- * (jdx/hk#971). Off by default elsewhere so commits invoke each linter
- * once instead of per-chunk.
- */
-export const planHkAll = (options: PlanHkAllOptions): HkSpawn => ({
+/** Plans a full-repo hk run. */
+export const planHkAll = (options: PlanHkAllOptions): HkInvocation => ({
   args: [hkMode(options.env), '--all', ...options.rawArgs],
   bin: 'hk',
-  env: { ...options.env, HK_BATCH: '1' },
 });
-
-/** Plan for a base-diff hk run: skip when nothing changed, else spawn. */
-export type HkBasePlan =
-  | { readonly kind: 'skip' }
-  | { readonly args: readonly string[]; readonly bin: 'hk'; readonly kind: 'spawn' };
 
 /** Inputs to {@link planHkBase}. */
 export interface PlanHkBaseOptions {
-  readonly files: readonly string[];
+  readonly base: string;
   readonly mode: 'check' | 'fix';
   readonly rest: readonly string[];
 }
 
-/** Plans a base-diff hk run over the changed files. */
-export const planHkBase = (options: PlanHkBaseOptions): HkBasePlan =>
-  options.files.length === 0
-    ? { kind: 'skip' }
-    : {
-        args: [options.mode, ...options.rest, ...options.files],
-        bin: 'hk',
-        kind: 'spawn',
-      };
+/** Plans a base-diff hk run over the range from `base` to HEAD. */
+export const planHkBase = (options: PlanHkBaseOptions): HkInvocation => ({
+  args: [options.mode, `--from-ref=${options.base}`, '--to-ref=HEAD', ...options.rest],
+  bin: 'hk',
+});
 
 /**
  * Side-effecting I/O the runners depend on. Injected so the orchestration
- * (shallow fetch, diff, skip-vs-spawn) is unit-testable without spawning
- * git/hk; the citty wrappers wire the real implementations.
+ * (shallow detection, base fetch, hk spawn) is unit-testable without
+ * spawning git/hk; the citty wrappers wire the real implementations.
  */
 export interface HkRunnerDeps {
   readonly capture: (command: string, args: readonly string[]) => Promise<string>;
@@ -89,13 +72,13 @@ export interface HkRunnerDeps {
 
 const defaultDeps: HkRunnerDeps = { capture, env: process.env, run };
 
-/** Runs hk across all files (full-repo, with batching forced on). */
+/** Runs hk across all files. */
 export const executeHkAll = async (
   rawArgs: readonly string[],
   deps: HkRunnerDeps = defaultDeps,
 ): Promise<void> => {
   const plan = planHkAll({ env: deps.env, rawArgs });
-  await deps.run(plan.bin, { args: plan.args, env: plan.env });
+  await deps.run(plan.bin, { args: plan.args });
 };
 
 /** Runs hk over the files changed from the resolved base ref. */
@@ -104,26 +87,13 @@ export const executeHkBase = async (
   deps: HkRunnerDeps = defaultDeps,
 ): Promise<void> => {
   const { base, rest } = resolveBaseRef(rawArgs);
-  /*
-   * We diff ourselves rather than use hk's `--from-ref/--to-ref`, which
-   * resolves a merge base and errors on shallow clones with no two-dot
-   * fallback (jdx/hk#972). Shallow clones (CI) lack the base commit, so
-   * fetch it (depth 1) first; HEAD is then GitHub's test-merge commit,
-   * making `diff base HEAD` exactly the PR's changes.
-   */
+  // Shallow clones lack the base commit; fetch it so hk can diff against it.
   const shallow = await deps.capture('git', ['rev-parse', '--is-shallow-repository']);
   if (shallow === 'true') {
     await deps.run('git', { args: ['fetch', '--no-tags', '--depth=1', 'origin', base] });
   }
-  const diff = await deps.capture('git', ['diff', '--name-only', '--diff-filter=d', base, 'HEAD']);
-  const plan = planHkBase({
-    files: diff.length === 0 ? [] : diff.split('\n'),
-    mode: hkMode(deps.env),
-    rest,
-  });
-  if (plan.kind === 'spawn') {
-    await deps.run(plan.bin, { args: plan.args });
-  }
+  const plan = planHkBase({ base, mode: hkMode(deps.env), rest });
+  await deps.run(plan.bin, { args: plan.args });
 };
 
 const all = defineCommand({

--- a/packages/cli/test/hk.test.ts
+++ b/packages/cli/test/hk.test.ts
@@ -147,4 +147,21 @@ describe.concurrent(executeHkBase, () => {
       command: 'hk',
     });
   });
+
+  it('strips the origin/ prefix from the fetched ref on a shallow clone', async ({
+    expect,
+  }) => {
+    const { deps, runCalls } = stubDeps({ 'rev-parse': 'true' });
+
+    await executeHkBase([], deps);
+
+    expect(runCalls[0]).toMatchObject({
+      args: ['fetch', '--no-tags', '--depth=1', 'origin', 'main'],
+      command: 'git',
+    });
+    expect(runCalls[1]).toMatchObject({
+      args: ['fix', '--from-ref=origin/main', '--to-ref=HEAD'],
+      command: 'hk',
+    });
+  });
 });

--- a/packages/cli/test/hk.test.ts
+++ b/packages/cli/test/hk.test.ts
@@ -148,7 +148,7 @@ describe.concurrent(executeHkBase, () => {
     });
   });
 
-  it('strips the origin/ prefix from the fetched ref on a shallow clone', async ({
+  it('derives the remote and branch from a remote-tracking base ref', async ({
     expect,
   }) => {
     const { deps, runCalls } = stubDeps({ 'rev-parse': 'true' });
@@ -162,6 +162,19 @@ describe.concurrent(executeHkBase, () => {
     expect(runCalls[1]).toMatchObject({
       args: ['fix', '--from-ref=origin/main', '--to-ref=HEAD'],
       command: 'hk',
+    });
+  });
+
+  it('fetches a non-origin remote from the base ref, keeping nested branches', async ({
+    expect,
+  }) => {
+    const { deps, runCalls } = stubDeps({ 'rev-parse': 'true' });
+
+    await executeHkBase(['upstream/release/v2'], deps);
+
+    expect(runCalls[0]).toMatchObject({
+      args: ['fetch', '--no-tags', '--depth=1', 'upstream', 'release/v2'],
+      command: 'git',
     });
   });
 });

--- a/packages/cli/test/hk.test.ts
+++ b/packages/cli/test/hk.test.ts
@@ -80,88 +80,71 @@ describe.concurrent(hkMode, () => {
 });
 
 describe.concurrent(planHkAll, () => {
-  it('runs --all and forces batching to stay under the cmd.exe limit', ({ expect }) => {
-    const plan = planHkAll({ env: { CI: 'true' }, rawArgs: ['-S', 'eslint'] });
-
-    expect(plan).toMatchObject({
+  it('runs the mode against --all with forwarded args', ({ expect }) => {
+    expect(planHkAll({ env: { CI: 'true' }, rawArgs: ['-S', 'eslint'] })).toStrictEqual({
       args: ['check', '--all', '-S', 'eslint'],
       bin: 'hk',
     });
-    expect(plan.env['HK_BATCH']).toBe('1');
-  });
-
-  it('preserves the inherited env alongside HK_BATCH', ({ expect }) => {
-    const plan = planHkAll({ env: { FOO: 'bar' }, rawArgs: [] });
-
-    expect(plan.env).toMatchObject({ FOO: 'bar', HK_BATCH: '1' });
   });
 });
 
 describe.concurrent(planHkBase, () => {
-  it('skips when no files changed', ({ expect }) => {
-    expect(planHkBase({ files: [], mode: 'fix', rest: [] })).toStrictEqual({
-      kind: 'skip',
+  it('diffs the base ref against HEAD', ({ expect }) => {
+    expect(planHkBase({ base: 'origin/main', mode: 'fix', rest: [] })).toStrictEqual({
+      args: ['fix', '--from-ref=origin/main', '--to-ref=HEAD'],
+      bin: 'hk',
     });
   });
 
-  it('passes changed files after forwarded args', ({ expect }) => {
+  it('forwards passthrough args after the ref range', ({ expect }) => {
     expect(
-      planHkBase({ files: ['a.ts', 'b.ts'], mode: 'check', rest: ['-S', 'eslint'] }),
+      planHkBase({ base: 'HEAD~3', mode: 'check', rest: ['-S', 'eslint'] }),
     ).toStrictEqual({
-      args: ['check', '-S', 'eslint', 'a.ts', 'b.ts'],
+      args: ['check', '--from-ref=HEAD~3', '--to-ref=HEAD', '-S', 'eslint'],
       bin: 'hk',
-      kind: 'spawn',
     });
   });
 });
 
 describe.concurrent(executeHkAll, () => {
-  it('runs hk --all with batching forced on', async ({ expect }) => {
+  it('runs hk --all in the resolved mode', async ({ expect }) => {
     const { deps, runCalls } = stubDeps({}, { CI: 'true' });
 
     await executeHkAll(['-S', 'eslint'], deps);
 
-    expect(runCalls).toHaveLength(1);
-    expect(runCalls[0]).toMatchObject({
-      args: ['check', '--all', '-S', 'eslint'],
-      command: 'hk',
-    });
-    expect(runCalls[0]?.env?.['HK_BATCH']).toBe('1');
+    expect(runCalls).toStrictEqual([
+      { args: ['check', '--all', '-S', 'eslint'], command: 'hk', env: undefined },
+    ]);
   });
 });
 
 describe.concurrent(executeHkBase, () => {
-  it('fixes changed files without fetching on a full clone', async ({ expect }) => {
-    const { deps, runCalls, captureCalls } = stubDeps({
-      'diff': 'a.ts\nb.ts',
-      'rev-parse': 'false',
-    });
+  it('diffs the base against HEAD without fetching on a full clone', async ({ expect }) => {
+    const { deps, runCalls } = stubDeps({ 'rev-parse': 'false' });
 
     await executeHkBase([], deps);
 
     expect(runCalls).toStrictEqual([
-      { args: ['fix', 'a.ts', 'b.ts'], command: 'hk', env: undefined },
+      {
+        args: ['fix', '--from-ref=origin/main', '--to-ref=HEAD'],
+        command: 'hk',
+        env: undefined,
+      },
     ]);
-    expect(captureCalls.some(args => args.includes('origin/main'))).toBe(true);
   });
 
   it('fetches the base ref first on a shallow clone', async ({ expect }) => {
-    const { deps, runCalls } = stubDeps({ 'diff': 'a.ts', 'rev-parse': 'true' });
+    const { deps, runCalls } = stubDeps({ 'rev-parse': 'true' }, { CI: 'true' });
 
-    await executeHkBase(['HEAD~2'], deps);
+    await executeHkBase(['HEAD~2', '-S', 'eslint'], deps);
 
     expect(runCalls[0]).toMatchObject({
       args: ['fetch', '--no-tags', '--depth=1', 'origin', 'HEAD~2'],
       command: 'git',
     });
-    expect(runCalls[1]).toMatchObject({ args: ['fix', 'a.ts'], command: 'hk' });
-  });
-
-  it('skips hk entirely when nothing changed', async ({ expect }) => {
-    const { deps, runCalls } = stubDeps({ 'diff': '', 'rev-parse': 'false' });
-
-    await executeHkBase([], deps);
-
-    expect(runCalls).toHaveLength(0);
+    expect(runCalls[1]).toMatchObject({
+      args: ['check', '--from-ref=HEAD~2', '--to-ref=HEAD', '-S', 'eslint'],
+      command: 'hk',
+    });
   });
 });

--- a/packages/cli/test/hk.test.ts
+++ b/packages/cli/test/hk.test.ts
@@ -151,7 +151,7 @@ describe.concurrent(executeHkBase, () => {
   it('derives the remote and branch from a remote-tracking base ref', async ({
     expect,
   }) => {
-    const { deps, runCalls } = stubDeps({ 'rev-parse': 'true' });
+    const { deps, runCalls } = stubDeps({ 'remote': 'origin', 'rev-parse': 'true' });
 
     await executeHkBase([], deps);
 
@@ -165,15 +165,28 @@ describe.concurrent(executeHkBase, () => {
     });
   });
 
-  it('fetches a non-origin remote from the base ref, keeping nested branches', async ({
+  it('fetches a configured non-origin remote, keeping nested branches', async ({
     expect,
   }) => {
-    const { deps, runCalls } = stubDeps({ 'rev-parse': 'true' });
+    const { deps, runCalls } = stubDeps({ 'remote': 'origin\nupstream', 'rev-parse': 'true' });
 
     await executeHkBase(['upstream/release/v2'], deps);
 
     expect(runCalls[0]).toMatchObject({
       args: ['fetch', '--no-tags', '--depth=1', 'upstream', 'release/v2'],
+      command: 'git',
+    });
+  });
+
+  it('treats a slashed base whose prefix is not a remote as a branch on origin', async ({
+    expect,
+  }) => {
+    const { deps, runCalls } = stubDeps({ 'remote': 'origin', 'rev-parse': 'true' });
+
+    await executeHkBase(['feat/name'], deps);
+
+    expect(runCalls[0]).toMatchObject({
+      args: ['fetch', '--no-tags', '--depth=1', 'origin', 'feat/name'],
       command: 'git',
     });
   });

--- a/packages/hk-config/Defaults.pkl
+++ b/packages/hk-config/Defaults.pkl
@@ -1,7 +1,7 @@
 /// Shared hk building blocks for @gtbuchanan/tooling consumers. Import this
 /// and spread `fileHygiene` / add `forbidSubmodules` into your hooks; use
-/// `defaultExclude` / `batchFiles` to wire the same exclude+batch onto your
-/// own tool steps (eslint, etc.).
+/// `defaultExclude` to wire the same exclude onto your own tool steps
+/// (eslint, etc.).
 @ModuleInfo { minPklVersion = "0.27.2" }
 module gtbuchanan.hk.Defaults
 
@@ -18,17 +18,12 @@ vendorExclude: Regex = Regex(#"^vendor/"#)
 /// vendored sources. Wire onto your own steps with `exclude = Defaults.defaultExclude`.
 defaultExclude: Regex = Regex("\(lockfileExclude.pattern)|\(vendorExclude.pattern)")
 
-/// `gtb hk all` exports HK_BATCH=1 so file-heavy steps chunk under Windows'
-/// cmd.exe 8191-char limit (jdx/hk#971). Off by default elsewhere so commits
-/// invoke each linter once instead of per-chunk.
-batchFiles: Boolean = (read?("env:HK_BATCH") ?? "0") == "1"
-
-/// File-hygiene builtins with lockfile-exclude + batch already wired.
+/// File-hygiene builtins with the lockfile-exclude already wired.
 fileHygiene: Mapping<String, Config.Step> = new {
-  ["check-added-large-files"] = (Builtins.check_added_large_files) { exclude = defaultExclude; batch = batchFiles }
-  ["end-of-file-fixer"] = (Builtins.newlines) { exclude = defaultExclude; batch = batchFiles }
-  ["fix-byte-order-marker"] = (Builtins.byte_order_marker) { exclude = defaultExclude; batch = batchFiles }
-  ["trailing-whitespace"] = (Builtins.trailing_whitespace) { exclude = defaultExclude; batch = batchFiles }
+  ["check-added-large-files"] = (Builtins.check_added_large_files) { exclude = defaultExclude }
+  ["end-of-file-fixer"] = (Builtins.newlines) { exclude = defaultExclude }
+  ["fix-byte-order-marker"] = (Builtins.byte_order_marker) { exclude = defaultExclude }
+  ["trailing-whitespace"] = (Builtins.trailing_whitespace) { exclude = defaultExclude }
 }
 
 // POSIX gitlink (submodule, mode 160000) guard; the cmd.exe variant lives

--- a/packages/hk-config/README.md
+++ b/packages/hk-config/README.md
@@ -37,14 +37,13 @@ only inside the `renovate` npm package — add `npm:renovate` to your mise
 ## Building Blocks
 
 - `fileHygiene` — large-file, end-of-file-newline, byte-order-marker, and
-  trailing-whitespace fixers, each pre-wired with the default exclude and
-  `HK_BATCH`-gated batching.
+  trailing-whitespace fixers, each pre-wired with the default exclude.
 - `forbidSubmodules` — a per-OS gitlink (submodule) guard.
 - `renovateConfig` — validates `.github/renovate.json` via
   `renovate-config-validator`. Amend its `glob` to target a different file
   (e.g. `default.json` for preset-authoring repos).
-- `defaultExclude` / `batchFiles` — the default exclude regex (lockfiles plus
-  a root `vendor/`) and batch toggle, exposed so you can wire the same
-  behavior onto your own tool steps.
+- `defaultExclude` — the default exclude regex (lockfiles plus a root
+  `vendor/`), exposed so you can wire the same exclude onto your own tool
+  steps.
 - `lockfileExclude` / `vendorExclude` — the individual exclude regexes that
   compose `defaultExclude`, for steps that need only one.


### PR DESCRIPTION
hk 1.47 ([release notes](https://github.com/jdx/hk/releases/tag/v1.47.0)) closed out the two upstream issues this repo had local workarounds for, and we already pin hk 1.48. This removes both workarounds.

## What hk fixed

- **[jdx/hk#971](https://github.com/jdx/hk/discussions/971)** ([PR #974](https://github.com/jdx/hk/pull/974)) — auto-batching now respects the `cmd.exe` command-line limit (4095-byte safe length on Windows), so a full-repo run no longer overflows the 8191-char cap.
- **[jdx/hk#972](https://github.com/jdx/hk/discussions/972)** ([PR #975](https://github.com/jdx/hk/pull/975)) — `--from-ref`/`--to-ref` gained a no-merge-base fallback for shallow clones.

## Changes

- **`@gtbuchanan/hk-config`** — drop the `batchFiles` primitive and the per-step `batch` wiring from `fileHygiene`. hk auto-batches under the arg limit on its own.
- **`@gtbuchanan/cli`** — `gtb hk all` no longer sets `HK_BATCH`; `gtb hk base` hands the range to hk as `--from-ref=<base> --to-ref=HEAD` instead of pre-computing the changed-file list. The shallow base-fetch stays (hk still needs the object present). Anchoring `--to-ref=HEAD` (the merge commit) with the base as its ancestor keeps the merge base resolvable, so the target-branch-side-leakage trap (the one [energyworldnet/build#83](https://github.com/energyworldnet/build/pull/83) fixes by diffing against the PR head) doesn't arise.

## Validation

Ran a full-repo `hk check --all` on Windows with `HK_BATCH` unset: all `{{files}}`-referencing steps auto-batched 307 files into ~3 chunks and passed — no "command line is too long". The pre-commit hook on this PR's 8-file changeset stayed single-invocation, confirming small changesets aren't over-split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)