### PR TITLE
Fix gtb tsconfig sync/verify in single-package repos

### DIFF
--- a/.changeset/tsconfig-single-package-collapse.md
+++ b/.changeset/tsconfig-single-package-collapse.md
@@ -1,0 +1,20 @@
+---
+'@gtbuchanan/cli': patch
+---
+
+Fix `gtb sync`/`gtb verify` disagreeing on tsconfigs in single-package repos
+
+When the workspace root is itself the lone package, the root and
+per-package tsconfig layers of the sync plan target the same
+`tsconfig.json` / `tsconfig.build.json`. The package layer won, writing an
+`extends` of `../../tsconfig.base.json` that resolves outside the repo
+(`TS5083`), and `verify` reported drift against whichever layer it
+compared — so it could never pass, leaving the `Config Check` job
+permanently red.
+
+The plan now collapses layers that land on the same file, keeping the
+root layer's `extends` while folding in the package layer's
+`compilerOptions` and `include`. Package `extends` paths are also derived
+from the package's actual depth below the root instead of assuming a
+`packages/<name>` layout, so a package nested one level deep resolves
+correctly too.

--- a/packages/cli/skills/gtb-build-pipeline/SKILL.md
+++ b/packages/cli/skills/gtb-build-pipeline/SKILL.md
@@ -84,6 +84,8 @@ Test tasks hash `CI` into their cache key (`env: ["CI"]` in `turbo.json`) so loc
 
 Run after adding packages, changing the task graph, or updating tooling. Without `--force`, existing script values are preserved — this is how packages keep custom overrides. Use `--force` only when intentionally resetting scripts to their generated defaults.
 
+**Single-package tsconfigs.** When the root _is_ the lone package (no `packages` globs in `pnpm-workspace.yaml`), the root and per-package tsconfig layers target the same files, so sync collapses them into one: both `tsconfig.json` and `tsconfig.build.json` extend `./tsconfig.base.json`, and the build config carries the root layer's `declaration`/`sourceMap` alongside the package layer's `outDir`/`rootDir`/`include`. Package `extends` paths are derived from the package's actual depth below the root, not assumed to be `packages/<name>`.
+
 **Scoped runs.** Both `gtb sync` and `gtb verify` take positional scope args to limit the work to a subset: `gtb sync mise`, `gtb verify mise turbo`. No args means all scopes. This lets a repo regenerate or check just one artifact — e.g. an hk-preset adopter runs `gtb sync mise` to write `mise.tasks.toml` without a full workspace sync. An unknown scope exits non-zero.
 
 `mise.tasks.toml` is loaded by a one-time manual `[task_config] includes = ["mise.tasks.toml"]` in `mise.toml` (so sync never round-trips the hand-authored file); `gtb verify mise` asserts the include is present. An explicit `includes` replaces mise's default `mise-tasks/` discovery, so a repo keeping its own script tasks lists both: `includes = ["mise-tasks", "mise.tasks.toml"]`.

--- a/packages/cli/src/lib/tsconfig-gen.ts
+++ b/packages/cli/src/lib/tsconfig-gen.ts
@@ -125,14 +125,93 @@ export interface TsconfigDescriptor {
 }
 
 /**
+ * Builds an `extends` specifier pointing from a package directory at a
+ * root-level config, in the POSIX-relative form tsc expects. Derived from
+ * the actual directories rather than assuming the conventional
+ * `packages/<name>` depth, so a package nested one level deep — or a
+ * single-package repo, where the lone package *is* the root and the answer
+ * is `./<file>` — resolves correctly.
+ */
+const rootRelative = (fromDir: string, rootDir: string, fileName: string): string => {
+  const prefix = path.relative(fromDir, rootDir).split(path.sep).join('/');
+  return prefix === '' ? `./${fileName}` : `${prefix}/${fileName}`;
+};
+
+/**
+ * Collapses two descriptors that target the same file. This happens only in
+ * a single-package repo, where the lone package is the workspace root, so
+ * the root and per-package layers land on one `tsconfig.json` /
+ * `tsconfig.build.json`. The package layer contributes its owned
+ * compilerOptions and `include`; `extends` stays the root's, since the
+ * package layer would otherwise point `tsconfig.build.json` at itself.
+ */
+const mergeDescriptors = (
+  root: TsconfigDescriptor,
+  pkg: TsconfigDescriptor,
+): TsconfigDescriptor => ({
+  generate: (opts) => {
+    const base = root.generate(opts);
+    const overlay = pkg.generate(opts);
+
+    return {
+      ...base,
+      ...(overlay.include !== undefined && { include: overlay.include }),
+      compilerOptions: { ...base.compilerOptions, ...overlay.compilerOptions },
+    };
+  },
+  ownedKeys: { ...root.ownedKeys, ...pkg.ownedKeys },
+  path: root.path,
+});
+
+/** Folds descriptors targeting the same path into one, preserving order. */
+const dedupeByPath = (
+  descriptors: readonly TsconfigDescriptor[],
+): readonly TsconfigDescriptor[] => {
+  const byPath = new Map<string, TsconfigDescriptor>();
+  for (const descriptor of descriptors) {
+    const existing = byPath.get(descriptor.path);
+    byPath.set(
+      descriptor.path,
+      existing === undefined ? descriptor : mergeDescriptors(existing, descriptor),
+    );
+  }
+
+  return byPath.values().toArray();
+};
+
+const planPackageTsconfigs = (
+  rootDir: string,
+  pkg: PackageCapabilities,
+): readonly TsconfigDescriptor[] => {
+  if (!pkg.hasTypeScript) {
+    return [];
+  }
+
+  const typeCheck: TsconfigDescriptor = {
+    generate: opts =>
+      generateTypeCheckConfig(rootRelative(pkg.dir, rootDir, 'tsconfig.base.json'), opts),
+    ownedKeys: typeCheckOwned,
+    path: path.join(pkg.dir, 'tsconfig.json'),
+  };
+  const buildConfig: TsconfigDescriptor = {
+    generate: opts =>
+      generateBuildConfig(rootRelative(pkg.dir, rootDir, 'tsconfig.build.json'), opts),
+    ownedKeys: buildOwned,
+    path: path.join(pkg.dir, 'tsconfig.build.json'),
+  };
+
+  return pkg.isPublished ? [typeCheck, buildConfig] : [typeCheck];
+};
+
+/**
  * Builds the list of tsconfig descriptors for the entire workspace.
  * Both `sync` (write) and `verify` (validate) consume this plan.
  */
 export const planTsconfigs = (
   rootDir: string,
   packages: readonly PackageCapabilities[],
-): readonly TsconfigDescriptor[] => {
-  const descriptors: TsconfigDescriptor[] = [
+): readonly TsconfigDescriptor[] =>
+  dedupeByPath([
     {
       generate: opts => generateTypeCheckConfig('./tsconfig.base.json', opts),
       ownedKeys: typeCheckOwned,
@@ -143,27 +222,5 @@ export const planTsconfigs = (
       ownedKeys: rootBuildOwned,
       path: path.join(rootDir, 'tsconfig.build.json'),
     },
-  ];
-
-  for (const pkg of packages) {
-    if (!pkg.hasTypeScript) {
-      continue;
-    }
-
-    descriptors.push({
-      generate: opts => generateTypeCheckConfig('../../tsconfig.base.json', opts),
-      ownedKeys: typeCheckOwned,
-      path: path.join(pkg.dir, 'tsconfig.json'),
-    });
-
-    if (pkg.isPublished) {
-      descriptors.push({
-        generate: opts => generateBuildConfig('../../tsconfig.build.json', opts),
-        ownedKeys: buildOwned,
-        path: path.join(pkg.dir, 'tsconfig.build.json'),
-      });
-    }
-  }
-
-  return descriptors;
-};
+    ...packages.flatMap(pkg => planPackageTsconfigs(rootDir, pkg)),
+  ]);

--- a/packages/cli/src/lib/tsconfig-gen.ts
+++ b/packages/cli/src/lib/tsconfig-gen.ts
@@ -3,6 +3,7 @@ import { parseTsconfig } from 'get-tsconfig';
 import * as v from 'valibot';
 import type { PackageCapabilities } from './discovery.ts';
 import { readJsonFile } from './file-writer.ts';
+import { toPosixRelative } from './paths.ts';
 import { StringArray, UnknownRecord } from './schemas.ts';
 
 /** Directories and file patterns included in tsconfig.json for type-checking. */
@@ -133,7 +134,7 @@ export interface TsconfigDescriptor {
  * is `./<file>` — resolves correctly.
  */
 const rootRelative = (fromDir: string, rootDir: string, fileName: string): string => {
-  const prefix = path.relative(fromDir, rootDir).split(path.sep).join('/');
+  const prefix = toPosixRelative(fromDir, rootDir);
   return prefix === '' ? `./${fileName}` : `${prefix}/${fileName}`;
 };
 
@@ -144,24 +145,36 @@ const rootRelative = (fromDir: string, rootDir: string, fileName: string): strin
  * `tsconfig.build.json`. The package layer contributes its owned
  * compilerOptions and `include`; `extends` stays the root's, since the
  * package layer would otherwise point `tsconfig.build.json` at itself.
+ *
+ * The union of both layers' owned keys is re-applied last: each layer's
+ * `generate` already merged the same user options over its own owned keys,
+ * so overlaying the package layer would otherwise let a user value win back
+ * a key the root layer owns (`declaration`, `sourceMap`) — silently, since
+ * `verify` compares against this same output.
  */
 const mergeDescriptors = (
   root: TsconfigDescriptor,
   pkg: TsconfigDescriptor,
-): TsconfigDescriptor => ({
-  generate: (opts) => {
-    const base = root.generate(opts);
-    const overlay = pkg.generate(opts);
+): TsconfigDescriptor => {
+  const ownedKeys = { ...root.ownedKeys, ...pkg.ownedKeys };
 
-    return {
-      ...base,
-      ...(overlay.include !== undefined && { include: overlay.include }),
-      compilerOptions: { ...base.compilerOptions, ...overlay.compilerOptions },
-    };
-  },
-  ownedKeys: { ...root.ownedKeys, ...pkg.ownedKeys },
-  path: root.path,
-});
+  return {
+    generate: (opts) => {
+      const base = root.generate(opts);
+      const overlay = pkg.generate(opts);
+
+      return {
+        ...base,
+        ...(overlay.include !== undefined && { include: overlay.include }),
+        compilerOptions: {
+          ...base.compilerOptions, ...overlay.compilerOptions, ...ownedKeys,
+        },
+      };
+    },
+    ownedKeys,
+    path: root.path,
+  };
+};
 
 /** Folds descriptors targeting the same path into one, preserving order. */
 const dedupeByPath = (

--- a/packages/cli/test/tsconfig-gen.test.ts
+++ b/packages/cli/test/tsconfig-gen.test.ts
@@ -1,12 +1,28 @@
 import { mkdirSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
+import * as build from '@gtbuchanan/test-utils/builders';
 import { describe, it } from 'vitest';
-import { buildInclude, resolveBuildIncludes } from '#src/lib/tsconfig-gen.js';
+import type { GeneratedTsconfig, TsconfigDescriptor } from '#src/lib/tsconfig-gen.js';
+import {
+  buildInclude, planTsconfigs, resolveBuildIncludes, typeCheckInclude,
+} from '#src/lib/tsconfig-gen.js';
 import { createTempDir } from './helpers.ts';
+import { makeCapabilities } from './turbo-config.helpers.ts';
 
 const writeConfig = (dir: string, name: string, content: string): void => {
   writeFileSync(path.join(dir, name), content);
 };
+
+const descriptorAt = (
+  descriptors: readonly TsconfigDescriptor[],
+  filePath: string,
+): TsconfigDescriptor | undefined =>
+  descriptors.find(descriptor => descriptor.path === filePath);
+
+const generateAt = (
+  descriptors: readonly TsconfigDescriptor[],
+  filePath: string,
+): GeneratedTsconfig | undefined => descriptorAt(descriptors, filePath)?.generate();
 
 describe.concurrent(resolveBuildIncludes, () => {
   it('reads the explicit include array from tsconfig.build.json', ({ expect }) => {
@@ -108,5 +124,134 @@ describe.concurrent(resolveBuildIncludes, () => {
     writeConfig(dir, 'tsconfig.build.json', '{ this is not json');
 
     expect(resolveBuildIncludes(dir)).toStrictEqual([...buildInclude]);
+  });
+});
+
+describe.concurrent(planTsconfigs, () => {
+  it('points a package at the root configs from its own depth', ({ expect }) => {
+    const rootDir = path.resolve(build.packageName());
+    const pkgDir = path.join(rootDir, 'packages', build.packageName());
+
+    const descriptors = planTsconfigs(rootDir, [
+      makeCapabilities({ dir: pkgDir, hasTypeScript: true, isPublished: true }),
+    ]);
+
+    expect(generateAt(descriptors, path.join(pkgDir, 'tsconfig.json')))
+      .toHaveProperty('extends', '../../tsconfig.base.json');
+    expect(generateAt(descriptors, path.join(pkgDir, 'tsconfig.build.json')))
+      .toHaveProperty('extends', '../../tsconfig.build.json');
+  });
+
+  it('derives the extends depth rather than assuming packages/<name>', ({ expect }) => {
+    const rootDir = path.resolve(build.packageName());
+    const pkgDir = path.join(rootDir, build.packageName());
+
+    const descriptors = planTsconfigs(rootDir, [
+      makeCapabilities({ dir: pkgDir, hasTypeScript: true }),
+    ]);
+
+    expect(generateAt(descriptors, path.join(pkgDir, 'tsconfig.json')))
+      .toHaveProperty('extends', '../tsconfig.base.json');
+  });
+
+  it('omits the build descriptor for an unpublished package', ({ expect }) => {
+    const rootDir = path.resolve(build.packageName());
+    const pkgDir = path.join(rootDir, 'packages', build.packageName());
+
+    const descriptors = planTsconfigs(rootDir, [
+      makeCapabilities({ dir: pkgDir, hasTypeScript: true }),
+    ]);
+
+    expect(descriptorAt(descriptors, path.join(pkgDir, 'tsconfig.build.json')))
+      .toBeUndefined();
+  });
+
+  it('emits one descriptor per file when the root is the package', ({ expect }) => {
+    const rootDir = path.resolve(build.packageName());
+
+    const descriptors = planTsconfigs(rootDir, [
+      makeCapabilities({ dir: rootDir, hasTypeScript: true, isPublished: true }),
+    ]);
+
+    expect(descriptors.map(descriptor => descriptor.path)).toStrictEqual([
+      path.join(rootDir, 'tsconfig.json'),
+      path.join(rootDir, 'tsconfig.build.json'),
+    ]);
+  });
+
+  it('keeps the collapsed root tsconfig.json extending the local base', ({ expect }) => {
+    const rootDir = path.resolve(build.packageName());
+
+    const descriptors = planTsconfigs(rootDir, [
+      makeCapabilities({ dir: rootDir, hasTypeScript: true, isPublished: true }),
+    ]);
+
+    expect(generateAt(descriptors, path.join(rootDir, 'tsconfig.json'))).toStrictEqual({
+      compilerOptions: { noEmit: true },
+      extends: './tsconfig.base.json',
+      include: [...typeCheckInclude],
+    });
+  });
+
+  it('folds the package build layer into the root tsconfig.build.json', ({ expect }) => {
+    const rootDir = path.resolve(build.packageName());
+
+    const descriptors = planTsconfigs(rootDir, [
+      makeCapabilities({ dir: rootDir, hasTypeScript: true, isPublished: true }),
+    ]);
+
+    /*
+     * The package layer would extend `./tsconfig.build.json` — itself — so the
+     * collapsed descriptor keeps the root layer's base extends and takes only
+     * the package layer's compilerOptions and include.
+     */
+    expect(generateAt(descriptors, path.join(rootDir, 'tsconfig.build.json'))).toStrictEqual({
+      compilerOptions: {
+        declaration: true, outDir: 'dist/source', rootDir: '.', sourceMap: true,
+      },
+      extends: './tsconfig.base.json',
+      include: [...buildInclude],
+    });
+  });
+
+  it('owns both layers compilerOptions on the collapsed build config', ({ expect }) => {
+    const rootDir = path.resolve(build.packageName());
+
+    const descriptors = planTsconfigs(rootDir, [
+      makeCapabilities({ dir: rootDir, hasTypeScript: true, isPublished: true }),
+    ]);
+    const descriptor = descriptorAt(descriptors, path.join(rootDir, 'tsconfig.build.json'));
+
+    // Both layers' keys are owned, so verify checks the whole collapsed set.
+    expect(descriptor?.ownedKeys).toStrictEqual({
+      declaration: true, outDir: 'dist/source', rootDir: '.', sourceMap: true,
+    });
+  });
+
+  it('leaves the root build config bare when the root package is unpublished', ({ expect }) => {
+    const rootDir = path.resolve(build.packageName());
+
+    const descriptors = planTsconfigs(rootDir, [
+      makeCapabilities({ dir: rootDir, hasTypeScript: true }),
+    ]);
+
+    expect(generateAt(descriptors, path.join(rootDir, 'tsconfig.build.json'))).toStrictEqual({
+      compilerOptions: { declaration: true, sourceMap: true },
+      extends: './tsconfig.base.json',
+    });
+  });
+
+  it('preserves user compilerOptions under the collapsed generated keys', ({ expect }) => {
+    const rootDir = path.resolve(build.packageName());
+    const userKey = build.packageName();
+
+    const descriptors = planTsconfigs(rootDir, [
+      makeCapabilities({ dir: rootDir, hasTypeScript: true, isPublished: true }),
+    ]);
+    const generated = descriptorAt(descriptors, path.join(rootDir, 'tsconfig.build.json'))
+      ?.generate({ [userKey]: true, outDir: 'stale' });
+
+    expect(generated).toHaveProperty(['compilerOptions', userKey], true);
+    expect(generated).toHaveProperty(['compilerOptions', 'outDir'], 'dist/source');
   });
 });

--- a/packages/cli/test/tsconfig-gen.test.ts
+++ b/packages/cli/test/tsconfig-gen.test.ts
@@ -254,4 +254,22 @@ describe.concurrent(planTsconfigs, () => {
     expect(generated).toHaveProperty(['compilerOptions', userKey], true);
     expect(generated).toHaveProperty(['compilerOptions', 'outDir'], 'dist/source');
   });
+
+  it('overrides user values for keys owned by either collapsed layer', ({ expect }) => {
+    const rootDir = path.resolve(build.packageName());
+
+    const descriptors = planTsconfigs(rootDir, [
+      makeCapabilities({ dir: rootDir, hasTypeScript: true, isPublished: true }),
+    ]);
+
+    /*
+     * `declaration`/`sourceMap` belong to the root layer only, so the package
+     * layer's own user merge would otherwise hand them back to the user.
+     */
+    expect(descriptorAt(descriptors, path.join(rootDir, 'tsconfig.build.json'))
+      ?.generate({ declaration: false, rootDir: 'stale', sourceMap: false }))
+      .toHaveProperty('compilerOptions', {
+        declaration: true, outDir: 'dist/source', rootDir: '.', sourceMap: true,
+      });
+  });
 });

--- a/packages/cli/test/tsconfig-single-package.test.ts
+++ b/packages/cli/test/tsconfig-single-package.test.ts
@@ -1,0 +1,83 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import * as build from '@gtbuchanan/test-utils/builders';
+import { describe, it } from 'vitest';
+import { runSync } from '#src/commands/root/sync.js';
+import { runVerify } from '#src/commands/root/verify.js';
+import { readJsonFile } from '#src/lib/file-writer.js';
+import { captureLogger, createTempDir, writeJson } from './helpers.ts';
+
+/**
+ * Scaffolds a repo whose root _is_ the lone package — a `pnpm-workspace.yaml`
+ * carrying settings but no `packages` globs, so discovery falls back to
+ * single-package mode with `pkg.dir === rootDir`.
+ */
+const createSinglePackageProject = (): string => {
+  const root = createTempDir();
+  writeFileSync(path.join(root, 'pnpm-workspace.yaml'), 'linkWorkspacePackages: true\n');
+  mkdirSync(path.join(root, 'src'), { recursive: true });
+  writeJson(root, 'package.json', {
+    devDependencies: {
+      '@gtbuchanan/cli': build.semverRange(),
+      '@gtbuchanan/tsconfig': build.semverRange(),
+    },
+    name: build.scopedPackageName(),
+    publishConfig: { directory: build.publishDirectory() },
+    scripts: {},
+    version: build.semverVersion(),
+  });
+  writeFileSync(path.join(root, 'tsconfig.base.json'), '{}');
+
+  return root;
+};
+
+const syncTsconfigs = (root: string): void => {
+  runSync({
+    cwd: root,
+    force: true,
+    logger: captureLogger().logger,
+    scopes: new Set(['tsconfig']),
+  });
+};
+
+describe.concurrent('single-package tsconfigs', () => {
+  it('writes tsconfigs that resolve inside the repo', ({ expect }) => {
+    const root = createSinglePackageProject();
+
+    syncTsconfigs(root);
+
+    for (const name of ['tsconfig.json', 'tsconfig.build.json']) {
+      expect(readJsonFile(path.join(root, name)))
+        .toHaveProperty('extends', './tsconfig.base.json');
+    }
+  });
+
+  it('keeps the emit options the build task needs', ({ expect }) => {
+    const root = createSinglePackageProject();
+
+    syncTsconfigs(root);
+
+    expect(readJsonFile(path.join(root, 'tsconfig.build.json'))).toMatchObject({
+      compilerOptions: { declaration: true, outDir: 'dist/source', rootDir: '.' },
+      include: ['bin', 'src'],
+    });
+  });
+
+  it('leaves no drift for verify to report', ({ expect }) => {
+    const root = createSinglePackageProject();
+
+    syncTsconfigs(root);
+
+    expect(runVerify({ cwd: root, scopes: new Set(['tsconfig']) })).toStrictEqual([]);
+  });
+
+  it('stays idempotent across repeated syncs', ({ expect }) => {
+    const root = createSinglePackageProject();
+
+    syncTsconfigs(root);
+    const first = readJsonFile(path.join(root, 'tsconfig.build.json'));
+    syncTsconfigs(root);
+
+    expect(readJsonFile(path.join(root, 'tsconfig.build.json'))).toStrictEqual(first);
+  });
+});


### PR DESCRIPTION
Fixes #300.

## Problem

`planTsconfigs` emits a root layer and a per-package layer. In a single-package repo (`pnpm-workspace.yaml` with settings but no `packages` globs) `pkg.dir === rootDir`, so both layers target the same `tsconfig.json` / `tsconfig.build.json`. Sync applied them in order and the package layer won, writing `"extends": "../../tsconfig.base.json"` at the workspace root — a path outside the repo (`TS5083`). Verify walked the same plan and flagged whichever layer it compared last, so it could never pass, leaving the pre-commit step and the `Config Check` CI job permanently red.

## Fix

- **`rootRelative()`** derives the `extends` specifier from the actual package/root directories instead of hardcoding `../../`. This also fixes a latent bug for packages nested at any depth other than `packages/<name>`.
- **`dedupeByPath` + `mergeDescriptors`** collapse descriptors that land on the same file. The root layer's `extends` wins — the package layer would otherwise point `tsconfig.build.json` at itself — while the package layer contributes its `compilerOptions` and `include`.

The issue suggested skipping the per-package descriptors entirely when `pkg.dir === rootDir`. I didn't take that route: it would drop `outDir`/`rootDir`/`include` from a published single-package repo's `tsconfig.build.json`, so `compile:ts` would emit beside the sources instead of into `dist/source`. Collapsing keeps both layers.

## Result

Against a scratch single-package repo, `gtb sync tsconfig` now writes:

```jsonc
// tsconfig.json
{ "compilerOptions": { "noEmit": true }, "extends": "./tsconfig.base.json", "include": [...] }

// tsconfig.build.json
{
  "compilerOptions": { "declaration": true, "outDir": "dist/source", "rootDir": ".", "sourceMap": true },
  "extends": "./tsconfig.base.json",
  "include": ["bin", "src"]
}
```

and `gtb verify tsconfig` reports no drift.

## Testing

- `describe(planTsconfigs)` block in `tsconfig-gen.test.ts` covering extends depth (nested and root-as-package), descriptor collapsing, merged `ownedKeys`, and user `compilerOptions` preservation.
- `tsconfig-single-package.test.ts` — sync→verify round trip, emit options, idempotency. Split into its own file because `verify.test.ts` was already at the `max-lines` cap.
- Confirmed the new tests fail against the unpatched source and pass with the fix.
- Full `pnpm build` passes. This repo's own tsconfigs are unchanged (it's a monorepo, so the collapse path never triggers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
