### PR TITLE
eslint-config: dedupe overlapping no-process-exit rules

### DIFF
--- a/.changeset/dedupe-no-process-exit.md
+++ b/.changeset/dedupe-no-process-exit.md
@@ -1,0 +1,9 @@
+---
+'@gtbuchanan/eslint-config': patch
+---
+
+Dedupe overlapping `no-process-exit` rules. `unicorn/no-process-exit` is
+now the canonical rule (its message is CLI-aware) and `n/no-process-exit`
+is disabled globally. The entry-point exemption moves to the unicorn rule,
+so `process.exit()` in entry points is fully exempt instead of only
+partially.

--- a/packages/eslint-config/e2e/cli.test.ts
+++ b/packages/eslint-config/e2e/cli.test.ts
@@ -52,13 +52,13 @@ describe.concurrent('eslint CLI integration', () => {
     expect(result).toMatchObject({ exitCode: 0 });
   });
 
-  it('detects process.exit via eslint-plugin-n', async ({ fixture, expect }) => {
+  it('detects process.exit via eslint-plugin-unicorn', async ({ fixture, expect }) => {
     const { exitCode, stdout } = await fixture.run({
       files: { 'bad.ts': 'process.exit(0);\n' },
     });
 
     expect(exitCode).not.toBe(0);
-    expect(stdout).toContain('n/no-process-exit');
+    expect(stdout).toContain('unicorn/no-process-exit');
   });
 
   it('applies oxlint overlay as last config', async ({ fixture, expect }) => {
@@ -125,7 +125,7 @@ describe.concurrent('eslint CLI integration', () => {
 
     // Warnings don't cause a non-zero exit code
     expect(exitCode).toBe(0);
-    expect(stdout).toContain('n/no-process-exit');
+    expect(stdout).toContain('unicorn/no-process-exit');
   });
 
   it('formats JSON, Markdown, YAML, and CSS via Prettier plugins', async ({ fixture, expect }) => {

--- a/packages/eslint-config/src/plugins/node.ts
+++ b/packages/eslint-config/src/plugins/node.ts
@@ -22,6 +22,9 @@ const plugin: PluginFactory = options => [
       'n/no-missing-import': 'off' as const,
       // Justification: Redundant with TypeScript module resolution
       'n/no-unpublished-import': 'off' as const,
+      /* Justification: Redundant with unicorn/no-process-exit, which is the
+         canonical rule here (its message is CLI-aware) */
+      'n/no-process-exit': 'off' as const,
     },
   }),
   {
@@ -30,7 +33,7 @@ const plugin: PluginFactory = options => [
       // Justification: Entry points use process.exit() for controlled shutdown
       'n/hashbang': 'off',
       // Justification: Entry points use process.exit() for controlled shutdown
-      'n/no-process-exit': 'off',
+      'unicorn/no-process-exit': 'off',
     },
   },
 ];

--- a/packages/eslint-config/test/configure.test.ts
+++ b/packages/eslint-config/test/configure.test.ts
@@ -73,7 +73,7 @@ describe.concurrent(configure, () => {
       onlyWarn: false,
     });
     const entryConfig = configs.find(
-      cfg => cfg.rules?.['n/no-process-exit'] === 'off',
+      cfg => cfg.rules?.['unicorn/no-process-exit'] === 'off',
     );
 
     expect(entryConfig?.files).toStrictEqual(['**/cli.ts']);


### PR DESCRIPTION
Closes #264.

The shared config enabled both `n/no-process-exit` and
`unicorn/no-process-exit`, which both flag `process.exit()`. The
redundancy meant every legitimate call had to disable *two* rules, and
the `entryPoints` exemption in `plugins/node.ts` only turned off `n/`,
so entry points were still flagged by the unicorn rule.

## Approach

Option B from the issue: keep `unicorn/no-process-exit` as the canonical
rule (its message is CLI-aware — "Only use `process.exit()` in CLI
apps"), disable `n/no-process-exit` globally, and move the entry-point
exemption to the unicorn rule. `unicorn` is ordered before `node` in
`plugins/index.ts`, so the entry-point override correctly wins.

## Changes

- `src/plugins/node.ts` — disable `n/no-process-exit` globally; switch
  the `entryPoints` override from `n/no-process-exit` to
  `unicorn/no-process-exit`.
- `test/configure.test.ts` — entry-point override lookup keys on the
  unicorn rule.
- `e2e/cli.test.ts` — detection test renamed and both `process.exit`
  assertions now expect `unicorn/no-process-exit`.

## Verification

Full `pnpm build` (turbo graph incl. e2e) passes. The eslint-config e2e
run confirms `process.exit(0)` in a non-entry-point file is now flagged
by `unicorn/no-process-exit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)