### PR TITLE
Stop pre-commit checks from blocking the changesets release

### DIFF
--- a/.changeset/changelog-duplicate-headings-siblings-only.md
+++ b/.changeset/changelog-duplicate-headings-siblings-only.md
@@ -1,0 +1,11 @@
+---
+'@gtbuchanan/eslint-config': patch
+---
+
+Scope CHANGELOG duplicate-heading lint to siblings only
+
+`markdown/no-duplicate-headings` now uses `checkSiblingsOnly` for
+`**/CHANGELOG.md`, so the `### Minor Changes` / `### Patch Changes`
+sections that changesets repeats across version headings no longer trip
+the rule (it still flags genuine duplicate siblings within one section).
+Authored Markdown keeps full duplicate-heading enforcement.

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -63,8 +63,14 @@ jobs:
       # and execs it without a shell, so `&&` (and everything after) would be
       # passed to changesets as bogus positional args ("Too many arguments
       # passed to changesets").
+      #
+      # `HK=0` skips the hk pre-commit hook on changesets/action's automated
+      # commit (mise's postinstall installs the hook in CI too). A
+      # machine-generated release commit shouldn't run dev hooks — the release
+      # PR's own `Pre-Commit` CI is the enforcement point.
       - env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          HK: '0'
         id: changesets-action
         uses: changesets/action@v1
         with:

--- a/packages/eslint-config/src/plugins/markdown.ts
+++ b/packages/eslint-config/src/plugins/markdown.ts
@@ -36,13 +36,21 @@ const plugin: PluginFactory = () => [
     rules: { ...cfg.rules, ...extraRules, ...prettierConflicts },
   })),
   {
-    /*
-     * Changesets writes `[<commit>] <message>` for each entry, where
-     * `[<commit>]` is parsed as a reference-style link with no matching
-     * definition. The rule otherwise applies on authored Markdown.
-     */
     files: ['**/CHANGELOG.md'],
-    rules: { 'markdown/no-missing-label-refs': 'off' },
+    rules: {
+      /*
+       * Each version section repeats `### Minor Changes` / `### Patch
+       * Changes`, duplicates only across (non-sibling) version headings.
+       * `checkSiblingsOnly` still flags genuine duplicate siblings within a
+       * section. The rule otherwise applies fully to authored Markdown.
+       */
+      'markdown/no-duplicate-headings': ['warn', { checkSiblingsOnly: true }],
+      /*
+       * Changesets writes `[<commit>] <message>` per entry, where
+       * `[<commit>]` parses as a reference-style link with no definition.
+       */
+      'markdown/no-missing-label-refs': 'off',
+    },
   },
 ];
 


### PR DESCRIPTION
## Context

Follow-up to #185. That PR fixed the `&&`-chaining bug so `gtb version` runs, but merging it exposed two further release-pipeline blockers that the original crash had masked (no release had ever gotten far enough to hit them). The release run after #185 (`27697541608`) confirmed `gtb version` works — `🦋 All files have been updated`, all 4 changesets consumed — then failed on these two:

## Fixes

**1. hk pre-commit hook fires on changesets/action's automated commit.**
mise's `postinstall` installs the git hook in CI too, so the bot's release commit ran the dev pre-commit hook and failed. A machine-generated release commit shouldn't run dev hooks — the release PR's own `Pre-Commit` CI is the enforcement point. → `HK=0` on the changesets/action step (`cd.yml`).

**2. `markdown/no-duplicate-headings` flags changeset CHANGELOGs.**
The rule is `warn` globally (fatal under `--max-warnings=0`), and the existing `**/CHANGELOG.md` override only disabled `no-missing-label-refs`. Changeset CHANGELOGs repeat `### Minor Changes` / `### Patch Changes` across version sections — duplicates only across non-sibling version headings. This broke the version commit's hook **and** would break the release PR's `Pre-Commit` CI. → scope the rule to `['warn', { checkSiblingsOnly: true }]` for `CHANGELOG.md`, which still catches genuine duplicate *siblings* within one section.

## Verify

- `checkSiblingsOnly` behavior validated directly: a changeset-style CHANGELOG (cross-version `### Minor Changes` repeats) lints clean; a true sibling duplicate within one version section is still flagged.
- `@gtbuchanan/eslint-config` build + typecheck + lint + e2e (26 tests, incl. markdownlint coverage) all green.

The changeset-check reusable already exempts the release branch (`github.head_ref != 'changeset-release/main'`), so the release PR won't trip it.

> [!NOTE]
> Pre-commit hook bypassed locally for the commit (the same unrelated `shellcheck` mise-shim env gap as #185; CI re-runs `actionlint` correctly). `cd.yml`'s only `run:` script is unchanged from #185, which passed actionlint in CI.