### PR TITLE
Fix gtb CLI crash under TypeScript 7

### DIFF
--- a/.changeset/cli-typescript7-startup-crash.md
+++ b/.changeset/cli-typescript7-startup-crash.md
@@ -1,0 +1,15 @@
+---
+'@gtbuchanan/cli': patch
+---
+
+Fix `gtb` crashing on startup when TypeScript 7 is the resolved compiler
+
+`tsconfig-gen` resolved a package's build `include` through the classic
+`typescript` compiler API (`ts.sys`, `ts.readConfigFile`,
+`ts.parseJsonConfigFileContent`). TypeScript 7 restructured its npm package so
+those are no longer exposed from the main entry, leaving `ts.sys` undefined and
+crashing every `gtb` command at module load. The build `include` is now read
+with `get-tsconfig`, which mirrors tsc's `extends` resolution — relative paths
+and node_modules package specifiers alike — without depending on the
+`typescript` package. `typescript` remains a peer dependency for the
+`tsc`-backed `compile:ts` / `typecheck:ts` tasks.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -30,6 +30,7 @@
     "citty": "catalog:",
     "cross-spawn": "catalog:",
     "find-up-simple": "catalog:",
+    "get-tsconfig": "catalog:",
     "hosted-git-info": "catalog:",
     "smol-toml": "catalog:",
     "valibot": "catalog:",

--- a/packages/cli/src/lib/tsconfig-gen.ts
+++ b/packages/cli/src/lib/tsconfig-gen.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import ts from 'typescript';
+import { parseTsconfig } from 'get-tsconfig';
 import * as v from 'valibot';
 import type { PackageCapabilities } from './discovery.ts';
 import { readJsonFile } from './file-writer.ts';
@@ -11,43 +11,25 @@ export const typeCheckInclude = ['bin', 'scripts', 'src', 'test', 'e2e', '*', '.
 /** Directories included in tsconfig.build.json for compilation. */
 export const buildInclude = ['bin', 'src'] as const;
 
-const ReadConfigSchema = v.object({
-  config: v.unknown(),
-  error: v.optional(v.unknown()),
-});
-
-const ResolvedConfigSchema = v.object({
-  include: v.optional(StringArray),
-});
-
-const readFile = (path: string): string | undefined => ts.sys.readFile(path);
-
-/** Stub host that skips directory scanning — we only need the resolved config. */
-const parseHost: ts.ParseConfigHost = {
-  fileExists: path => ts.sys.fileExists(path),
-  readDirectory: () => [],
-  readFile,
-  useCaseSensitiveFileNames: ts.sys.useCaseSensitiveFileNames,
-};
-
 /**
- * Resolves the effective `include` from a tsconfig.build.json using the
- * TypeScript API. Lets `parseJsonConfigFileContent` handle extends
- * resolution. Falls back to {@link buildInclude} if resolution fails.
+ * Resolves the effective `include` globs from a package's tsconfig.build.json,
+ * following `extends` — including node_modules package specifiers and their
+ * `exports` maps — via {@link parseTsconfig}, which mirrors tsc's resolution
+ * without depending on the `typescript` package. The globs feed turbo's
+ * `compile:ts` cache inputs, so patterns (e.g. `*.proto.ts`) are preserved
+ * verbatim rather than expanded to matched files; an `include` inherited from
+ * an extended config is rebased to that config's location, matching tsc. Falls
+ * back to {@link buildInclude} when the file is missing, unparsable, or its
+ * `extends` chain cannot be resolved.
  */
 export const resolveBuildIncludes = (dir: string): readonly string[] => {
-  const configPath = path.join(dir, 'tsconfig.build.json');
-  const raw = v.safeParse(ReadConfigSchema, ts.readConfigFile(configPath, readFile));
-  if (!raw.success || raw.output.error !== undefined) {
+  try {
+    const { include } = parseTsconfig(path.join(dir, 'tsconfig.build.json'));
+    const result = v.safeParse(StringArray, include);
+    return result.success ? result.output : buildInclude;
+  } catch {
     return buildInclude;
   }
-
-  const parsed = ts.parseJsonConfigFileContent(
-    raw.output.config, parseHost, dir, undefined, configPath,
-  );
-  const result = v.safeParse(ResolvedConfigSchema, parsed.raw);
-
-  return result.success ? result.output.include ?? buildInclude : buildInclude;
 };
 
 /** Shape of a generated tsconfig file. */

--- a/packages/cli/test/tsconfig-gen.test.ts
+++ b/packages/cli/test/tsconfig-gen.test.ts
@@ -1,0 +1,103 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, it } from 'vitest';
+import { buildInclude, resolveBuildIncludes } from '#src/lib/tsconfig-gen.js';
+import { createTempDir } from './helpers.ts';
+
+const writeConfig = (dir: string, name: string, content: string): void => {
+  writeFileSync(path.join(dir, name), content);
+};
+
+describe.concurrent(resolveBuildIncludes, () => {
+  it('reads the explicit include array from tsconfig.build.json', ({ expect }) => {
+    const dir = createTempDir();
+    writeConfig(
+      dir, 'tsconfig.build.json', JSON.stringify({ include: ['bin', 'src', 'generated'] }),
+    );
+
+    expect(resolveBuildIncludes(dir)).toStrictEqual(['bin', 'src', 'generated']);
+  });
+
+  it('preserves glob patterns verbatim rather than expanding to files', ({ expect }) => {
+    const dir = createTempDir();
+    writeConfig(dir, 'tsconfig.build.json', JSON.stringify({ include: ['src', '*.proto.ts'] }));
+
+    expect(resolveBuildIncludes(dir)).toStrictEqual(['src', '*.proto.ts']);
+  });
+
+  it('tolerates comments and trailing commas (JSONC)', ({ expect }) => {
+    const dir = createTempDir();
+    writeConfig(dir, 'tsconfig.build.json', [
+      '{',
+      '  // build inputs',
+      '  "include": ["bin", "src",], /* trailing comma */',
+      '}',
+    ].join('\n'));
+
+    expect(resolveBuildIncludes(dir)).toStrictEqual(['bin', 'src']);
+  });
+
+  it('follows relative extends when the child omits include', ({ expect }) => {
+    const dir = createTempDir();
+    writeConfig(dir, 'base.json', JSON.stringify({ include: ['lib'] }));
+    writeConfig(dir, 'tsconfig.build.json', JSON.stringify({ extends: './base.json' }));
+
+    expect(resolveBuildIncludes(dir)).toStrictEqual(['lib']);
+  });
+
+  it('resolves an extends target that omits the .json extension', ({ expect }) => {
+    const dir = createTempDir();
+    writeConfig(dir, 'base.json', JSON.stringify({ include: ['lib'] }));
+    writeConfig(dir, 'tsconfig.build.json', JSON.stringify({ extends: './base' }));
+
+    expect(resolveBuildIncludes(dir)).toStrictEqual(['lib']);
+  });
+
+  it('lets the nearest include win over an extended one', ({ expect }) => {
+    const dir = createTempDir();
+    writeConfig(dir, 'base.json', JSON.stringify({ include: ['lib'] }));
+    writeConfig(
+      dir, 'tsconfig.build.json', JSON.stringify({ extends: './base.json', include: ['src'] }),
+    );
+
+    expect(resolveBuildIncludes(dir)).toStrictEqual(['src']);
+  });
+
+  it('falls back to buildInclude when the file is missing', ({ expect }) => {
+    const dir = createTempDir();
+
+    expect(resolveBuildIncludes(dir)).toStrictEqual([...buildInclude]);
+  });
+
+  it('resolves an extends that points to a node_modules package (via exports)', ({ expect }) => {
+    const dir = createTempDir();
+    const pkgDir = path.join(dir, 'node_modules', '@acme', 'base');
+    mkdirSync(pkgDir, { recursive: true });
+    writeConfig(pkgDir, 'package.json', JSON.stringify({
+      name: '@acme/base', version: '1.0.0', exports: { './build': './tsconfig.build.json' },
+    }));
+    writeConfig(pkgDir, 'tsconfig.build.json', JSON.stringify({ include: ['src', '*.proto.ts'] }));
+    writeConfig(dir, 'tsconfig.build.json', JSON.stringify({ extends: '@acme/base/build' }));
+
+    // An inherited include is rebased to the extended config's location (tsc semantics).
+    expect(resolveBuildIncludes(dir)).toStrictEqual([
+      'node_modules/@acme/base/src', 'node_modules/@acme/base/*.proto.ts',
+    ]);
+  });
+
+  it('falls back to buildInclude when an extends package cannot be resolved', ({ expect }) => {
+    const dir = createTempDir();
+    writeConfig(
+      dir, 'tsconfig.build.json', JSON.stringify({ extends: '@nonexistent/tsconfig-xyz' }),
+    );
+
+    expect(resolveBuildIncludes(dir)).toStrictEqual([...buildInclude]);
+  });
+
+  it('falls back to buildInclude on malformed content', ({ expect }) => {
+    const dir = createTempDir();
+    writeConfig(dir, 'tsconfig.build.json', '{ this is not json');
+
+    expect(resolveBuildIncludes(dir)).toStrictEqual([...buildInclude]);
+  });
+});

--- a/packages/cli/test/tsconfig-gen.test.ts
+++ b/packages/cli/test/tsconfig-gen.test.ts
@@ -53,6 +53,15 @@ describe.concurrent(resolveBuildIncludes, () => {
     expect(resolveBuildIncludes(dir)).toStrictEqual(['lib']);
   });
 
+  it('follows a multi-level extends chain to an inherited include', ({ expect }) => {
+    const dir = createTempDir();
+    writeConfig(dir, 'grandparent.json', JSON.stringify({ include: ['lib'] }));
+    writeConfig(dir, 'parent.json', JSON.stringify({ extends: './grandparent.json' }));
+    writeConfig(dir, 'tsconfig.build.json', JSON.stringify({ extends: './parent.json' }));
+
+    expect(resolveBuildIncludes(dir)).toStrictEqual(['lib']);
+  });
+
   it('lets the nearest include win over an extended one', ({ expect }) => {
     const dir = createTempDir();
     writeConfig(dir, 'base.json', JSON.stringify({ include: ['lib'] }));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,6 +102,9 @@ catalogs:
     find-up-simple:
       specifier: ^1.0.1
       version: 1.0.1
+    get-tsconfig:
+      specifier: ^4.14.0
+      version: 4.14.0
     hosted-git-info:
       specifier: ^10.1.1
       version: 10.1.1
@@ -241,6 +244,9 @@ importers:
       find-up-simple:
         specifier: 'catalog:'
         version: 1.0.1
+      get-tsconfig:
+        specifier: 'catalog:'
+        version: 4.14.0
       hosted-git-info:
         specifier: 'catalog:'
         version: 10.1.1
@@ -1898,6 +1904,9 @@ packages:
 
   get-tsconfig@4.13.7:
     resolution: {integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==}
+
+  get-tsconfig@4.14.0:
+    resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
 
   git-hooks-list@4.2.1:
     resolution: {integrity: sha512-WNvqJjOxxs/8ZP9+DWdwWJ7cDsd60NHf39XnD82pDVrKO5q7xfPqpkK6hwEAmBa/ZSEE4IOoR75EzbbIuwGlMw==}
@@ -4357,6 +4366,10 @@ snapshots:
   get-east-asian-width@1.5.0: {}
 
   get-tsconfig@4.13.7:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  get-tsconfig@4.14.0:
     dependencies:
       resolve-pkg-maps: 1.0.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -35,6 +35,7 @@ catalog:
   eslint-plugin-unicorn: ^70.0.0
   eslint-plugin-yml: 3.5.0
   find-up-simple: ^1.0.1
+  get-tsconfig: ^4.14.0
   hosted-git-info: ^10.1.1
   jiti: ^2.6.1
   markdownlint: ^0.41.0


### PR DESCRIPTION
## Problem

TypeScript 7.0 became npm `latest` and restructured its package — the main entry no longer exposes the classic compiler API. `@gtbuchanan/cli` declares `typescript` as a peer dep (`>=5.0.0`), so the e2e fixture's fresh install now pulls TS 7, and `packages/cli/src/lib/tsconfig-gen.ts` — which read a package's build `include` via `ts.sys` / `ts.readConfigFile` / `ts.parseJsonConfigFileContent` — crashed at module load (`Cannot read properties of undefined (reading 'useCaseSensitiveFileNames')`). Every `gtb` command exited 1, so `CI / E2E Test` failed on all open PRs built after TS 7 shipped.

## Fix

Read the build `include` with [`get-tsconfig`](https://github.com/privatenumber/get-tsconfig) instead of the `typescript` compiler API. It mirrors tsc's `extends` resolution — relative paths **and** node_modules package specifiers (including `exports` maps) — without depending on the `typescript` package, so it's immune to TypeScript version churn. The resolved `include` is returned as glob patterns verbatim (they feed turbo's `compile:ts` cache inputs, so they must stay globs — not resolved file lists). `typescript` remains a peer dependency for the `tsc`-backed `compile:ts` / `typecheck:ts` tasks.

## Notes

- Added `resolveBuildIncludes` unit tests, including node_modules package-`extends` resolution — the crash slipped through because the function was only exercised by the e2e suite.
- Verified locally and in CI: `gtb verify`, the CLI fast tests, and the CLI e2e suite (which fresh-installs TS 7.0.2) all pass.
- Does **not** add support for TS 7's `tsc`/tsgo for the `compile:ts` path; that's a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)