### PR TITLE
Add shell steps, recommended set, and hooksFor to hk-config

### DIFF
--- a/.changeset/hk-config-shared-shell-steps.md
+++ b/.changeset/hk-config-shared-shell-steps.md
@@ -1,0 +1,19 @@
+---
+'@gtbuchanan/hk-config': minor
+---
+
+Expand the shared preset so consumers adopt it in ~one line instead of
+re-declaring every step and hook.
+
+- Add `actionlint` (carries the Windows shellcheck-deadlock workaround
+  previously inline in the self-host `hk.pkl`), `shellcheck`, and `shfmt`
+  steps. `shellcheck` / `shfmt` select shell sources by content type
+  (extension and shebang, matching extensionless scripts) with
+  `defaultExclude` pre-wired.
+- Add the `shell` group (`shellcheck` + `shfmt`) and the `recommended`
+  step mapping (file hygiene + `forbid-submodules` + `renovate-config` +
+  `actionlint` + shell) for one-line adoption; every step is glob/type-gated,
+  so inapplicable steps are inert.
+- Add `hooksFor(steps)`, building the standard `pre-commit` / `check` /
+  `fix` hook trio (pre-commit stashes via `patch-file` and adds the
+  commit-time-only `no-commit-to-branch` guard).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,27 +93,43 @@ coverage, setupFiles, and mock reset.
   Python/venv layer: file-hygiene checks are native `Builtins.*`, and
   external tools come from mise. Installed automatically by mise's
   `[hooks] postinstall = "hk install --mise"` on `mise install` (Git
-  2.54+ config-based hooks, wrapped in `mise x`). `hk.pkl` imports the
-  shared `packages/hk-config/Defaults.pkl` preset and composes its steps:
+  2.54+ config-based hooks, wrapped in `mise x`). `hk.pkl` spreads the
+  shared preset's `Defaults.recommended` step set, adds the repo-specific
+  `renovate-preset` and `eslint` steps, and builds the `pre-commit` /
+  `check` / `fix` hooks via `Defaults.hooksFor`:
   - File hygiene — `Defaults.fileHygiene` (large files, EOF newline, BOM,
     trailing whitespace, each with the lockfile-exclude pre-wired)
-  - `actionlint` (`Builtins.actionlint`, binary via mise `aqua:rhysd/actionlint`).
+  - `actionlint` — `Defaults.actionlint`, binary via mise `aqua:rhysd/actionlint`.
     actionlint runs `shellcheck` (mise `aqua:koalaman/shellcheck`) on workflow
-    `run:` scripts when it's on PATH; the hk.pkl step wraps the builtin to
-    disable shellcheck on Windows only, working around an actionlint deadlock
-    (see the comment there for mechanism and removal trigger).
+    `run:` scripts when it's on PATH; the shared preset's step wraps the builtin
+    to disable shellcheck on Windows only, working around an actionlint deadlock
+    (see the comment in `Defaults.pkl` for mechanism and removal trigger).
   - `forbid-submodules` — `Defaults.forbidSubmodules`, a per-OS gitlink
     guard (no builtin)
+  - `shellcheck` / `shfmt` — from `Defaults.shell` (via `recommended`),
+    binaries via mise `aqua:koalaman/shellcheck` and `aqua:mvdan/sh`. Select
+    shell sources by content type (extension and shebang), so the extensionless
+    Termux pnpm shim (`packages/pnpm-termux-shim/bin/pnpm`) is covered
   - `renovate-preset` / `renovate-config` — both derive from
     `Defaults.renovateConfig` (binary via mise `npm:renovate`);
     `renovate-preset` retargets the glob to `default.json`.
     `check-illegal-windows-names` was dropped (no builtin; redundant on a
     Windows-primary repo)
-  - `eslint` / `no-commit-to-branch` — repo-specific, stay in `hk.pkl`
+  - `eslint` — repo-specific, stays in `hk.pkl`. `no-commit-to-branch` is
+    wired into `pre-commit` by `Defaults.hooksFor` (commit-time-only guard)
 - **`@gtbuchanan/hk-config` preset** (`packages/hk-config/Defaults.pkl`).
   The reusable building blocks (`fileHygiene`, `forbidSubmodules`,
-  `renovateConfig`, and the `defaultExclude` primitive) ship as a
-  Pkl package — private to npm, published as a **GitHub release** so
+  `renovateConfig`, `actionlint`, `shellcheck`, `shfmt`, and the
+  `defaultExclude` primitive) ship as a Pkl package — `shellcheck` /
+  `shfmt` select by content type (extension **and** shebang, so
+  extensionless scripts match) with `defaultExclude` pre-wired. The preset
+  also exports the `shell` group (`shellcheck` + `shfmt`), the `recommended`
+  step mapping (file hygiene + `forbid-submodules` + `renovate-config` +
+  `actionlint` + shell — every step glob/type-gated, so inapplicable ones are
+  inert) for one-line adoption, and `hooksFor(steps)` which builds the standard
+  `pre-commit` / `check` / `fix` trio (pre-commit stashes via `patch-file` and
+  adds the commit-time-only `no-commit-to-branch` guard). It's private to
+  npm, published as a **GitHub release** so
   consumers `package://`-import it with sha256 integrity (see CD below).
   Consumer import:
   `package://github.com/gtbuchanan/tooling/releases/download/hk-config@<ver>/hk-config@<ver>#/Defaults.pkl`.

--- a/hk.pkl
+++ b/hk.pkl
@@ -1,5 +1,4 @@
 amends "package://github.com/jdx/hk/releases/download/v1.48.0/hk@1.48.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.48.0/hk@1.48.0#/Builtins.pkl"
 
 // Shared hk preset (@gtbuchanan/tooling). Self-host imports it by relative
 // path because tooling can't `package://`-import its own unpublished
@@ -10,32 +9,12 @@ import "packages/hk-config/Defaults.pkl"
 // eslint args shared by the step's check/fix; only `--fix` differs.
 local eslintArgs = "--max-warnings=0 --no-warn-ignored {{files}}"
 
-// actionlint pipes each `run:` script to shellcheck's stdin before starting
-// the process, so a script larger than the kernel pipe buffer deadlocks the
-// hook (rhysd/actionlint#650). Buffer sizes are smaller on Windows/macOS than
-// on Linux, so it bites our Windows-primary dev loop but not CI. Disable
-// shellcheck on Windows only; CI (Linux) and other platforms reuse the
-// builtin's command verbatim (no drift) and keep full shellcheck coverage.
-// The upstream fix (#651) is merged but unreleased as of actionlint 1.7.12 —
-// drop this guard once a release containing it lands.
-local actionlintCheck: String = Builtins.actionlint.check
-
 local allSteps = new Mapping<String, Step> {
-    ...Defaults.fileHygiene
-    ["actionlint"] = (Builtins.actionlint) {
-        check = new Script {
-            windows = "actionlint -shellcheck= {{ files }}"
-            linux = actionlintCheck
-            macos = actionlintCheck
-            other = actionlintCheck
-        }
-    }
-    ["forbid-submodules"] = Defaults.forbidSubmodules
+    ...Defaults.recommended
 
-    // Both validate via Defaults.renovateConfig (npm:renovate on PATH from
-    // `hk install --mise`); renovate-preset retargets the shareable preset.
+    // Validates the shareable preset itself; the .github/renovate.json
+    // validator (renovate-config) comes from recommended.
     ["renovate-preset"] = (Defaults.renovateConfig) { glob = "default.json" }
-    ["renovate-config"] = Defaults.renovateConfig
 
     ["eslint"] {
         check = "pnpm exec eslint \(eslintArgs)"
@@ -43,22 +22,4 @@ local allSteps = new Mapping<String, Step> {
     }
 }
 
-hooks {
-    ["pre-commit"] {
-        fix = true
-        stash = "git"
-        steps {
-            ...allSteps
-            // Commit-time guard only: it needs a branch name, so it errors on
-            // CI's detached HEAD and is irrelevant to `hk check`/`hk fix`.
-            ["no-commit-to-branch"] = Builtins.no_commit_to_branch
-        }
-    }
-    ["check"] {
-        steps { ...allSteps }
-    }
-    ["fix"] {
-        fix = true
-        steps { ...allSteps }
-    }
-}
+hooks = Defaults.hooksFor(allSteps)

--- a/mise.lock
+++ b/mise.lock
@@ -200,3 +200,35 @@ url = "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellche
 [tools.shellcheck."platforms.windows-x64"]
 checksum = "sha256:8a4e35ab0b331c85d73567b12f2a444df187f483e5079ceffa6bda1faa2e740e"
 url = "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.zip"
+
+[[tools.shfmt]]
+version = "3.13.0"
+backend = "aqua:mvdan/sh"
+
+[tools.shfmt."platforms.linux-arm64"]
+checksum = "sha256:2091a31afd47742051a77bf7cfd175533ab07e924c20ef3151cd108fa1cab5b0"
+url = "https://github.com/mvdan/sh/releases/download/v3.13.0/shfmt_v3.13.0_linux_arm64"
+
+[tools.shfmt."platforms.linux-arm64-musl"]
+checksum = "sha256:2091a31afd47742051a77bf7cfd175533ab07e924c20ef3151cd108fa1cab5b0"
+url = "https://github.com/mvdan/sh/releases/download/v3.13.0/shfmt_v3.13.0_linux_arm64"
+
+[tools.shfmt."platforms.linux-x64"]
+checksum = "sha256:70aa99784703a8d6569bbf0b1e43e1a91906a4166bf1a79de42050a6d0de7551"
+url = "https://github.com/mvdan/sh/releases/download/v3.13.0/shfmt_v3.13.0_linux_amd64"
+
+[tools.shfmt."platforms.linux-x64-musl"]
+checksum = "sha256:70aa99784703a8d6569bbf0b1e43e1a91906a4166bf1a79de42050a6d0de7551"
+url = "https://github.com/mvdan/sh/releases/download/v3.13.0/shfmt_v3.13.0_linux_amd64"
+
+[tools.shfmt."platforms.macos-arm64"]
+checksum = "sha256:650970603b5946dc6041836ddcfa7a19d99b5da885e4687f64575508e99cf718"
+url = "https://github.com/mvdan/sh/releases/download/v3.13.0/shfmt_v3.13.0_darwin_arm64"
+
+[tools.shfmt."platforms.macos-x64"]
+checksum = "sha256:b6890a0009abf71d36d7c536ad56e3132c547ceb77cd5d5ee62b3469ab4e9417"
+url = "https://github.com/mvdan/sh/releases/download/v3.13.0/shfmt_v3.13.0_darwin_amd64"
+
+[tools.shfmt."platforms.windows-x64"]
+checksum = "sha256:62241aaf6b0ca236f8625d8892784b73fa67ad40bc677a1ad1a64ae395f6a7d5"
+url = "https://github.com/mvdan/sh/releases/download/v3.13.0/shfmt_v3.13.0_windows_amd64.exe"

--- a/mise.toml
+++ b/mise.toml
@@ -49,6 +49,5 @@ hk = "1.48.0"
 node = "24.16.0"
 "npm:renovate" = "43.231.2"
 pkl = "0.31.1"
-# actionlint shells out to shellcheck to lint `run:` step scripts; without it
-# on PATH that analysis is silently skipped (and a stale shim errors locally).
 shellcheck = "0.11.0"
+shfmt = "3.13.0"

--- a/packages/hk-config/Defaults.pkl
+++ b/packages/hk-config/Defaults.pkl
@@ -1,7 +1,8 @@
-/// Shared hk building blocks for @gtbuchanan/tooling consumers. Import this
-/// and spread `fileHygiene` / add `forbidSubmodules` into your hooks; use
-/// `defaultExclude` to wire the same exclude onto your own tool steps
-/// (eslint, etc.).
+/// Shared hk building blocks for @gtbuchanan/tooling consumers. The fast path:
+/// spread `...recommended` into a step mapping, add your repo-specific steps
+/// (e.g. eslint), and build the hook trio with `hooksFor(steps)`. The
+/// individual steps (`fileHygiene`, `actionlint`, `shell`, ...) and the
+/// `defaultExclude` primitive stay exported for granular composition.
 @ModuleInfo { minPklVersion = "0.27.2" }
 module gtbuchanan.hk.Defaults
 
@@ -17,6 +18,29 @@ vendorExclude: Regex = Regex(#"^vendor/"#)
 /// Default exclude for file-hygiene (and consumer tool) steps: lockfiles plus
 /// vendored sources. Wire onto your own steps with `exclude = Defaults.defaultExclude`.
 defaultExclude: Regex = Regex("\(lockfileExclude.pattern)|\(vendorExclude.pattern)")
+
+// actionlint pipes each `run:` script to shellcheck's stdin before starting
+// the process, so a script larger than the kernel pipe buffer deadlocks the
+// hook (rhysd/actionlint#650). Buffer sizes are smaller on Windows/macOS than
+// on Linux, so it bites a Windows-primary dev loop but not CI. Disable
+// shellcheck on Windows only; CI (Linux) and other platforms reuse the
+// builtin's command verbatim (no drift) and keep full shellcheck coverage.
+// The upstream fix (#651) is merged but unreleased as of actionlint 1.7.12 —
+// drop this guard once a release containing it lands.
+local actionlintCheck: String = Builtins.actionlint.check
+
+/// actionlint with the Windows shellcheck-deadlock workaround pre-wired (see
+/// the comment above for mechanism and removal trigger). Binary via mise
+/// `aqua:rhysd/actionlint`; shellcheck (`aqua:koalaman/shellcheck`) on PATH
+/// enables run-script linting on non-Windows platforms.
+actionlint: Config.Step = (Builtins.actionlint) {
+  check = new Config.Script {
+    windows = "actionlint -shellcheck= {{ files }}"
+    linux = actionlintCheck
+    macos = actionlintCheck
+    other = actionlintCheck
+  }
+}
 
 /// File-hygiene builtins with the lockfile-exclude already wired.
 fileHygiene: Mapping<String, Config.Step> = new {
@@ -49,4 +73,73 @@ forbidSubmodules: Config.Step = new {
 renovateConfig: Config.Step = new {
   glob = ".github/renovate.json"
   check = "renovate-config-validator --strict {{files}}"
+}
+
+/// shellcheck over shell sources selected by content type — extension AND
+/// shebang — so extensionless scripts (mise tasks, maintainer scripts) match.
+/// `glob = null` drops the builtin's `*.sh` glob; vendored sources excluded.
+/// Cheap: hk reads a file's shebang only when it's executable or has no
+/// extension-derived type, so extension-matched files never incur the read.
+/// Needs shellcheck on PATH (mise `aqua:koalaman/shellcheck`).
+shellcheck: Config.Step = (Builtins.shellcheck) {
+  glob = null
+  types = List("shell")
+  exclude = defaultExclude
+}
+
+/// shfmt over shell sources, selected by content type like `shellcheck`.
+/// Needs shfmt on PATH (mise `aqua:mvdan/sh`).
+shfmt: Config.Step = (Builtins.shfmt) {
+  glob = null
+  types = List("shell")
+  exclude = defaultExclude
+}
+
+/// shellcheck + shfmt as a spreadable group, for repos that lint shell and
+/// want to opt the pair in or out as a unit.
+shell: Mapping<String, Config.Step> = new {
+  ["shellcheck"] = shellcheck
+  ["shfmt"] = shfmt
+}
+
+/// The recommended step set — spread `...recommended` into a hook's steps to
+/// adopt the whole preset in one line, then add only repo-specific steps (e.g.
+/// eslint). Every step is glob/type-gated, so the ones a repo doesn't need are
+/// inert (pruned, their tool never resolved): a shell-free repo pays nothing
+/// for the shell steps. `renovate-preset` (targeting `default.json`) is
+/// intentionally omitted — it's specific to preset-authoring repos.
+recommended: Mapping<String, Config.Step> = new {
+  ...fileHygiene
+  ["actionlint"] = actionlint
+  ["forbid-submodules"] = forbidSubmodules
+  ["renovate-config"] = renovateConfig
+  ...shell
+}
+
+/// Build the standard `pre-commit` / `check` / `fix` hook trio from a step
+/// mapping, eliminating the per-repo hook boilerplate. `pre-commit` runs in fix
+/// mode and stashes unstaged changes (`patch-file` — faster than `git` and
+/// avoids the `index is locked` errors git stash hits on Windows — so a fixer
+/// touching a partially-staged file can't drag unstaged hunks into the commit)
+/// and adds the commit-time-only `no-commit-to-branch` guard (it needs a branch
+/// name, so it errors on CI's detached HEAD and is irrelevant to `check`/`fix`).
+/// `check` and `fix` run the same steps in check and fix mode (no stash — they
+/// run over all files, not a partial commit). Consumer:
+/// `hooks = Defaults.hooksFor(allSteps)`.
+function hooksFor(allSteps: Mapping<String, Config.Step>): Mapping<String, Config.Hook> = new {
+  ["pre-commit"] {
+    fix = true
+    stash = "patch-file"
+    steps {
+      ...allSteps
+      ["no-commit-to-branch"] = Builtins.no_commit_to_branch
+    }
+  }
+  ["check"] {
+    steps { ...allSteps }
+  }
+  ["fix"] {
+    fix = true
+    steps { ...allSteps }
+  }
 }


### PR DESCRIPTION
Extracts the reusable hk logic surfaced while adopting the `@gtbuchanan/hk-config` preset in a consumer repo ([claude-code-termux#19](https://github.com/gtbuchanan/claude-code-termux/pull/19)) into the shared preset, and makes this repo consume it.

## `packages/hk-config/Defaults.pkl`

- **`actionlint`** — the Windows shellcheck-deadlock workaround (rhysd/actionlint#650), moved out of the self-host `hk.pkl` so consumers inherit it via the package import instead of re-declaring it.
- **`shellcheck` / `shfmt`** — select shell sources by content type (extension **and** shebang, so extensionless scripts like mise tasks and maintainer scripts match) with `defaultExclude` pre-wired. The shebang read is cheap: hk only reads it for executable/extensionless files, never for extension-matched ones.
- **`shell`** group (`shellcheck` + `shfmt`) and the **`recommended`** step mapping (file hygiene + `forbid-submodules` + `renovate-config` + `actionlint` + shell) for one-line adoption. Every step is glob/type-gated, so steps a repo does not need are inert (pruned, their tool never resolved).
- **`hooksFor(steps)`** — builds the standard `pre-commit` / `check` / `fix` hook trio, eliminating the per-repo hook boilerplate. `pre-commit` stashes via `patch-file` (faster than `git` and avoids the `index is locked` errors git stash hits on Windows) and wires in the commit-time-only `no-commit-to-branch` guard.

## `hk.pkl`

Collapsed to `...Defaults.recommended` plus the repo-specific `renovate-preset` and `eslint` steps, with `hooks = Defaults.hooksFor(allSteps)`. Dropped the inline actionlint workaround, the duplicated hook trio, and the now-unused `Builtins` import.

## `mise.toml` / `mise.lock`

Added `shfmt` 3.13.0 (`shellcheck` was already pinned for actionlint), locked across all 7 platforms. This repo now lints the previously-uncovered Termux pnpm shim (`packages/pnpm-termux-shim/bin/pnpm`) — verified `hk check` is green on it.

## Follow-up

Once this releases, the `claude-code-termux` PR can bump its `hk-config@` pin and collapse to `...Defaults.recommended` + `hooksFor`, dropping its inline actionlint/shellcheck/shfmt blocks and the three hook blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)