### PR TITLE
Salt turbo global hash with lockfile in self-hosted workspaces

### DIFF
--- a/.changeset/turbo-lockfile-global-hash.md
+++ b/.changeset/turbo-lockfile-global-hash.md
@@ -1,0 +1,6 @@
+---
+---
+
+Salt the turbo global hash with `pnpm-lock.yaml` in self-hosted
+workspaces, where internally-vendored tool-config packages hide plugin
+bumps from sibling task hashes and CI replays stale passes

--- a/packages/cli/src/lib/turbo-config.ts
+++ b/packages/cli/src/lib/turbo-config.ts
@@ -4,6 +4,7 @@ import { skillsConfigFilename } from './skills-config.ts';
 import { localeComparer } from './sort.ts';
 import { typeCheckInclude } from './tsconfig-gen.ts';
 import { aggregateTasks } from './turbo-aggregates.ts';
+import { toTurboGlobs } from './turbo-globs.ts';
 
 /** Turbo-only aggregate task names (no CLI handler). */
 export const Aggregate = {
@@ -121,24 +122,6 @@ export const resolveToolFlags = (discovery: WorkspaceDiscovery): ToolFlags => {
 
 /** Creates a topological (cross-package) task dependency. */
 const topo = (task: string): string => `^${task}`;
-
-/** Script file extensions for turbo input globs. Sorted alphabetically. */
-const scriptExts = ['cjs', 'cts', 'js', 'jsx', 'mjs', 'mts', 'ts', 'tsx'] as const;
-
-const isGlob = (pattern: string): boolean => /[*?\{]/v.test(pattern);
-
-/**
- * Converts a tsconfig `include` entry to turbo input glob(s).
- * Directories become recursive (`src` → `src/**`).
- * Root-level globs (`*`, `.*`) expand to per-extension patterns
- * since turbo globs are extension-agnostic unlike tsconfig.
- */
-const toTurboGlobs = (include: string): readonly string[] => {
-  if (include === '*') return scriptExts.map(ext => `*.${ext}`);
-  if (include === '.*') return scriptExts.map(ext => `.*.${ext}`);
-  if (isGlob(include)) return [include];
-  return [`${include}/**`];
-};
 
 const typecheckTasks = (flags: ToolFlags): readonly ConditionalEntry<TurboTask>[] => [
   {
@@ -390,10 +373,25 @@ export const generateTurboJson = (discovery: WorkspaceDiscovery): TurboJson => {
     ...deploySkillsTasks(flags),
     ...aggregateTasks(flags),
   ];
+  /*
+   * Self-hosted workspaces vendor tool-config packages (eslint-config,
+   * vitest-config) internally. Turbo hashes internal dependencies by their
+   * files only, so a lockfile-only bump to one of their plugins (e.g. an
+   * eslint plugin pinned via the root catalog) never reaches sibling tasks
+   * that consume the plugin without a task edge — CI then replays stale
+   * passes. Salting the global hash with the lockfile closes that seam.
+   * Consumers resolve those packages externally, where turbo's per-package
+   * transitive closure already invalidates correctly, so they keep
+   * granular caching.
+   */
+  const globalDependencies = [
+    ...(discovery.hasMise ? ['mise.lock', 'mise.toml'] : []),
+    ...(discovery.isSelfHosted ? ['pnpm-lock.yaml'] : []),
+  ];
 
   return {
     $schema: 'https://turbo.build/schema.json',
-    ...(discovery.hasMise && { globalDependencies: ['mise.lock', 'mise.toml'] }),
+    ...(globalDependencies.length > 0 && { globalDependencies }),
     tasks: collect(entries),
   };
 };

--- a/packages/cli/src/lib/turbo-globs.ts
+++ b/packages/cli/src/lib/turbo-globs.ts
@@ -1,0 +1,17 @@
+/** Script file extensions for turbo input globs. Sorted alphabetically. */
+const scriptExts = ['cjs', 'cts', 'js', 'jsx', 'mjs', 'mts', 'ts', 'tsx'] as const;
+
+const isGlob = (pattern: string): boolean => /[*?\{]/v.test(pattern);
+
+/**
+ * Converts a tsconfig `include` entry to turbo input glob(s).
+ * Directories become recursive (`src` → `src/**`).
+ * Root-level globs (`*`, `.*`) expand to per-extension patterns
+ * since turbo globs are extension-agnostic unlike tsconfig.
+ */
+export const toTurboGlobs = (include: string): readonly string[] => {
+  if (include === '*') return scriptExts.map(ext => `*.${ext}`);
+  if (include === '.*') return scriptExts.map(ext => `.*.${ext}`);
+  if (isGlob(include)) return [include];
+  return [`${include}/**`];
+};

--- a/packages/cli/test/turbo-json-global-deps.test.ts
+++ b/packages/cli/test/turbo-json-global-deps.test.ts
@@ -1,0 +1,49 @@
+import { describe, it } from 'vitest';
+import { generateTurboJson } from '#src/lib/turbo-config.js';
+import { makeCapabilities, makeDiscovery } from './turbo-config.helpers.ts';
+
+describe.concurrent('generateTurboJson (globalDependencies)', () => {
+  it('emits globalDependencies for mise files when the workspace has mise.toml', ({ expect }) => {
+    const discovery = makeDiscovery([makeCapabilities()], { hasMise: true });
+
+    const result = generateTurboJson(discovery);
+
+    expect(result.globalDependencies).toStrictEqual(['mise.lock', 'mise.toml']);
+  });
+
+  it('omits globalDependencies when the workspace has no mise.toml', ({ expect }) => {
+    const discovery = makeDiscovery([makeCapabilities()]);
+
+    const result = generateTurboJson(discovery);
+
+    expect(result).not.toHaveProperty('globalDependencies');
+  });
+
+  /*
+   * Self-hosted workspaces vendor tool-config packages (eslint-config,
+   * vitest-config) internally, so turbo's lockfile closure never reaches
+   * sibling tasks that consume their plugins — the lockfile must salt the
+   * global hash. Consumers get those packages externally, where turbo's
+   * per-package transitive closure already invalidates correctly.
+   */
+  it('emits the lockfile in globalDependencies when self-hosted', ({ expect }) => {
+    const discovery = makeDiscovery([makeCapabilities()], { isSelfHosted: true });
+
+    const result = generateTurboJson(discovery);
+
+    expect(result.globalDependencies).toStrictEqual(['pnpm-lock.yaml']);
+  });
+
+  it('emits mise files and the lockfile when self-hosted with mise.toml', ({ expect }) => {
+    const discovery = makeDiscovery([makeCapabilities()], {
+      hasMise: true,
+      isSelfHosted: true,
+    });
+
+    const result = generateTurboJson(discovery);
+
+    expect(result.globalDependencies).toStrictEqual([
+      'mise.lock', 'mise.toml', 'pnpm-lock.yaml',
+    ]);
+  });
+});

--- a/packages/cli/test/turbo-json.test.ts
+++ b/packages/cli/test/turbo-json.test.ts
@@ -375,20 +375,4 @@ describe.concurrent(generateTurboJson, () => {
       'vitest.config.*', '!vitest.config.e2e.*',
     ]));
   });
-
-  it('emits globalDependencies for mise files when the workspace has mise.toml', ({ expect }) => {
-    const discovery = makeDiscovery([makeCapabilities()], { hasMise: true });
-
-    const result = generateTurboJson(discovery);
-
-    expect(result.globalDependencies).toStrictEqual(['mise.lock', 'mise.toml']);
-  });
-
-  it('omits globalDependencies when the workspace has no mise.toml', ({ expect }) => {
-    const discovery = makeDiscovery([makeCapabilities()]);
-
-    const result = generateTurboJson(discovery);
-
-    expect(result).not.toHaveProperty('globalDependencies');
-  });
 });

--- a/turbo.json
+++ b/turbo.json
@@ -2,7 +2,8 @@
   "$schema": "https://turbo.build/schema.json",
   "globalDependencies": [
     "mise.lock",
-    "mise.toml"
+    "mise.toml",
+    "pnpm-lock.yaml"
   ],
   "tasks": {
     "//#lint:eslint": {


### PR DESCRIPTION
## Summary

Closes the cache-invalidation gap behind the eslint-plugin-unicorn v72 incident (#278): turbo hashes internal workspace dependencies by their files only, so a lockfile-only bump to a plugin of an internally-vendored tool-config package (pinned via the root catalog, consumed by sibling lint tasks with no task edge) never changes the sibling task hashes. CI replayed a stale passing lint cache while cold-cache local builds failed. The same latent gap applies to test tasks via `vitest-config`.

`generateTurboJson` now emits `pnpm-lock.yaml` in `globalDependencies` when `discovery.isSelfHosted` — any dep change invalidates all caches, which for a dep bump is exactly the re-validation you want.

**Consumers are unaffected byte-for-byte.** `isSelfHosted` requires `@gtbuchanan/cli` as a `workspace:` dep, which no npm consumer can be. Consumers resolve the tool-config packages externally, where turbo's per-package transitive external closure already invalidates correctly — forcing the lockfile into their global hash would only destroy cache granularity turbo gives them natively. Hence an empty changeset (no observable change for any published-package consumer).

Also, to stay within `max-lines` (both files were parked at the limit): `toTurboGlobs` moved to a new `turbo-globs.ts`, and the `globalDependencies` tests split into `turbo-json-global-deps.test.ts`, following the existing `turbo-json-*.test.ts` convention.

Validated TDD-style (new tests red then green) and with a full local build — which now full-misses the turbo cache, itself confirming the new global hash takes effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)