### PR TITLE
Group apple/pkl Renovate updates into one PR

### DIFF
--- a/.changeset/renovate-group-pkl.md
+++ b/.changeset/renovate-group-pkl.md
@@ -1,0 +1,5 @@
+---
+---
+
+Group apple/pkl Renovate updates so the mise tool and .chezmoidata version
+comment collapse into a single PR instead of one per manager

--- a/default.json
+++ b/default.json
@@ -37,6 +37,13 @@
       ]
     },
     {
+      "description": "Group pkl updates (mise tool + .chezmoidata version comment share one apple/pkl release)",
+      "groupName": "pkl",
+      "matchSourceUrls": [
+        "https://github.com/apple/pkl"
+      ]
+    },
+    {
       "description": "Group playwright-cli monorepo",
       "groupName": "playwright-cli monorepo",
       "matchSourceUrls": [


### PR DESCRIPTION
Pkl is tracked by two Renovate managers — the mise tool (`aqua:apple/pkl` in `mise.toml`/`mise.lock`) and version-comment references in consumer repos (e.g. dotfiles' `home/.chezmoidata/hk.yaml` with `datasource=github-releases depName=apple/pkl`). Each manager raised a separate PR for the same release (see gtbuchanan/dotfiles#76 and gtbuchanan/dotfiles#77, both bumping `0.31.1` → `0.32.0`).

This adds a `packageRules` entry matching the `apple/pkl` source URL so both managers collapse into a single grouped PR, mirroring the existing `hk` group (which already handles the same mise-tool-plus-version-comment double-tracking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)