### PR TITLE
Pin pnpm in mise.toml instead of the idiomatic version file

### DIFF
--- a/.changeset/pin-pnpm-in-mise-tools.md
+++ b/.changeset/pin-pnpm-in-mise-tools.md
@@ -1,0 +1,4 @@
+---
+---
+
+Pin pnpm in `mise.toml` instead of reading it from `packageManager`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -471,13 +471,20 @@ reasoning here so the question doesn't get re-litigated:
 
 The forced consequence: `packageManager` in `package.json` is
 required — turbo errors out with `Missing packageManager` during
-workspace resolution. Rather than duplicate the pnpm pin in
-`mise.toml`'s `[tools]`, we set
-`idiomatic_version_file_enable_tools = ["pnpm"]` so mise reads the
-version directly from the same `packageManager` field. One pin, two
-consumers (turbo and mise). `mise.lock` still locks pnpm's
-per-platform binaries via the aqua backend; only the version source
-is shared.
+workspace resolution. The pnpm version is therefore pinned twice: in
+`package.json`'s `packageManager` (for turbo) and in `mise.toml`'s
+`[tools]` (for mise). Renovate bumps both and groups them into one PR
+via the `pnpm` `packageRule` in `default.json`.
+
+We previously deduplicated this with
+`idiomatic_version_file_enable_tools = ["pnpm"]`, which let mise read
+the version straight from `packageManager`. It broke Renovate PRs:
+Renovate's npm manager bumps `packageManager` but has no idea that
+change implies a mise tool bump, so `mise.lock`'s pnpm entry kept the
+old version and every `MISE_LOCKED=1` install failed on the drift.
+Renovate _does_ regenerate `mise.lock` for `[tools]` entries, so
+accepting the duplication is what keeps the lockfile honest. Don't
+"simplify" this back to the idiomatic version file.
 
 The `TURBO_DANGEROUSLY_DISABLE_PACKAGE_MANAGER_CHECK` escape hatch
 exists but turbo's own schema warns it disables some pnpm-aware

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,10 +4,10 @@
 
 [mise] manages the repo's pinned dev tools for every contributor and
 CI. Run `mise install` to get the versions the repo pins.
-Those versions live in `mise.toml`; pnpm's version lives in
-`package.json`'s `packageManager` field because turbo requires that
-field for workspace resolution (mise reads the version from there via
-`idiomatic_version_file_enable_tools`).
+Those versions live in `mise.toml`. pnpm is pinned twice — in
+`mise.toml` and in `package.json`'s `packageManager` field, which turbo
+requires for workspace resolution — so keep the two in sync when
+bumping by hand (Renovate groups them into one PR).
 
 Install mise:
 

--- a/default.json
+++ b/default.json
@@ -60,6 +60,13 @@
       ]
     },
     {
+      "description": "Group pnpm updates (the mise tool and package.json's packageManager field pin the same release)",
+      "groupName": "pnpm",
+      "matchSourceUrls": [
+        "https://github.com/pnpm/pnpm"
+      ]
+    },
+    {
       "description": "Group playwright-cli monorepo",
       "groupName": "playwright-cli monorepo",
       "matchSourceUrls": [

--- a/mise.toml
+++ b/mise.toml
@@ -13,10 +13,6 @@ postinstall = "hk install --mise"
 [settings]
 # Required for the `[hooks]` table.
 experimental = true
-# pnpm's version comes from `packageManager` in package.json (turbo
-# requires that field, and mise reads it natively when listed here).
-# Keeps the pnpm pin in one place instead of mirroring it in mise.toml.
-idiomatic_version_file_enable_tools = ["pnpm"]
 lockfile = true
 # Matches the Renovate/pnpm 3-day quarantine. Only filters fuzzy/`latest`
 # resolution (e.g. manual `mise up --bump`); install of the exact pins
@@ -49,5 +45,11 @@ hk = "1.51.0"
 node = "24.18.0"
 "npm:renovate" = "43.265.1"
 pkl = "0.32.1"
+# Deliberately duplicates `packageManager` in package.json (turbo requires
+# that field). Renovate groups both bumps into one PR — see the "pnpm"
+# packageRule in default.json. Reading the version from package.json via
+# `idiomatic_version_file_enable_tools` avoided the duplication but left
+# mise.lock unbumped, failing every `MISE_LOCKED=1` install.
+pnpm = "11.15.0"
 shellcheck = "0.11.0"
 shfmt = "3.13.1"


### PR DESCRIPTION
## Problem

pnpm's version was pinned once, in `package.json`'s `packageManager`, with `idiomatic_version_file_enable_tools = ["pnpm"]` telling mise to read it from there. That saved a duplicate pin but broke Renovate PRs: Renovate's npm manager bumps `packageManager` with no idea the change implies a mise tool bump, so `mise.lock`'s pnpm entry kept the old version and every `MISE_LOCKED=1` install failed on the drift.

## Change

- `mise.toml` — drop `idiomatic_version_file_enable_tools`, pin `pnpm` in `[tools]`. Renovate *does* regenerate `mise.lock` for `[tools]` entries (see the recent `pkl` bumps, which touch both files).
- `default.json` — add a `pnpm` group `packageRule` matching `https://github.com/pnpm/pnpm`, so the mise bump and the `packageManager` bump land in one PR. Same shape as the existing `hk` / `pkl` groups.
- `AGENTS.md` / `CONTRIBUTING.md` — record the rationale, including a "don't simplify this back" note so the deduplication isn't re-attempted.

`packageManager` stays because turbo requires it for workspace resolution, so the version is now duplicated on purpose.

## Notes

`mise.lock` needed no change — it already recorded pnpm 11.15.0 via the aqua backend, confirming the lock entry shape is identical either way; only the version *source* moved.

Verified locally: `mise install` succeeds with no lockfile churn, `renovate-config-validator --strict` passes on `default.json` and `.github/renovate.json`, and the pre-commit hooks pass on the changed files.

Watch the first grouped pnpm bump — if it still shows only `package.json` changing, the group match isn't firing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
