### PR TITLE
Remove stale oxlint overlay e2e test

### DIFF
--- a/.changeset/remove-stale-oxlint-test.md
+++ b/.changeset/remove-stale-oxlint-test.md
@@ -1,0 +1,6 @@
+---
+---
+
+Remove a stale eslint-config e2e test that asserted a removed oxlint
+overlay. Its premise no longer holds, and its assertion duplicated the
+existing clean-file test.

--- a/packages/eslint-config/e2e/cli.test.ts
+++ b/packages/eslint-config/e2e/cli.test.ts
@@ -61,16 +61,6 @@ describe.concurrent('eslint CLI integration', () => {
     expect(stdout).toContain('unicorn/no-process-exit');
   });
 
-  it('applies oxlint overlay as last config', async ({ fixture, expect }) => {
-    const { exitCode, stdout } = await fixture.run({
-      files: { 'test.ts': 'export const greeting = 42;\n' },
-    });
-
-    // Should pass — oxlint overlay disables overlapping ESLint rules
-    expect(exitCode).toBe(0);
-    expect(stdout).not.toContain('Error');
-  });
-
   it('respects global ignores for dist/', async ({ fixture, expect }) => {
     const longLine = `export const x = '${'a'.repeat(101)}';\n`;
     const { exitCode } = await fixture.run({


### PR DESCRIPTION
The `applies oxlint overlay as last config` test in
`packages/eslint-config/e2e/cli.test.ts` dates to the initial commit.
Its premise was that the oxlint overlay, applied as the last ESLint
config, disabled overlapping ESLint rules — so a file like
`export const greeting = 42;` would lint clean.

oxlint was removed in #42 (ESLint became the sole linter), so that
premise no longer holds. The test's name and comment reference a
feature that no longer exists, and its assertion (a valid TS file lints
clean) merely duplicates the existing `passes for a clean file` test.
Removing it.

## Verification

Full `pnpm build` (turbo graph incl. e2e) passes; the eslint-config
e2e suite drops from 18 to 17 tests with no other change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)