### PR TITLE
Raise tsconfig lib/target to ES2025 for Node 24

### DIFF
--- a/.changeset/tsconfig-es2025-lib-target.md
+++ b/.changeset/tsconfig-es2025-lib-target.md
@@ -1,0 +1,8 @@
+---
+'@gtbuchanan/tsconfig': minor
+---
+
+Raise `lib` and `target` to ES2025 in `node.json` to match the Node 24
+engine floor, so lint rules that assume ES2025 APIs (e.g.
+`unicorn/prefer-set-methods` suggesting `Set#difference`) compile
+without suppressions

--- a/.changeset/tsconfig-es2025-lib-target.md
+++ b/.changeset/tsconfig-es2025-lib-target.md
@@ -5,4 +5,5 @@
 Raise `lib` and `target` to ES2025 in `node.json` to match the Node 24
 engine floor, so lint rules that assume ES2025 APIs (e.g.
 `unicorn/prefer-set-methods` suggesting `Set#difference`) compile
-without suppressions
+without suppressions, and declare the `typescript` peer range this
+requires (`>=6.0.0`, the first release accepting `es2025`)

--- a/packages/tsconfig/README.md
+++ b/packages/tsconfig/README.md
@@ -27,8 +27,8 @@ pnpm add -D @gtbuchanan/tsconfig
 
 Includes all `@tsconfig/strictest` options plus:
 
-- `target`: ES2024
-- `lib`: ES2024
+- `target`: ES2025
+- `lib`: ES2025
 - `module`: nodenext
 - `moduleResolution`: nodenext
 - `types`: node

--- a/packages/tsconfig/e2e/flatten.test.ts
+++ b/packages/tsconfig/e2e/flatten.test.ts
@@ -49,6 +49,24 @@ describe('tsconfig flattening', () => {
     });
   });
 
+  it('exposes the ES2025 lib surface', async ({ fixture, expect }) => {
+    fixture.writeFile(
+      'tsconfig.json',
+      JSON.stringify({
+        compilerOptions: { noEmit: true, types: [] },
+        extends: ['@gtbuchanan/tsconfig/node.json'],
+      }),
+    );
+    fixture.writeFile(
+      'index.ts',
+      'export const missing = (a: Set<string>, b: Set<string>) => a.difference(b);\n',
+    );
+
+    const result = await fixture.run('tsc', ['--noEmit']);
+
+    expect(result).toMatchObject({ exitCode: 0 });
+  });
+
   it('works without @tsconfig/strictest installed', async ({ fixture, expect }) => {
     fixture.writeFile(
       'tsconfig.json',

--- a/packages/tsconfig/node.json
+++ b/packages/tsconfig/node.json
@@ -3,12 +3,12 @@
   "compilerOptions": {
     "allowJs": true,
     "lib": [
-      "ES2024"
+      "ES2025"
     ],
     "module": "nodenext",
     "moduleResolution": "nodenext",
     "resolveJsonModule": true,
-    "target": "ES2024",
+    "target": "ES2025",
     "types": [
       "node"
     ]

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -23,6 +23,9 @@
     "@gtbuchanan/vitest-config": "workspace:*",
     "@tsconfig/strictest": "catalog:"
   },
+  "peerDependencies": {
+    "typescript": ">=6.0.0"
+  },
   "engines": {
     "node": ">=24.0.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -503,6 +503,10 @@ importers:
         version: 6.0.6
 
   packages/tsconfig:
+    dependencies:
+      typescript:
+        specifier: '>=6.0.0'
+        version: 6.0.3
     devDependencies:
       '@gtbuchanan/eslint-config':
         specifier: workspace:*


### PR DESCRIPTION
Closes #306

`@gtbuchanan/tsconfig`'s `node.json` pinned `lib` and `target` to ES2024 while every package declares `engines: { "node": ">=24.0.0" }`. Node 24 implements the full ES2025 library surface, so the type config was a year behind the runtime it targets.

The gap put the two published configs in direct contradiction: `unicorn/prefer-set-methods` (enabled by `@gtbuchanan/eslint-config`) tells you to use `Set#difference()`, which is declared in `lib.es2025.collection.d.ts` — not pulled in by `lib: ["ES2024"]`. Applying the lint fix failed to compile, so the only ways out were a suppression or restructuring code to dodge a rule that was correct about the runtime.

## Changes

- `packages/tsconfig/node.json` — `lib` and `target` both raised to `ES2025`
- `packages/tsconfig/README.md` — documented values updated
- `packages/tsconfig/e2e/flatten.test.ts` — new case compiling `Set#difference` against the published config

## Decisions on the issue's open questions

**`target` moves in lockstep with `lib`.** They were equal before and stay equal, preserving the invariant.

**Bump type is `minor`.** The package is pre-1.0, so `minor` is already the breaking-capable slot under 0.x semver. The `engines: ">=24.0.0"` floor means no supported consumer can receive downlevel-free output it cannot run.

## Verification

Confirmed the new e2e case is a genuine regression test — the same snippet under `lib: ["ES2024"]` fails with:

```
error TS2550: Property 'difference' does not exist on type 'Set<string>'.
Do you need to change your target library? Try changing the 'lib'
compiler option to 'es2025' or later.
```

TypeScript 6.0.3 accepts `es2025` for both options.

🤖 Generated with [Claude Code](https://claude.com/claude-code)