### PR TITLE
Sign CD changesets version commit via GitHub API

### DIFF
--- a/.changeset/cd-signed-version-commit.md
+++ b/.changeset/cd-signed-version-commit.md
@@ -1,0 +1,4 @@
+---
+---
+
+Sign the changesets version commit and tags via the GitHub API

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -74,6 +74,9 @@ jobs:
         id: changesets-action
         uses: changesets/action@v1
         with:
+          # GPG-sign the version commit + tags (default git-cli leaves them
+          # unverified).
+          commitMode: github-api
           github-token: ${{ steps.app-token.outputs.token }}
           version: ${{ inputs.gtb-from-source && 'pnpm run gtb' || 'pnpm exec gtb' }} version
 


### PR DESCRIPTION
`changesets/action` defaults to `commitMode: git-cli`, which pushes the version commit and tags via the local git CLI — leaving them unverified. This switches to `commitMode: github-api` so they're GPG-signed and attributed to the GitHub App owning the token (already wired in via `create-github-app-token`).

Mirrors the Renovate preset's `platformCommit: "enabled"` verified-bot-commit policy, so the changesets release commit/tags get the same verified checkmark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)