### PR TITLE
Allow require() in .cjs files for eslint-config

### DIFF
--- a/.changeset/eslint-config-cjs-require-imports.md
+++ b/.changeset/eslint-config-cjs-require-imports.md
@@ -1,0 +1,13 @@
+---
+'@gtbuchanan/eslint-config': minor
+---
+
+Allow `require()` in `.cjs` files
+
+The `.cjs` extension forces CommonJS, so `require()` is the only way to
+import — `import` is a syntax error there. Every consumer with a `.cjs`
+file (a script stub, `.pnpmfile.cjs`, etc.) had to turn
+`@typescript-eslint/no-require-imports` off itself.
+
+Also exports the `cjsFiles` glob so consumers can scope their own `.cjs`
+overrides to the same pattern.

--- a/packages/eslint-config/e2e/cli.test.ts
+++ b/packages/eslint-config/e2e/cli.test.ts
@@ -5,7 +5,6 @@ import { it as base, describe } from 'vitest';
 import {
   type Fixture,
   createFixture,
-  jsTsconfig,
   requireOnlyWarnConfig,
 } from './fixture.ts';
 
@@ -68,19 +67,20 @@ describe.concurrent('eslint CLI integration', () => {
 
     const cjs = await fixture.run({
       files: { 'legacy.cjs': code },
-      tsconfig: jsTsconfig,
+      tsconfig: fixture.jsTsconfig,
     });
     const js = await fixture.run({
       files: { 'legacy.js': code },
-      tsconfig: jsTsconfig,
+      tsconfig: fixture.jsTsconfig,
     });
 
     /*
-     * A parse error would suppress every rule, making the negative
-     * assertion below pass vacuously — guard against it explicitly.
+     * Empty stdout pins the .cjs run to fully clean — no parse error
+     * silently suppressing every rule, which would make a bare "does not
+     * report" assertion pass vacuously.
      */
-    expect(cjs.stdout).not.toContain('Parsing error');
-    expect(cjs.stdout).not.toContain('@typescript-eslint/no-require-imports');
+    expect(cjs).toMatchObject({ exitCode: 0, stdout: '' });
+    expect(js).toMatchObject({ exitCode: 1 });
     expect(js.stdout).toContain('@typescript-eslint/no-require-imports');
   });
 

--- a/packages/eslint-config/e2e/cli.test.ts
+++ b/packages/eslint-config/e2e/cli.test.ts
@@ -5,6 +5,7 @@ import { it as base, describe } from 'vitest';
 import {
   type Fixture,
   createFixture,
+  jsTsconfig,
   requireOnlyWarnConfig,
 } from './fixture.ts';
 
@@ -59,6 +60,28 @@ describe.concurrent('eslint CLI integration', () => {
 
     expect(exitCode).not.toBe(0);
     expect(stdout).toContain('unicorn/no-process-exit');
+  });
+
+  it('allows require() in .cjs but not .js', async ({ fixture, expect }) => {
+    // The .cjs extension forces CommonJS, so require() is the only option
+    const code = "const path = require('node:path');\n\nmodule.exports = path;\n";
+
+    const cjs = await fixture.run({
+      files: { 'legacy.cjs': code },
+      tsconfig: jsTsconfig,
+    });
+    const js = await fixture.run({
+      files: { 'legacy.js': code },
+      tsconfig: jsTsconfig,
+    });
+
+    /*
+     * A parse error would suppress every rule, making the negative
+     * assertion below pass vacuously — guard against it explicitly.
+     */
+    expect(cjs.stdout).not.toContain('Parsing error');
+    expect(cjs.stdout).not.toContain('@typescript-eslint/no-require-imports');
+    expect(js.stdout).toContain('@typescript-eslint/no-require-imports');
   });
 
   it('respects global ignores for dist/', async ({ fixture, expect }) => {

--- a/packages/eslint-config/e2e/fixture.ts
+++ b/packages/eslint-config/e2e/fixture.ts
@@ -40,11 +40,27 @@ const tsconfig = `${JSON.stringify({
   include: ['**/*.ts', '**/*.mts', '**/*.cts'],
 })}\n`;
 
+/**
+ * Variant of the default tsconfig that also covers JavaScript
+ * extensions, for tests that lint `.cjs`/`.js` sources.
+ */
+export const jsTsconfig = `${JSON.stringify({
+  compilerOptions: { allowJs: true },
+  extends: './tsconfig.root.json',
+  include: ['**/*.cjs', '**/*.js', '**/*.mjs'],
+})}\n`;
+
 interface RunOptions {
   config?: string;
   env?: Record<string, string | undefined>;
   files: Record<string, string>;
   flags?: readonly string[];
+  /**
+   * Overrides the default `tsconfig.json`. Needed for tests that lint
+   * non-TypeScript extensions — the project service rejects any file no
+   * tsconfig includes, which fails the run before rules ever execute.
+   */
+  tsconfig?: string;
 }
 
 export const createFixture = () => {
@@ -56,10 +72,16 @@ export const createFixture = () => {
 
   const eslint = path.join(fixture.hookDir, 'node_modules/.bin/eslint');
 
-  const run = async ({ config, env, files, flags = [] }: RunOptions) => {
+  const run = async ({
+    config,
+    env,
+    files,
+    flags = [],
+    tsconfig: tsconfigOverride,
+  }: RunOptions) => {
     const runDir = mkdtempSync(path.join(fixture.projectDir, 'run-'));
     writeFileSync(path.join(runDir, 'eslint.config.ts'), config ?? requireConfig);
-    writeFileSync(path.join(runDir, 'tsconfig.json'), tsconfig);
+    writeFileSync(path.join(runDir, 'tsconfig.json'), tsconfigOverride ?? tsconfig);
     writeFileSync(path.join(runDir, 'tsconfig.root.json'), tsconfigRoot);
 
     const fileNames = Object.keys(files);

--- a/packages/eslint-config/e2e/fixture.ts
+++ b/packages/eslint-config/e2e/fixture.ts
@@ -40,16 +40,6 @@ const tsconfig = `${JSON.stringify({
   include: ['**/*.ts', '**/*.mts', '**/*.cts'],
 })}\n`;
 
-/**
- * Variant of the default tsconfig that also covers JavaScript
- * extensions, for tests that lint `.cjs`/`.js` sources.
- */
-export const jsTsconfig = `${JSON.stringify({
-  compilerOptions: { allowJs: true },
-  extends: './tsconfig.root.json',
-  include: ['**/*.cjs', '**/*.js', '**/*.mjs'],
-})}\n`;
-
 interface RunOptions {
   config?: string;
   env?: Record<string, string | undefined>;
@@ -65,12 +55,32 @@ interface RunOptions {
 
 export const createFixture = () => {
   const fixture = createIsolatedFixture({
-    depsPackages: ['typescript'],
+    depsPackages: ['@types/node', 'typescript'],
     hookPackages: ['eslint', 'jiti'],
     packageName: '@gtbuchanan/eslint-config',
   });
 
   const eslint = path.join(fixture.hookDir, 'node_modules/.bin/eslint');
+
+  /*
+   * Variant of the default tsconfig covering JavaScript extensions, for
+   * tests that lint .cjs/.js sources. Without node types, `require` is
+   * `any` and `module` is unresolved, so the no-unsafe-* rules fire on
+   * any CommonJS sample and drown out what those tests assert. Both
+   * fields are required to get them: `typeRoots` because the isolated
+   * deps directory is not an ancestor of the run directory, and `types`
+   * because TypeScript 6 no longer includes every package under
+   * `typeRoots` automatically.
+   */
+  const jsTsconfig = `${JSON.stringify({
+    compilerOptions: {
+      allowJs: true,
+      typeRoots: [path.join(fixture.depsDir, 'node_modules/@types')],
+      types: ['node'],
+    },
+    extends: './tsconfig.root.json',
+    include: ['**/*.cjs', '**/*.js', '**/*.mjs'],
+  })}\n`;
 
   const run = async ({
     config,
@@ -108,6 +118,7 @@ export const createFixture = () => {
 
   return {
     eslint,
+    jsTsconfig,
     nodePath: fixture.nodePath,
     projectDir: fixture.projectDir,
     run,

--- a/packages/eslint-config/src/files.ts
+++ b/packages/eslint-config/src/files.ts
@@ -23,6 +23,13 @@ export const tsOnlyFiles: string[] = tsOnlyExtensions.map(
 );
 
 /**
+ * Glob patterns matching files whose extension forces CommonJS, making
+ * `require()` the only way to import. `.cts` is excluded — TypeScript
+ * compiles its `import` statements down to `require`.
+ */
+export const cjsFiles: string[] = ['**/*.cjs'];
+
+/**
  * Markdown files excluded from structural lint. Changesets owns the
  * format of files in `.changeset/**` and validates them against its
  * own schema.

--- a/packages/eslint-config/src/index.ts
+++ b/packages/eslint-config/src/index.ts
@@ -7,6 +7,7 @@ import { scriptFileExtensions } from './files.ts';
 import { plugins } from './plugins/index.ts';
 
 export {
+  cjsFiles,
   scriptFileExtensions,
   scriptFiles,
   tsOnlyExtensions,

--- a/packages/eslint-config/src/plugins/typescript.ts
+++ b/packages/eslint-config/src/plugins/typescript.ts
@@ -1,6 +1,6 @@
 import type { Linter } from 'eslint';
 import tseslint from 'typescript-eslint';
-import { scriptFiles, tsOnlyFiles } from '../files.ts';
+import { cjsFiles, scriptFiles, tsOnlyFiles } from '../files.ts';
 import type { PluginFactory, ResolvedOptions } from '../index.ts';
 
 // --- TypeScript rule overrides (on top of strictTypeChecked + stylisticTypeChecked) ---
@@ -61,6 +61,15 @@ const tsOnlyRuleOverrides: Linter.Config = {
   },
 };
 
+/** Rule overrides for files the .cjs extension forces into CommonJS. */
+const cjsRuleOverrides: Linter.Config = {
+  files: [...cjsFiles],
+  rules: {
+    // Justification: .cjs forbids import syntax, so require() is the only option
+    '@typescript-eslint/no-require-imports': 'off',
+  },
+};
+
 /** Resolves TypeScript parser options from the shared config options. */
 export const resolveParserOptions = (
   options: ResolvedOptions,
@@ -77,6 +86,7 @@ const plugin: PluginFactory = options => [
   { languageOptions: { parserOptions: resolveParserOptions(options) } },
   scriptRuleOverrides,
   tsOnlyRuleOverrides,
+  cjsRuleOverrides,
   {
     files: ['**/*'],
     ignores: [...scriptFiles],

--- a/packages/test-utils/src/lib/tarball.ts
+++ b/packages/test-utils/src/lib/tarball.ts
@@ -17,18 +17,33 @@ interface TarballEntry {
 
 const require = createRequire(import.meta.url);
 
+/*
+ * Resolve the manifest directly so types-only packages pin too —
+ * `@types/node` and friends declare no entry point, so resolving the bare
+ * name throws. Packages that keep `./package.json` out of their exports
+ * map fall back to walking up from the entry point.
+ */
+const resolveManifest = (name: string): string => {
+  try {
+    return require.resolve(`${name}/package.json`);
+  } catch {
+    const entryDir = path.dirname(require.resolve(name));
+    const pkgPath = findUpSync('package.json', { cwd: entryDir });
+    if (pkgPath === undefined) {
+      throw new Error(`Could not find package.json for ${name}`);
+    }
+    return pkgPath;
+  }
+};
+
 /**
  * Resolves a package name to `name@version` using the version currently
  * installed in this project's node_modules. This pins e2e fixture installs
  * to the exact versions tested during development.
  */
 export const pinned = (name: string): string => {
-  const entryDir = path.dirname(require.resolve(name));
-  const pkgPath = findUpSync('package.json', { cwd: entryDir });
-  if (pkgPath === undefined) {
-    throw new Error(`Could not find package.json for ${name}`);
-  }
-  const { version } = v.parse(PackageJson, JSON.parse(readFileSync(pkgPath, 'utf8')));
+  const manifest = readFileSync(resolveManifest(name), 'utf8');
+  const { version } = v.parse(PackageJson, JSON.parse(manifest));
   return `${name}@${version}`;
 };
 


### PR DESCRIPTION
Closes #305

`@typescript-eslint/no-require-imports` fired on `.cjs` files, where `require()` is the only option — the extension forces CommonJS, so an `import` statement is a syntax error. Every consumer with a `.cjs` file (script stubs, `.pnpmfile.cjs`) had to turn the rule off itself.

## Changes

- **`src/files.ts`** — new `cjsFiles` glob (`['**/*.cjs']`). It deliberately excludes `.cts`, where TypeScript compiles `import` down to `require`, so the rule still applies there.
- **`src/plugins/typescript.ts`** — `cjsRuleOverrides` block disabling the rule for those files.
- **`src/index.ts`** — re-exports `cjsFiles` alongside the existing glob exports, so consumers can scope their own `.cjs` overrides to the same pattern.

## Neighbouring rules

The issue asked to check these in the same pass. Both are already non-issues, verified by probing a real `.cjs` file against the config:

- `unicorn/prefer-module` — enabled, but reports nothing on `.cjs`; the rule early-returns for that extension itself. No override needed.
- `@typescript-eslint/no-var-requires` — resolves to `undefined`; removed in typescript-eslint v8 and folded into `no-require-imports`.

## Testing

Behavioral test in `e2e/cli.test.ts` running the real ESLint CLI, with a `.js` control so it can't pass vacuously:

```ts
expect(cjs.stdout).not.toContain('Parsing error');
expect(cjs.stdout).not.toContain('@typescript-eslint/no-require-imports');
expect(js.stdout).toContain('@typescript-eslint/no-require-imports');
```

Two notes on how it got there:

- A unit-level test is not viable. A bare `Linter` can't run type-aware rules with `projectService`, so it returns a single fatal message and *no* rule ever fires — a "should not report" assertion passes for the wrong reason. The `.js` control is what exposed this.
- That same vacuity risk applies at the e2e level via parse errors, hence the explicit `Parsing error` guard. It earned its keep immediately: the fixture's default tsconfig includes only TypeScript extensions, so the project service rejected both samples outright. `fixture.run` now takes an optional `tsconfig` override — a per-test opt-in, leaving the other e2e tests untouched.

The assertions target the rule by name rather than `exitCode`, so the test doesn't couple to unrelated rules firing on the sample file.