### PR TITLE
Move agent-skills @eslint/* deps to peerDependencies

### DIFF
--- a/.changeset/agent-skills-eslint-peer-deps.md
+++ b/.changeset/agent-skills-eslint-peer-deps.md
@@ -1,0 +1,18 @@
+---
+'@gtbuchanan/eslint-plugin-agent-skills': minor
+---
+
+Move `@eslint/json` and `@eslint/markdown` to peer dependencies
+
+`configs.recommended` registers both under the `json` and `markdown`
+plugin namespaces. ESLint rejects a namespace registered by two configs
+unless both pass the identical plugin object, so a consumer config that
+also registers `markdown` — `@gtbuchanan/eslint-config` does, for
+`**/*.md` — has to resolve to the same copy this plugin imports. As
+regular dependencies with exact pins, the two published manifests drift
+apart whenever only one package is re-released after a bump, pnpm
+installs two copies, and linting any `skills/*/SKILL.md` fails with
+`Cannot redefine plugin "markdown"` before a single rule runs.
+
+Consumers installing this plugin directly now need to install
+`@eslint/json` and `@eslint/markdown` alongside it.

--- a/packages/eslint-plugin-agent-skills/README.md
+++ b/packages/eslint-plugin-agent-skills/README.md
@@ -32,10 +32,21 @@ constraints that pure schemas can't express. This package ships:
 
 ```sh
 pnpm add -D \
+  @eslint/json \
+  @eslint/markdown \
   @gtbuchanan/eslint-plugin-md-frontmatter \
   @gtbuchanan/eslint-plugin-agent-skills \
   eslint
 ```
+
+`@eslint/json` and `@eslint/markdown` are peer dependencies rather than
+regular ones because `configs.recommended` registers them under the
+`json` and `markdown` plugin namespaces. ESLint rejects a namespace that
+is registered twice unless both configs pass the identical plugin
+object, so any config that also registers `markdown` (including
+`@gtbuchanan/eslint-config`) must resolve to the same copy this plugin
+imports. A peer dependency is what guarantees that; a regular dependency
+lets the two pins drift and installs a second copy.
 
 ## Usage
 

--- a/packages/eslint-plugin-agent-skills/package.json
+++ b/packages/eslint-plugin-agent-skills/package.json
@@ -21,17 +21,19 @@
     "typecheck:ts": "pnpm run gtb task typecheck:ts"
   },
   "dependencies": {
-    "@eslint/json": "catalog:",
-    "@eslint/markdown": "catalog:",
     "@gtbuchanan/eslint-plugin-md-frontmatter": "workspace:*",
     "ajv": "catalog:",
     "yaml": "catalog:"
   },
   "devDependencies": {
+    "@eslint/json": "catalog:",
+    "@eslint/markdown": "catalog:",
     "@gtbuchanan/vitest-config": "workspace:*",
     "@types/mdast": "catalog:"
   },
   "peerDependencies": {
+    "@eslint/json": "^2.0.0",
+    "@eslint/markdown": "^8.0.0",
     "eslint": "^10.0.0"
   },
   "engines": {

--- a/packages/eslint-plugin-agent-skills/test/recommended-plugins.test.ts
+++ b/packages/eslint-plugin-agent-skills/test/recommended-plugins.test.ts
@@ -1,5 +1,7 @@
+import frontmatter from '@gtbuchanan/eslint-plugin-md-frontmatter';
+import type { ESLint } from 'eslint';
 import { describe, it } from 'vitest';
-import { configs } from '#src/index.js';
+import plugin, { configs } from '#src/index.js';
 import manifest from '../package.json' with { type: 'json' };
 
 /*
@@ -7,30 +9,48 @@ import manifest from '../package.json' with { type: 'json' };
  * dependency. ESLint rejects a namespace registered by two configs unless
  * both pass the identical plugin object, so a consumer config that registers
  * the same namespace — `@gtbuchanan/eslint-config` registers `markdown` for
- * every Markdown file — must resolve to the copy this plugin imports. Only a peer
- * dependency guarantees that; as a regular dependency the published pins
+ * every Markdown file — must resolve to the copy this plugin imports. Only a
+ * peer dependency guarantees that; as a regular dependency the published pins
  * drift apart on the next release cut and a second copy gets installed.
  *
- * Workspace siblings (`@gtbuchanan/*`) are exempt: changesets bumps every
- * dependent in the same release, so their specs cannot drift apart.
+ * Workspace-owned plugins are exempt: changesets bumps every dependent in the
+ * same release, so their specs cannot drift apart. They are matched by object
+ * identity rather than by name because neither declares `meta`, and identity
+ * keeps the exemption correct if either ever starts to.
  */
+const isWorkspacePlugin = (candidate: ESLint.Plugin): boolean =>
+  candidate === plugin || candidate === frontmatter;
+
+const thirdPartyPlugins = [
+  ...new Set(configs.recommended.flatMap(
+    config => Object.values(config.plugins ?? {}),
+  )),
+].filter(registered => !isWorkspacePlugin(registered));
+
 const thirdPartyPluginNames = [
   ...new Set(
-    configs.recommended
-      .flatMap(config => Object.values(config.plugins ?? {}))
-      .map(plugin => plugin.meta?.name)
-      .filter(name => name !== undefined)
-      .filter(name => !name.startsWith('@gtbuchanan/')),
+    thirdPartyPlugins
+      .map(({ meta }) => meta?.name)
+      .filter(name => name !== undefined),
   ),
 ];
 
 describe('configs.recommended plugin resolution', () => {
   /*
-   * Guards the derivation itself. Every name comes from `meta.name`, which is
-   * optional — if upstream drops it the list silently empties and every
-   * assertion below passes vacuously.
+   * `meta.name` is how a third-party plugin is traced back to the package
+   * that has to be a peer. One that omits it would otherwise drop out of the
+   * derived list silently, and the peer assertions below would pass without
+   * ever covering it.
    */
-  it('identifies the third-party plugins it registers', ({ expect }) => {
+  it('exposes a package name for every third-party plugin', ({ expect }) => {
+    const unidentified = thirdPartyPlugins.filter(
+      ({ meta }) => meta?.name === undefined,
+    );
+
+    expect(unidentified).toStrictEqual([]);
+  });
+
+  it('registers at least one third-party plugin', ({ expect }) => {
     expect(thirdPartyPluginNames).not.toStrictEqual([]);
   });
 

--- a/packages/eslint-plugin-agent-skills/test/recommended-plugins.test.ts
+++ b/packages/eslint-plugin-agent-skills/test/recommended-plugins.test.ts
@@ -1,0 +1,43 @@
+import { describe, it } from 'vitest';
+import { configs } from '#src/index.js';
+import manifest from '../package.json' with { type: 'json' };
+
+/*
+ * Every third-party plugin `configs.recommended` registers has to be a peer
+ * dependency. ESLint rejects a namespace registered by two configs unless
+ * both pass the identical plugin object, so a consumer config that registers
+ * the same namespace — `@gtbuchanan/eslint-config` registers `markdown` for
+ * every Markdown file — must resolve to the copy this plugin imports. Only a peer
+ * dependency guarantees that; as a regular dependency the published pins
+ * drift apart on the next release cut and a second copy gets installed.
+ *
+ * Workspace siblings (`@gtbuchanan/*`) are exempt: changesets bumps every
+ * dependent in the same release, so their specs cannot drift apart.
+ */
+const thirdPartyPluginNames = [
+  ...new Set(
+    configs.recommended
+      .flatMap(config => Object.values(config.plugins ?? {}))
+      .map(plugin => plugin.meta?.name)
+      .filter(name => name !== undefined)
+      .filter(name => !name.startsWith('@gtbuchanan/')),
+  ),
+];
+
+describe('configs.recommended plugin resolution', () => {
+  /*
+   * Guards the derivation itself. Every name comes from `meta.name`, which is
+   * optional — if upstream drops it the list silently empties and every
+   * assertion below passes vacuously.
+   */
+  it('identifies the third-party plugins it registers', ({ expect }) => {
+    expect(thirdPartyPluginNames).not.toStrictEqual([]);
+  });
+
+  it.for(thirdPartyPluginNames)(
+    'declares %s as a peer dependency',
+    (packageName, { expect }) => {
+      expect(Object.keys(manifest.peerDependencies)).toContain(packageName);
+    },
+  );
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -392,12 +392,6 @@ importers:
 
   packages/eslint-plugin-agent-skills:
     dependencies:
-      '@eslint/json':
-        specifier: 'catalog:'
-        version: 2.0.1
-      '@eslint/markdown':
-        specifier: 'catalog:'
-        version: 8.0.3(supports-color@7.2.0)
       '@gtbuchanan/eslint-plugin-md-frontmatter':
         specifier: workspace:*
         version: link:../eslint-plugin-md-frontmatter
@@ -411,6 +405,12 @@ importers:
         specifier: 'catalog:'
         version: 2.9.0
     devDependencies:
+      '@eslint/json':
+        specifier: 'catalog:'
+        version: 2.0.1
+      '@eslint/markdown':
+        specifier: 'catalog:'
+        version: 8.0.3(supports-color@7.2.0)
       '@gtbuchanan/vitest-config':
         specifier: workspace:*
         version: link:../vitest-config


### PR DESCRIPTION
Closes #299.

Linting any `skills/*/SKILL.md` in a consumer repo that installs both `@gtbuchanan/eslint-config` and (transitively) `@gtbuchanan/eslint-plugin-agent-skills` fails before any rule runs:

```
ConfigError: Config (unnamed): Key "plugins": Cannot redefine plugin "markdown".
```

`configs.recommended` registers `@eslint/json` and `@eslint/markdown` under the `json` and `markdown` plugin namespaces. ESLint rejects a namespace registered by two configs unless both pass the identical plugin object, and two module instances never are. For a `SKILL.md`, both this plugin's block and the eslint-config Markdown block match.

As regular dependencies with exact pins, the two published manifests drift apart whenever only one package is re-released after a bump — which is what happened across an `@eslint/markdown` bump. Aligning the pins would unblock today and leave the recurrence; peer dependencies remove the failure mode structurally, since the plugin then resolves to whatever copy the consumer config already uses.

## Changes

- `@eslint/json` and `@eslint/markdown` move from `dependencies` to `peerDependencies`, plus `devDependencies` so the workspace still resolves them.
- README install list and a note on why they are peers.
- A test that derives the third-party plugins `configs.recommended` registers — flattening each block's `plugins` map — and asserts each is declared as a peer dependency.

## Notes

The peer ranges are written literally (`^2.0.0`, `^8.0.0`) rather than as `catalog:`. A `catalog:` peer would publish as the same exact pin that caused the drift, since the catalog entries for both are exact.

Workspace-owned plugins are exempt from the new test, matched by **object identity** rather than by npm scope or name. Changesets bumps every dependent in the same release, so their specs cannot drift apart the way a third-party pin can — `md-frontmatter` is correctly a regular dependency — and identity keeps the exemption correct if either workspace plugin ever starts declaring `meta`.

Two guards keep the derivation from rotting into a no-op, since `meta.name` is what traces a plugin back to the package that has to be a peer:

- Every **third-party** plugin must expose `meta.name`. One that omits it would otherwise be filtered out silently and never have its peer dependency checked.
- The derived list must be non-empty, covering the case where `meta.name` disappears upstream entirely.

The identity check is a predicate rather than `Set#has` filtering. For two known objects a `Set` is ceremony, and it draws `unicorn/prefer-set-methods`, whose suggested fix (`Set#difference()`) is declared in `lib.es2025.collection.d.ts` and does not typecheck under this repo's `lib: ["es2024"]` — see #306.

## Verification

- Full monorepo build passes, including the `eslint-config` e2e that lints a `SKILL.md` through the packed tarballs.
- The published manifest was checked by unpacking the tarball: `peerDependencies` carries the ranges and `dependencies` no longer lists either package.
- The peer assertion was confirmed red by temporarily reverting `@eslint/markdown` to a regular dependency — it fails on that package and passes on `@eslint/json`.
- The unnamed-plugin guard was confirmed red by making a `meta`-less plugin look third-party.

## Follow-ups

- #303 — the root cause more broadly: 23 catalog entries are exact pins published verbatim as runtime dependencies of `@gtbuchanan/eslint-config`, `@gtbuchanan/cli`, and `@gtbuchanan/vitest-config`. `@eslint/json` and `@eslint/markdown` are just the two that collided with a plugin namespace.
- #306 — raise `lib`/`target` to ES2025 to match the Node 24 engine floor, resolving the case where `@gtbuchanan/eslint-config` recommends an API `@gtbuchanan/tsconfig` will not compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)