### PR TITLE
Add shellcheck to mise; guard actionlint hang on Windows

### DIFF
--- a/.changeset/shellcheck-mise.md
+++ b/.changeset/shellcheck-mise.md
@@ -1,0 +1,7 @@
+---
+---
+
+Add shellcheck to mise so actionlint lints workflow `run:` scripts.
+Disable actionlint's shellcheck integration on Windows only, where its
+stdin-pipe deadlock (rhysd/actionlint#650) hangs the hook; CI and other
+platforms keep full coverage.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,7 +97,11 @@ coverage, setupFiles, and mock reset.
   shared `packages/hk-config/Defaults.pkl` preset and composes its steps:
   - File hygiene — `Defaults.fileHygiene` (large files, EOF newline, BOM,
     trailing whitespace, each with the lockfile-exclude pre-wired)
-  - `actionlint` (`Builtins.actionlint`, binary via mise `aqua:rhysd/actionlint`)
+  - `actionlint` (`Builtins.actionlint`, binary via mise `aqua:rhysd/actionlint`).
+    actionlint runs `shellcheck` (mise `aqua:koalaman/shellcheck`) on workflow
+    `run:` scripts when it's on PATH; the hk.pkl step wraps the builtin to
+    disable shellcheck on Windows only, working around an actionlint deadlock
+    (see the comment there for mechanism and removal trigger).
   - `forbid-submodules` — `Defaults.forbidSubmodules`, a per-OS gitlink
     guard (no builtin)
   - `renovate-preset` / `renovate-config` — both derive from

--- a/hk.pkl
+++ b/hk.pkl
@@ -10,9 +10,26 @@ import "packages/hk-config/Defaults.pkl"
 // eslint args shared by the step's check/fix; only `--fix` differs.
 local eslintArgs = "--max-warnings=0 --no-warn-ignored {{files}}"
 
+// actionlint pipes each `run:` script to shellcheck's stdin before starting
+// the process, so a script larger than the kernel pipe buffer deadlocks the
+// hook (rhysd/actionlint#650). Buffer sizes are smaller on Windows/macOS than
+// on Linux, so it bites our Windows-primary dev loop but not CI. Disable
+// shellcheck on Windows only; CI (Linux) and other platforms reuse the
+// builtin's command verbatim (no drift) and keep full shellcheck coverage.
+// The upstream fix (#651) is merged but unreleased as of actionlint 1.7.12 —
+// drop this guard once a release containing it lands.
+local actionlintCheck: String = Builtins.actionlint.check
+
 local allSteps = new Mapping<String, Step> {
     ...Defaults.fileHygiene
-    ["actionlint"] = Builtins.actionlint
+    ["actionlint"] = (Builtins.actionlint) {
+        check = new Script {
+            windows = "actionlint -shellcheck= {{ files }}"
+            linux = actionlintCheck
+            macos = actionlintCheck
+            other = actionlintCheck
+        }
+    }
     ["forbid-submodules"] = Defaults.forbidSubmodules
 
     // Both validate via Defaults.renovateConfig (npm:renovate on PATH from

--- a/mise.lock
+++ b/mise.lock
@@ -168,3 +168,35 @@ provenance = "github-attestations"
 checksum = "sha256:91c753435542b04859c689304fae0dd64eba6b40937cfa426a48485b712e4e9c"
 url = "https://github.com/pnpm/pnpm/releases/download/v11.6.0/pnpm-win32-x64.zip"
 provenance = "github-attestations"
+
+[[tools.shellcheck]]
+version = "0.11.0"
+backend = "aqua:koalaman/shellcheck"
+
+[tools.shellcheck."platforms.linux-arm64"]
+checksum = "sha256:12b331c1d2db6b9eb13cfca64306b1b157a86eb69db83023e261eaa7e7c14588"
+url = "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.linux.aarch64.tar.xz"
+
+[tools.shellcheck."platforms.linux-arm64-musl"]
+checksum = "sha256:12b331c1d2db6b9eb13cfca64306b1b157a86eb69db83023e261eaa7e7c14588"
+url = "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.linux.aarch64.tar.xz"
+
+[tools.shellcheck."platforms.linux-x64"]
+checksum = "sha256:8c3be12b05d5c177a04c29e3c78ce89ac86f1595681cab149b65b97c4e227198"
+url = "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.linux.x86_64.tar.xz"
+
+[tools.shellcheck."platforms.linux-x64-musl"]
+checksum = "sha256:8c3be12b05d5c177a04c29e3c78ce89ac86f1595681cab149b65b97c4e227198"
+url = "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.linux.x86_64.tar.xz"
+
+[tools.shellcheck."platforms.macos-arm64"]
+checksum = "sha256:56affdd8de5527894dca6dc3d7e0a99a873b0f004d7aabc30ae407d3f48b0a79"
+url = "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.darwin.aarch64.tar.xz"
+
+[tools.shellcheck."platforms.macos-x64"]
+checksum = "sha256:3c89db4edcab7cf1c27bff178882e0f6f27f7afdf54e859fa041fca10febe4c6"
+url = "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.darwin.x86_64.tar.xz"
+
+[tools.shellcheck."platforms.windows-x64"]
+checksum = "sha256:8a4e35ab0b331c85d73567b12f2a444df187f483e5079ceffa6bda1faa2e740e"
+url = "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.zip"

--- a/mise.toml
+++ b/mise.toml
@@ -49,3 +49,6 @@ hk = "1.48.0"
 node = "24.16.0"
 "npm:renovate" = "43.213.1"
 pkl = "0.31.1"
+# actionlint shells out to shellcheck to lint `run:` step scripts; without it
+# on PATH that analysis is silently skipped (and a stale shim errors locally).
+shellcheck = "0.11.0"


### PR DESCRIPTION
## What

actionlint shells each workflow `run:` script out to `shellcheck` when it's on PATH, but `shellcheck` wasn't a real mise tool — so that analysis was **silently skipped** in CI, and a stale shim made it **error** locally. This pins `shellcheck` `0.11.0` in mise so the integration actually works.

## The Windows catch

Enabling shellcheck surfaced an actionlint bug: it writes each `run:` script to shellcheck's stdin *before* starting the process, relying on the kernel pipe buffer to absorb it. A script larger than that buffer **deadlocks the hook** ([rhysd/actionlint#650](https://github.com/rhysd/actionlint/issues/650)). Linux's larger buffers mask it, but our Windows-primary dev loop hangs hard on `dependency-review.yml`'s 7.7 KB `run:` block.

The hk `actionlint` step now wraps the builtin with a per-OS `check` that passes `-shellcheck=` (disabled) **on Windows only**. CI (Linux) and macOS/other reuse the builtin's command verbatim (referenced, not copied — no drift) and keep full shellcheck coverage.

The upstream fix ([#651](https://github.com/rhysd/actionlint/pull/651)) is merged but **unreleased** as of actionlint `1.7.12` — both the code comment and AGENTS.md note to drop the guard once a release ships it.

## Verification

- `shellcheck` resolves via mise (`aqua:koalaman/shellcheck`), `mise.lock` pinned for all platforms incl. `windows-x64`.
- Direct shellcheck run over all workflow `run:` scripts: **0 findings** (our workflows are clean).
- `hk check --all --step actionlint` on Windows: hung indefinitely before → **7.3s, rc=0** now.
- `pnpm build` (full pipeline incl. e2e): **67/67 tasks pass**. `gtb verify`: no drift.

## Changeset

Empty (no published package affected — `shellcheck` lands in repo-local `mise.toml`/`mise.lock` and the guard in repo-local `hk.pkl`; the published `@gtbuchanan/hk-config` preset is untouched).