### PR TITLE
Drop blob reporter from coverage:vitest:merge run

### DIFF
--- a/.changeset/coverage-merge-blob-reporter.md
+++ b/.changeset/coverage-merge-blob-reporter.md
@@ -1,0 +1,9 @@
+---
+'@gtbuchanan/cli': patch
+---
+
+Fix `coverage:vitest:merge` failing under vitest 4 by overriding the
+reporter for the merge invocation (`--reporter=default`). Vitest 4
+rejects `--merge-reports` while `blob` is an active reporter, and the
+shared config enables `blob` unconditionally so the fast/slow runs can
+produce the per-bucket blobs.

--- a/packages/cli/src/commands/task/coverage-vitest-merge.ts
+++ b/packages/cli/src/commands/task/coverage-vitest-merge.ts
@@ -12,6 +12,12 @@ export const coverageVitestMerge = defineCommand({
       args: [
         '--merge-reports', 'dist/test-results/vitest/merge',
         '--coverage.reportsDirectory=dist/coverage/vitest/merged',
+        /*
+         * Replace the config's reporters for this run: vitest 4 refuses to
+         * merge while `blob` (needed by the fast/slow runs to produce the
+         * blobs) is an active reporter.
+         */
+        '--reporter=default',
         ...rawArgs,
       ],
     });

--- a/packages/cli/test/coverage-vitest-merge.test.ts
+++ b/packages/cli/test/coverage-vitest-merge.test.ts
@@ -1,0 +1,57 @@
+import { runCommand } from 'citty';
+import { describe, it, vi } from 'vitest';
+
+vi.mock(import('#src/lib/process.js'), async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, run: vi.fn<typeof actual.run>() };
+});
+
+const { run } = await import('#src/lib/process.js');
+const { coverageVitestMerge } = await import(
+  '#src/commands/task/coverage-vitest-merge.js',
+);
+
+const mockRun = vi.mocked(run);
+
+const getRunArgs = (): readonly string[] => {
+  const lastCall = mockRun.mock.calls.at(-1);
+  if (lastCall === undefined) {
+    return [];
+  }
+  return lastCall[1]?.args ?? [];
+};
+
+const invoke = async (rawArgs: readonly string[]): Promise<void> => {
+  await runCommand(coverageVitestMerge, { rawArgs: [...rawArgs] });
+};
+
+describe('coverage:vitest:merge', () => {
+  it('merges the blob reports directory', async ({ expect }) => {
+    await invoke([]);
+
+    expect(getRunArgs()).toContain('--merge-reports');
+    expect(getRunArgs()).toContain('dist/test-results/vitest/merge');
+  });
+
+  it('writes the merged coverage report directory', async ({ expect }) => {
+    await invoke([]);
+
+    expect(getRunArgs()).toContain(
+      '--coverage.reportsDirectory=dist/coverage/vitest/merged',
+    );
+  });
+
+  it('replaces config reporters so blob is inactive during merge', async ({
+    expect,
+  }) => {
+    await invoke([]);
+
+    expect(getRunArgs()).toContain('--reporter=default');
+  });
+
+  it('forwards extra args', async ({ expect }) => {
+    await invoke(['--silent']);
+
+    expect(getRunArgs()).toContain('--silent');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #286.

Vitest 4 refuses `--merge-reports` while `blob` is an active reporter, and `@gtbuchanan/vitest-config` enables `blob` unconditionally so the fast/slow runs can produce the per-bucket blobs. `gtb task coverage:vitest:merge` now passes `--reporter=default` on the merge invocation, replacing the config's reporters for that run only. Coverage output is configured separately under `test.coverage`, so the merged report still lands in `dist/coverage/vitest/merged`. The flag precedes forwarded raw args, so callers can still override the reporter.

## Testing

- New unit test (written red-first) pins the merge args, including the reporter override.
- Reproduced the exact issue error against vitest 4's merge guard (locally on 4.1.10) by merging a real blob without the flag, then ran the fixed `gtb task coverage:vitest:merge` end-to-end — the merge succeeded and wrote `lcov.info` + `lcov-report/`.
- Full `pnpm build` (build + fast/slow/e2e tests + lint) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
