### PR TITLE
Convert exact catalog pins to caret ranges

### DIFF
--- a/.changeset/catalog-caret-ranges.md
+++ b/.changeset/catalog-caret-ranges.md
@@ -1,0 +1,13 @@
+---
+'@gtbuchanan/eslint-config': patch
+'@gtbuchanan/vitest-config': patch
+'@gtbuchanan/cli': patch
+---
+
+Publish runtime dependencies as caret ranges instead of exact pins
+
+The `catalog:` entries backing these packages' runtime dependencies were
+exact pins, and pnpm substitutes the catalog spec verbatim at publish
+time — so consumers received hard pins that force a duplicate install
+whenever they resolve a different version of the same package. Exact
+pins remain only on root devDependencies, which are never published.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,13 +10,13 @@ catalogs:
       specifier: ^2.29.4
       version: 2.31.1
     '@eslint-community/eslint-plugin-eslint-comments':
-      specifier: 4.7.2
+      specifier: ^4.7.2
       version: 4.7.2
     '@eslint/json':
-      specifier: 2.0.1
+      specifier: ^2.0.1
       version: 2.0.1
     '@eslint/markdown':
-      specifier: 8.0.3
+      specifier: ^8.0.3
       version: 8.0.3
     '@faker-js/faker':
       specifier: ^10.4.0
@@ -28,7 +28,7 @@ catalogs:
       specifier: ^3.4.2
       version: 3.4.2
     '@stylistic/eslint-plugin':
-      specifier: 5.10.0
+      specifier: ^5.10.0
       version: 5.10.0
     '@tsconfig/strictest':
       specifier: ^2.0.8
@@ -49,7 +49,7 @@ catalogs:
       specifier: ^4.1.2
       version: 4.1.10
     '@vitest/eslint-plugin':
-      specifier: 1.6.23
+      specifier: ^1.6.23
       version: 1.6.23
     ajv:
       specifier: ^8.20.0
@@ -58,7 +58,7 @@ catalogs:
       specifier: ^0.2.2
       version: 0.2.2
     console-fail-test:
-      specifier: 0.6.1
+      specifier: ^0.6.1
       version: 0.6.1
     cross-spawn:
       specifier: ^7.0.6
@@ -67,37 +67,37 @@ catalogs:
       specifier: ^10.0.0
       version: 10.7.0
     eslint-plugin-format:
-      specifier: 2.0.1
+      specifier: ^2.0.1
       version: 2.0.1
     eslint-plugin-import-x:
-      specifier: 4.17.1
+      specifier: ^4.17.1
       version: 4.17.1
     eslint-plugin-jsdoc:
-      specifier: 63.1.0
+      specifier: ^63.1.0
       version: 63.1.0
     eslint-plugin-n:
-      specifier: 18.2.2
+      specifier: ^18.2.2
       version: 18.2.2
     eslint-plugin-only-warn:
-      specifier: 1.2.1
+      specifier: ^1.2.1
       version: 1.2.1
     eslint-plugin-pnpm:
-      specifier: 1.6.1
+      specifier: ^1.6.1
       version: 1.6.1
     eslint-plugin-promise:
       specifier: ^7.2.1
       version: 7.3.0
     eslint-plugin-regexp:
-      specifier: 3.1.1
+      specifier: ^3.1.1
       version: 3.1.1
     eslint-plugin-toml:
-      specifier: 1.4.0
+      specifier: ^1.4.0
       version: 1.4.0
     eslint-plugin-unicorn:
       specifier: ^72.0.0
       version: 72.0.0
     eslint-plugin-yml:
-      specifier: 3.6.0
+      specifier: ^3.6.0
       version: 3.6.0
     find-up-simple:
       specifier: ^1.0.1
@@ -118,19 +118,19 @@ catalogs:
       specifier: ^3.8.3
       version: 3.9.5
     prettier-plugin-css-order:
-      specifier: 2.2.0
+      specifier: ^2.2.0
       version: 2.2.0
     prettier-plugin-multiline-arrays:
-      specifier: 4.1.10
+      specifier: ^4.1.10
       version: 4.1.10
     prettier-plugin-packagejson:
-      specifier: 3.0.2
+      specifier: ^3.0.2
       version: 3.0.2
     prettier-plugin-sort-json:
-      specifier: 4.2.0
+      specifier: ^4.2.0
       version: 4.2.0
     prettier-plugin-toml:
-      specifier: 2.0.6
+      specifier: ^2.0.6
       version: 2.0.6
     skills:
       specifier: 1.5.19
@@ -139,7 +139,7 @@ catalogs:
       specifier: 1.2.0
       version: 1.2.0
     smol-toml:
-      specifier: 1.7.0
+      specifier: ^1.7.0
       version: 1.7.0
     turbo:
       specifier: ^2.5.4
@@ -148,10 +148,10 @@ catalogs:
       specifier: ^6.0.0
       version: 6.0.3
     typescript-eslint:
-      specifier: 8.64.0
+      specifier: ^8.64.0
       version: 8.64.0
     valibot:
-      specifier: 1.4.2
+      specifier: ^1.4.2
       version: 1.4.2
     vitest:
       specifier: ^4.1.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,54 +4,54 @@ allowBuilds:
 
 catalog:
   '@changesets/cli': ^2.29.4
-  '@eslint-community/eslint-plugin-eslint-comments': 4.7.2
-  '@eslint/json': 2.0.1
-  '@eslint/markdown': 8.0.3
+  '@eslint-community/eslint-plugin-eslint-comments': ^4.7.2
+  '@eslint/json': ^2.0.1
+  '@eslint/markdown': ^8.0.3
   '@faker-js/faker': ^10.4.0
   '@pnpm/lockfile.types': ^1100.0.5
   '@prettier/plugin-xml': ^3.4.2
-  '@stylistic/eslint-plugin': 5.10.0
+  '@stylistic/eslint-plugin': ^5.10.0
   '@tsconfig/strictest': ^2.0.8
   '@types/cross-spawn': ^6.0.6
   '@types/hosted-git-info': ^3.0.5
   '@types/mdast': ^4.0.4
   '@types/node': ^25.5.0
   '@vitest/coverage-v8': ^4.1.2
-  '@vitest/eslint-plugin': 1.6.23
+  '@vitest/eslint-plugin': ^1.6.23
   ajv: ^8.20.0
   citty: ^0.2.2
-  console-fail-test: 0.6.1
+  console-fail-test: ^0.6.1
   cross-spawn: ^7.0.6
   eslint: ^10.0.0
-  eslint-plugin-format: 2.0.1
-  eslint-plugin-import-x: 4.17.1
-  eslint-plugin-jsdoc: 63.1.0
-  eslint-plugin-n: 18.2.2
-  eslint-plugin-only-warn: 1.2.1
-  eslint-plugin-pnpm: 1.6.1
+  eslint-plugin-format: ^2.0.1
+  eslint-plugin-import-x: ^4.17.1
+  eslint-plugin-jsdoc: ^63.1.0
+  eslint-plugin-n: ^18.2.2
+  eslint-plugin-only-warn: ^1.2.1
+  eslint-plugin-pnpm: ^1.6.1
   eslint-plugin-promise: ^7.2.1
-  eslint-plugin-regexp: 3.1.1
-  eslint-plugin-toml: 1.4.0
+  eslint-plugin-regexp: ^3.1.1
+  eslint-plugin-toml: ^1.4.0
   eslint-plugin-unicorn: ^72.0.0
-  eslint-plugin-yml: 3.6.0
+  eslint-plugin-yml: ^3.6.0
   find-up-simple: ^1.0.1
   get-tsconfig: ^4.14.0
   hosted-git-info: ^10.1.1
   jiti: ^2.6.1
   markdownlint: ^0.41.0
   prettier: ^3.8.3
-  prettier-plugin-css-order: 2.2.0
-  prettier-plugin-multiline-arrays: 4.1.10
-  prettier-plugin-packagejson: 3.0.2
-  prettier-plugin-sort-json: 4.2.0
-  prettier-plugin-toml: 2.0.6
+  prettier-plugin-css-order: ^2.2.0
+  prettier-plugin-multiline-arrays: ^4.1.10
+  prettier-plugin-packagejson: ^3.0.2
+  prettier-plugin-sort-json: ^4.2.0
+  prettier-plugin-toml: ^2.0.6
   skills: 1.5.19
   skills-npm: 1.2.0
-  smol-toml: 1.7.0
+  smol-toml: ^1.7.0
   turbo: ^2.5.4
   typescript: ^6.0.0
-  typescript-eslint: 8.64.0
-  valibot: 1.4.2
+  typescript-eslint: ^8.64.0
+  valibot: ^1.4.2
   vitest: ^4.1.2
   yaml: ^2.8.3
 


### PR DESCRIPTION
Closes #303

Twenty-three `catalog:` entries in `pnpm-workspace.yaml` were exact pins consumed as runtime `dependencies` of published packages. pnpm substitutes the catalog spec verbatim at publish time, so consumers of `@gtbuchanan/eslint-config`, `@gtbuchanan/cli`, and `@gtbuchanan/vitest-config` received hard pins — forcing a duplicate install whenever they resolve a different version of the same package instead of deduping onto one copy.

Exact pins were only ever intended for devDependencies, which are never published. This converts every affected entry to a caret range. `skills` and `skills-npm` remain exact: both are root devDependencies, so the rule still holds for them.

## Changes

- `pnpm-workspace.yaml` — 23 catalog entries converted from exact pins to caret ranges
- `pnpm-lock.yaml` — specifier-only diff; every resolved version is unchanged
- Patch changeset for `@gtbuchanan/eslint-config`, `@gtbuchanan/cli`, and `@gtbuchanan/vitest-config`, since their published manifests change

## Renovate consequence (accepted)

Renovate's default `rangeStrategy: "auto"` resolves to `replace`, which only opens a PR when the new version falls *outside* the declared range. With caret ranges, in-range releases stop producing bump PRs and only majors will. This is a deliberate trade-off — `rangeStrategy: "bump"` is **not** being adopted. In-range drift is picked up by the weekly `lockFileMaintenance` run inherited from `:maintainLockFilesWeekly`.

## Verification

Full `pnpm build` passes locally (all tasks, including e2e).

🤖 Generated with [Claude Code](https://claude.com/claude-code)