### PR TITLE
Fix mise-setup cross-drive EXDEV on Windows

### DIFF
--- a/.github/actions/mise-setup/action.yml
+++ b/.github/actions/mise-setup/action.yml
@@ -32,7 +32,15 @@ runs:
         restore-keys: |
           mise-${{ runner.os }}-${{ runner.arch }}-
 
-    - uses: jdx/mise-action@v4.2.0
+    # mise-action unzips mise under os.tmpdir() then renames (io.mv) the binary
+    # into MISE_DATA_DIR. On Windows os.tmpdir() is on C: but MISE_DATA_DIR sits
+    # on runner.temp (D:), and the cross-drive rename fails with EXDEV — so point
+    # the process temp at the same volume as MISE_DATA_DIR for this step.
+    - env:
+        TEMP: ${{ runner.temp }}
+        TMP: ${{ runner.temp }}
+        TMPDIR: ${{ runner.temp }}
+      uses: jdx/mise-action@v4.2.0
       with:
         cache: false
         version: 2026.6.11


### PR DESCRIPTION
## Problem

`mise-setup` fails on Windows runners during tool install:

```
##[error]EXDEV: cross-device link not permitted, rename
'C:\Users\RUNNER~1\AppData\Local\Temp\...\mise.exe' -> 'D:\a\_temp\.mise\bin\mise.exe'
```

The action sets `MISE_DATA_DIR: ${{ runner.temp }}/.mise`, which on Windows runners is on **D:**. But `jdx/mise-action` unzips mise under `os.tmpdir()` (**C:**) and then `io.mv`s the binary into `MISE_DATA_DIR` — `io.mv` is a bare `fs.rename`, which can't cross drives, so it throws `EXDEV`. `jdx/mise-action@v4.2.0` is the latest, so no version bump fixes it.

This only surfaced now because it's the first Windows CI to consume this action (dotfiles' new cross-platform template-render matrix).

## Fix

Point the mise-action step's process temp (`TEMP`/`TMP`/`TMPDIR`) at `runner.temp`, so the download/unzip and `MISE_DATA_DIR` live on the **same volume** and the rename stays intra-drive. `MISE_DATA_DIR` stays exactly where it is — on the fast, roomy `runner.temp` disk (`D:`), not relocated to the OS drive. Scoped to the single step, so nothing else's temp changes; unconditional across OSes since `runner.temp` is a valid temp dir everywhere and non-Windows never hit `EXDEV`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)