### PR TITLE
Revert @vitest/eslint-plugin 1.6.21 bump

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,5 +2,14 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>gtbuchanan/tooling"
+  ],
+  "packageRules": [
+    {
+      "allowedVersions": "!/^1\\.6\\.21$/",
+      "description": "Skip @vitest/eslint-plugin 1.6.21: vitest/valid-expect false-positives on expect.any (upstream vitest-dev/eslint-plugin-vitest#924, fixed in 1.6.22 via #925). Remove once >=1.6.22 is adopted.",
+      "matchPackageNames": [
+        "@vitest/eslint-plugin"
+      ]
+    }
   ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,8 +49,8 @@ catalogs:
       specifier: ^4.1.2
       version: 4.1.9
     '@vitest/eslint-plugin':
-      specifier: 1.6.21
-      version: 1.6.21
+      specifier: 1.6.20
+      version: 1.6.20
     ajv:
       specifier: ^8.20.0
       version: 8.20.0
@@ -320,7 +320,7 @@ importers:
         version: 5.10.0(eslint@10.6.0(jiti@2.7.0))
       '@vitest/eslint-plugin':
         specifier: 'catalog:'
-        version: 1.6.21(@typescript-eslint/eslint-plugin@8.62.1(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)(vitest@4.1.9)
+        version: 1.6.20(@typescript-eslint/eslint-plugin@8.62.1(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)(vitest@4.1.9)
       eslint:
         specifier: ^10.0.0
         version: 10.6.0(jiti@2.7.0)
@@ -1340,8 +1340,8 @@ packages:
       '@vitest/browser':
         optional: true
 
-  '@vitest/eslint-plugin@1.6.21':
-    resolution: {integrity: sha512-5nu7QuW5Dg9v4I9t9ZiU1Hh91BoG0x3lOzOWYTsr1bqpIqcHYzFSQ052LvZwGtEm7Trh+Mr2heYEmZ4LkDjfaA==}
+  '@vitest/eslint-plugin@1.6.20':
+    resolution: {integrity: sha512-xRwWHFG0Utp6hXtbGiWk4VdKXCGdExD8kbWrrmFEiG5dk8anOJ+vbWbeOa8EbkocKQRTsx7JAWETccZiBgFp/Q==}
     engines: {node: '>=18'}
     peerDependencies:
       '@typescript-eslint/eslint-plugin': '*'
@@ -3831,7 +3831,7 @@ snapshots:
       tinyrainbow: 3.1.0
       vitest: 4.1.9(@types/node@25.9.5)(@vitest/coverage-v8@4.1.9)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.9.5)(jiti@2.7.0)(yaml@2.9.0))
 
-  '@vitest/eslint-plugin@1.6.21(@typescript-eslint/eslint-plugin@8.62.1(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)(vitest@4.1.9)':
+  '@vitest/eslint-plugin@1.6.20(@typescript-eslint/eslint-plugin@8.62.1(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)(vitest@4.1.9)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.62.1
       '@typescript-eslint/utils': 8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,7 +17,7 @@ catalog:
   '@types/mdast': ^4.0.4
   '@types/node': ^25.5.0
   '@vitest/coverage-v8': ^4.1.2
-  '@vitest/eslint-plugin': 1.6.21
+  '@vitest/eslint-plugin': 1.6.20
   ajv: ^8.20.0
   citty: ^0.2.2
   console-fail-test: 0.6.1


### PR DESCRIPTION
## Problem

`main` went red at the Build (`lint:eslint`) step after #241 bumped `@vitest/eslint-plugin` 1.6.20 → 1.6.21. That release's "Chai-style expect chains" change ([upstream #920](https://github.com/vitest-dev/eslint-plugin-vitest/pull/920)) regressed `vitest/valid-expect` to flag `expect.any(...)` as an "unknown modifier" ([upstream #924](https://github.com/vitest-dev/eslint-plugin-vitest/issues/924)), so the pre-existing `expect.any(String)` assertion in `packages/vitest-config/test/configure.test.ts` fails `--max-warnings=0`.

It surfaced on `main` (not on #241's own PR) because #248's source merge invalidated turbo's task cache, forcing `vitest-config#lint:eslint` to actually re-run against 1.6.21 rather than replay a pre-1.6.21 cache entry.

## Fix

- **Revert the catalog to the last-good 1.6.20** (mature; lint passes). The test code is correct — `expect.any` is a valid matcher — so no test change.
- **Add a repo-local Renovate rule** to skip 1.6.21, so Renovate advances straight to the fixed **1.6.22** ([#925](https://github.com/vitest-dev/eslint-plugin-vitest/pull/925)) once it clears the 3-day `minimumReleaseAge` quarantine, instead of re-applying the broken release. The rule is scoped to `.github/renovate.json` (not the shared preset) and documents the removal condition.

Root-only change (catalog + lockfile + renovate config), so no changeset is required (same as #241).

🤖 Generated with [Claude Code](https://claude.com/claude-code)