### PR TITLE
Fix unicorn/prefer-simple-condition-first warnings from v72

### DIFF
--- a/.changeset/fix-unicorn-v72-lint-warnings.md
+++ b/.changeset/fix-unicorn-v72-lint-warnings.md
@@ -1,0 +1,5 @@
+---
+---
+
+Reorder pure boolean conditions flagged by the new
+`unicorn/prefer-simple-condition-first` rule (no behavior change)

--- a/packages/cli/src/commands/root/verify.ts
+++ b/packages/cli/src/commands/root/verify.ts
@@ -35,7 +35,7 @@ export const parseIgnoreArgs = (args: readonly string[]): ReadonlySet<string> =>
   const ignored = new Set<string>();
   for (let idx = 0; idx < args.length; idx++) {
     const next = args[idx + 1];
-    if (args[idx] === '--ignore' && next !== undefined) {
+    if (next !== undefined && args[idx] === '--ignore') {
       ignored.add(next);
       idx++;
     }

--- a/packages/cli/src/commands/task/compile-skills.ts
+++ b/packages/cli/src/commands/task/compile-skills.ts
@@ -17,7 +17,7 @@ export const compileSkills = defineCommand({
     const pkgDir = process.cwd();
     const manifest = readParsedManifest(pkgDir);
     const dir = manifest.publishConfig?.directory;
-    if (manifest.private === true || dir === undefined) {
+    if (dir === undefined || manifest.private === true) {
       return;
     }
 

--- a/packages/cli/src/commands/task/pack-npm.ts
+++ b/packages/cli/src/commands/task/pack-npm.ts
@@ -101,7 +101,7 @@ const preparePackage = (
 ): void => {
   const manifest = readParsedManifest(pkgDir);
   const dir = manifest.publishConfig?.directory;
-  if (manifest.private === true || dir === undefined) {
+  if (dir === undefined || manifest.private === true) {
     return;
   }
 
@@ -137,7 +137,7 @@ const prepareAndPack = (
 ): void => {
   const manifest = readParsedManifest(pkgDir);
   const dir = manifest.publishConfig?.directory;
-  if (manifest.private === true || dir === undefined) {
+  if (dir === undefined || manifest.private === true) {
     return;
   }
 

--- a/packages/test-utils/src/lib/tarball.ts
+++ b/packages/test-utils/src/lib/tarball.ts
@@ -45,7 +45,7 @@ export const matchTarball = (files: readonly string[], packageName: string): str
     file => file.endsWith('.tgz') && pattern.test(file),
   );
   const [tgzName] = tarballs;
-  if (tarballs.length !== 1 || tgzName === undefined) {
+  if (tgzName === undefined || tarballs.length !== 1) {
     const count = String(tarballs.length);
     throw new Error(
       `Expected exactly 1 tarball matching "${needle}", found ${count}`,


### PR DESCRIPTION
## Summary

eslint-plugin-unicorn v72 (#275) introduced `prefer-simple-condition-first`, which flags several existing conditions — four in `@gtbuchanan/cli` and one in `@gtbuchanan/test-utils`. The v72 PR merged green because the turbo hash for `lint:eslint` does not capture the plugin version (it is an external dep of the internal `@gtbuchanan/eslint-config` package, pinned via the root pnpm catalog, and the task has explicit `inputs` with no cross-package `dependsOn`), so CI replayed a stale pre-bump cache entry. The warnings only surface on cold-cache builds — or as soon as any PR touches the flagged files, which would fail CI with warnings it did not introduce.

This reorders each flagged condition so the simple `undefined`-check operand comes first. Every operand is pure (no calls, no side effects), so the short-circuit reorder cannot change behavior. Empty changeset: nothing observable changes for consumers, so no release is warranted — the reordered code rides along with the next real release.

The full build passes locally, and since these edits change the lint task inputs, this PR''s CI actually re-executes lint with v72 instead of replaying the stale hit.

The cache-invalidation gap itself (turbo not seeing transitive catalog-pinned plugin versions) is a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)