### PR TITLE
Add hk-config Renovate customManager to shared preset

### DIFF
--- a/.changeset/renovate-hk-config-manager.md
+++ b/.changeset/renovate-hk-config-manager.md
@@ -1,0 +1,6 @@
+---
+---
+
+Add a Renovate customManager to the shared preset that bumps the
+hk-config version in consumer `.pkl` package URLs when a new
+`hk-config@<version>` GitHub release ships

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -422,7 +422,13 @@ Renovate's mise manager bumps `mise.toml`, but the pkl URLs are a second
 copy of the version it can't track natively. Its matchStrings are
 hk-specific (`download/v…`, `hk@…#`), so they ignore the generated
 `hk-config@…` URLs in `PklProject` (whose version is owned by `gtb sync`,
-not Renovate).
+not Renovate). A second entry does the same for consumer imports of
+`@gtbuchanan/hk-config`: it tracks this repo's `hk-config@<version>`
+release tags (via `extractVersionTemplate`) and bumps the `hk-config@…`
+package URLs in consumer `.pkl` files. Tooling itself is unaffected —
+it imports `Defaults.pkl` by relative path, and `PklProject` neither
+matches the `.pkl` file pattern nor contains a literal version (its
+`packageZipUrl` is an interpolation).
 
 ### Turbo cache miss on workspace edits
 

--- a/default.json
+++ b/default.json
@@ -15,6 +15,22 @@
         "hk@(?<currentValue>[^#\"]+?)#"
       ],
       "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "hk-config",
+      "description": "Keep the hk-config version embedded in consumer .pkl package URLs in sync with the hk-config@<version> GitHub release (tooling itself imports Defaults.pkl by relative path, so this only fires in consumer repos)",
+      "extractVersionTemplate": "^hk-config@(?<version>.+)$",
+      "managerFilePatterns": [
+        "/\\.pkl$/"
+      ],
+      "matchStrings": [
+        "releases/download/hk-config@(?<currentValue>[^/]+?)/",
+        "/hk-config@(?<currentValue>[^/#\"]+?)#"
+      ],
+      "packageNameTemplate": "gtbuchanan/tooling",
+      "versioningTemplate": "semver"
     }
   ],
   "description": [


### PR DESCRIPTION
## Summary

Consumers `package://`-import `@gtbuchanan/hk-config` with the version pinned in the URL (`releases/download/hk-config@<ver>/hk-config@<ver>#/Defaults.pkl`), but the shared preset had no manager tracking it — the existing customManager is deliberately hk-only (`download/v…`, `hk@…#`), so consumer pins went stale when a new hk-config release shipped.

This adds a second regex customManager to `default.json`:

- `github-releases` datasource against `gtbuchanan/tooling`, with `extractVersionTemplate: "^hk-config@(?<version>.+)$"` filtering the repo's mixed tag space (changesets' `@gtbuchanan/*@…` npm tags) down to hk-config releases (tag format verified against the live releases).
- Two matchStrings cover both copies of the version in the URL; the second uses `[^/#"]` so the lazy match can't swallow across the path segment. Verified the new and existing matchStrings don't cross-match each other's URLs.
- Tooling itself is unaffected: it imports `Defaults.pkl` by relative path, and `PklProject` neither matches the `.pkl` file pattern nor contains a literal version (its `packageZipUrl` is a sync-owned interpolation), so the `gtb sync` ownership boundary is preserved.

The existing "skip release-age quarantine for gtbuchanan's own packages" rule already matches this dep, so consumer bumps won't sit in the 3-day quarantine. Also documents the new entry in the AGENTS.md Renovate preset section.

`renovate-config-validator` passes (also enforced by the `renovate-preset` hk step). Empty changeset — the preset isn't a published npm package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)