### PR TITLE
Enforce pnpm workspace settings in eslint-config

### DIFF
--- a/.changeset/pnpm-workspace-settings-policy.md
+++ b/.changeset/pnpm-workspace-settings-policy.md
@@ -1,0 +1,32 @@
+---
+'@gtbuchanan/eslint-config': minor
+---
+
+Enforce a pnpm workspace settings policy
+
+`eslint-plugin-pnpm`'s `yaml-enforce-settings` is the only rule it ships
+that lints the settings keys of `pnpm-workspace.yaml` — the block that
+absorbed most of `.npmrc` in pnpm 10. No config enables it, because it
+carries no default policy and throws unless given one. The remaining
+rules cover only catalogs and package globs, so nothing kept install
+behavior consistent across repos.
+
+`configure()` now supplies a policy by default, exported as
+`defaultPnpmWorkspaceSettings`: `engineStrict`, `hoist`,
+`minimumReleaseAge`, and `strictPeerDependencies` are matched by value
+and auto-fixed into place; `minimumReleaseAgeExclude` is required to
+exist without pinning its contents; and `dangerouslyAllowAllBuilds`,
+`publicHoistPattern`, `shamefullyHoist`, and `trustLockfile` are
+forbidden outright.
+
+The split between the three knobs is deliberate. `settings` compares
+whole values and its fixer replaces the entire key/value pair, so
+pinning a list a consumer extends would make `--fix` delete their added
+scopes — hence the exclude list is required rather than value-matched.
+`settings` also cannot express "anything but this value", so a setting
+that is unsafe in one direction has to be banned by key instead.
+
+Repos whose `pnpm-workspace.yaml` omits these settings will see new
+warnings that `--fix` resolves. Pass a replacement policy to
+`pnpmWorkspaceSettings` to change it, or `false` to keep the catalog
+rules without the settings policy.

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -65,7 +65,7 @@ export default configure({
 - `@eslint/json` — JSON file linting
 - `@vitest/eslint-plugin` — Vitest test-specific rules
 - `eslint-plugin-n` — Node.js best practices
-- `eslint-plugin-pnpm` — pnpm workspace validation (opt-in)
+- `eslint-plugin-pnpm` — pnpm catalog validation and `pnpm-workspace.yaml` settings policy
 - `eslint-plugin-yml` — YAML linting and key sorting
 - `eslint-plugin-toml` — TOML linting and structural key/table ordering
 - `@eslint/markdown` — Official Markdown lint plugin (commonmark AST)

--- a/packages/eslint-config/e2e/cli.test.ts
+++ b/packages/eslint-config/e2e/cli.test.ts
@@ -186,6 +186,50 @@ describe.concurrent('eslint CLI integration', () => {
     expect(result.stdout).toContain('yamllint/octal-values');
   });
 
+  /*
+   * The two halves of the default workspace policy behave differently on
+   * purpose: `settings` entries are auto-fixed into the file, while
+   * `minimumReleaseAgeExclude` is only required to exist so that a
+   * consumer's own scopes survive `--fix`.
+   */
+  it('fixes missing settings but not the exclude list', async ({ fixture, expect }) => {
+    const workspace = [
+      'minimumReleaseAgeExclude:',
+      "  - '@gtbuchanan/*'",
+      "  - '@acme/*'",
+      '',
+    ].join('\n');
+
+    const result = await fixture.run({
+      files: { 'pnpm-workspace.yaml': workspace },
+      flags: ['--fix'],
+    });
+
+    const fixed = result.readFile('pnpm-workspace.yaml');
+
+    expect(fixed).toContain('engineStrict: true');
+    expect(fixed).toContain('strictPeerDependencies: true');
+    expect(fixed).toContain("'@acme/*'");
+    expect(fixed).toContain("'@gtbuchanan/*'");
+  });
+
+  it('reports a forbidden setting without removing it', async ({ fixture, expect }) => {
+    const workspace = [
+      'minimumReleaseAgeExclude:',
+      "  - '@gtbuchanan/*'",
+      'shamefullyHoist: true',
+      '',
+    ].join('\n');
+
+    const result = await fixture.run({
+      files: { 'pnpm-workspace.yaml': workspace },
+      flags: ['--fix'],
+    });
+
+    expect(result.stdout).toContain('pnpm/yaml-enforce-settings');
+    expect(result.readFile('pnpm-workspace.yaml')).toContain('shamefullyHoist: true');
+  });
+
   it('detects markdownlint violations in markdown files', async ({ fixture, expect }) => {
     // MD026 (no-trailing-punctuation) — markdownlint-only, not covered
     // by `@eslint/markdown`'s recommended set.

--- a/packages/eslint-config/skills/gtb-eslint-config/SKILL.md
+++ b/packages/eslint-config/skills/gtb-eslint-config/SKILL.md
@@ -50,6 +50,85 @@ All optional except `tsconfigRootDir` (recommended for type-aware rules):
   Linter class.
 - **`pnpm`** — Enables `eslint-plugin-pnpm` rules for `package.json`
   and `pnpm-workspace.yaml`. Defaults to `true`.
+- **`pnpmWorkspaceSettings`** — Policy for `pnpm/yaml-enforce-settings`,
+  which lints the settings keys of `pnpm-workspace.yaml`. Defaults to
+  `defaultPnpmWorkspaceSettings` (see below). Pass `false` to keep the
+  catalog rules but drop the settings policy. Ignored when `pnpm` is
+  `false`.
+
+## pnpm workspace settings policy
+
+`pnpm/yaml-enforce-settings` lints the settings keys of
+`pnpm-workspace.yaml` — the block that absorbed most of `.npmrc` in
+pnpm 10. The other `eslint-plugin-pnpm` rules cover only catalogs and
+package globs, so this is the one that keeps install behavior
+consistent across repos. `defaultPnpmWorkspaceSettings` enforces:
+
+- `settings` (exact key **and** value, auto-fixable) —
+  `engineStrict: true`, `hoist: false`, `minimumReleaseAge: 4320`
+  (3 days, matching the shared Renovate preset), and
+  `strictPeerDependencies: true`
+- `requiredFields` (key must exist, any value, never fixed) —
+  `minimumReleaseAgeExclude`
+- `forbiddenFields` (key must not exist, never fixed) —
+  `dangerouslyAllowAllBuilds`, `publicHoistPattern`, `shamefullyHoist`,
+  `trustLockfile`
+
+Each `settings` entry is inserted into the consumer's file by `--fix`,
+so the set is kept to values that differ from pnpm's own defaults.
+Settings that merely restate a default add a line that changes nothing.
+
+### Why the unsafe settings are forbidden keys
+
+`settings` can only express exact equality — there is no "anything but
+this value". A setting that is dangerous in one direction therefore has
+to be banned outright by key. `dangerouslyAllowAllBuilds` runs every
+dependency's install scripts without approval, bypassing `allowBuilds`.
+`publicHoistPattern` and `shamefullyHoist` both flatten dependencies
+into the root `node_modules`, undoing `hoist: false` and letting
+undeclared imports resolve — pnpm defines `shamefullyHoist` as
+`publicHoistPattern: '*'`, so banning one without the other leaves the
+hole open. `trustLockfile` skips the lockfile's supply-chain
+verification pass.
+
+Because these are key-presence checks, they also flag a harmless
+explicit value (`publicHoistPattern: []`), and a key absent from an
+older pnpm simply never appears.
+
+### Why the exclude list is required rather than value-matched
+
+`settings` compares whole values with deep equality, and its fixer
+replaces the entire key/value pair. For a list a consumer legitimately
+extends, that combination is destructive: adding `'@acme/*'` to
+`minimumReleaseAgeExclude` would read as a mismatch, and `--fix` would
+delete it. Requiring the key without pinning its value keeps the
+setting deliberate while leaving its contents to the consumer. Apply
+the same reasoning before moving any future list-valued setting into
+`settings`.
+
+### Overriding the policy
+
+`pnpmWorkspaceSettings` **replaces** the default rather than merging
+into it, and spread is shallow — a bare `...defaultPnpmWorkspaceSettings`
+still clobbers `settings` wholesale. Spread both levels:
+
+```typescript
+import {
+  configure,
+  defaultPnpmWorkspaceSettings as base,
+} from '@gtbuchanan/eslint-config';
+
+export default configure({
+  pnpmWorkspaceSettings: {
+    ...base,
+    settings: { ...base.settings, hoist: true },
+  },
+});
+```
+
+A policy with no `settings`, `requiredFields`, or `forbiddenFields`
+drops the rule instead of enabling it — the rule throws when given an
+empty policy, so `{}` and `false` behave the same.
 
 ## Pre-commit isolation
 

--- a/packages/eslint-config/src/index.ts
+++ b/packages/eslint-config/src/index.ts
@@ -5,6 +5,8 @@ import type { Linter } from 'eslint';
 import { defineConfig } from 'eslint/config';
 import { scriptFileExtensions } from './files.ts';
 import { plugins } from './plugins/index.ts';
+import { defaultPnpmWorkspaceSettings } from './pnpm-workspace.ts';
+import type { PnpmWorkspaceSettings } from './pnpm-workspace.ts';
 
 export {
   cjsFiles,
@@ -13,6 +15,8 @@ export {
   tsOnlyExtensions,
   tsOnlyFiles,
 } from './files.ts';
+export { defaultPnpmWorkspaceSettings } from './pnpm-workspace.ts';
+export type { PnpmWorkspaceSettings } from './pnpm-workspace.ts';
 
 const entryPointDirs = ['**/bin', '**/scripts'] as const;
 
@@ -49,6 +53,15 @@ export interface ESLintConfigureOptions {
    */
   readonly pnpm?: boolean;
   /**
+   * Policy enforced on the settings keys of `pnpm-workspace.yaml`.
+   * Replaces the default wholesale rather than merging into it — spread
+   * {@link defaultPnpmWorkspaceSettings} to extend it. Pass `false` to
+   * keep the catalog rules but drop the settings policy. Ignored when
+   * `pnpm` is `false`.
+   * @defaultValue {@link defaultPnpmWorkspaceSettings}
+   */
+  readonly pnpmWorkspaceSettings?: PnpmWorkspaceSettings | false;
+  /**
    * Target environment. Server targets enable require-unicode-regexp with
    * `/v` flag. Browser targets enable `no-console` and `no-alert`; entry
    * points are exempt from `no-console`.
@@ -82,6 +95,7 @@ export const configure = async (
     ],
     onlyWarn: options.onlyWarn ?? true,
     pnpm: options.pnpm ?? true,
+    pnpmWorkspaceSettings: options.pnpmWorkspaceSettings ?? defaultPnpmWorkspaceSettings,
     target: options.target ?? 'server',
     ...(options.tsconfigRootDir !== undefined && { tsconfigRootDir: options.tsconfigRootDir }),
   };

--- a/packages/eslint-config/src/plugins/pnpm.ts
+++ b/packages/eslint-config/src/plugins/pnpm.ts
@@ -1,13 +1,46 @@
+import type { Linter } from 'eslint';
 import { configs as pnpmPluginConfigs } from 'eslint-plugin-pnpm';
 import type { PluginFactory } from '../index.ts';
+import type { PnpmWorkspaceSettings } from '../pnpm-workspace.ts';
 
 // --- pnpm ---
+
+/*
+ * `pnpm/yaml-enforce-settings` throws at rule-creation time when every
+ * knob is empty, so an exhausted policy has to drop the rule entirely
+ * rather than pass it through.
+ */
+const isEmpty = ({
+  forbiddenFields = [],
+  requiredFields = [],
+  settings = {},
+}: PnpmWorkspaceSettings): boolean =>
+  forbiddenFields.length === 0 &&
+  requiredFields.length === 0 &&
+  Object.keys(settings).length === 0;
 
 const plugin: PluginFactory = (options) => {
   if (!options.pnpm) {
     return [];
   }
-  return [...pnpmPluginConfigs.json, ...pnpmPluginConfigs.yaml];
+
+  const policy = options.pnpmWorkspaceSettings;
+  const settingsRules: Linter.RulesRecord =
+    policy === false || isEmpty(policy)
+      ? {}
+      : { 'pnpm/yaml-enforce-settings': ['error', policy] };
+
+  /*
+   * Merge into the plugin's own YAML config rather than appending a
+   * config entry, so the rule inherits its files and YAML parser.
+   */
+  return [
+    ...pnpmPluginConfigs.json,
+    ...pnpmPluginConfigs.yaml.map(config => ({
+      ...config,
+      rules: { ...config.rules, ...settingsRules },
+    })),
+  ];
 };
 
 export default plugin;

--- a/packages/eslint-config/src/pnpm-workspace.ts
+++ b/packages/eslint-config/src/pnpm-workspace.ts
@@ -1,0 +1,54 @@
+/**
+ * Policy for `pnpm/yaml-enforce-settings`, which lints the settings keys
+ * of `pnpm-workspace.yaml` — the block that absorbed most of `.npmrc` in
+ * pnpm 10. Catalogs and package globs are covered by the plugin's other
+ * rules and are not part of this policy.
+ */
+export interface PnpmWorkspaceSettings {
+  /** Keys that must be absent. Reported, never auto-fixed. */
+  readonly forbiddenFields?: string[];
+  /** Keys that must be present, with any value. Reported, never auto-fixed. */
+  readonly requiredFields?: string[];
+  /** Keys that must be present with exactly these values. Auto-fixable. */
+  readonly settings?: Record<string, unknown>;
+}
+
+/**
+ * House policy applied to `pnpm-workspace.yaml` by default. Pass a
+ * replacement (or `false`) as `pnpmWorkspaceSettings` to opt out.
+ */
+export const defaultPnpmWorkspaceSettings: PnpmWorkspaceSettings = {
+  /*
+   * Settings that undo a control this policy relies on. Forbidding the key
+   * rather than matching a value is deliberate: `settings` can only express
+   * exact equality, never "anything but this". All are reported rather than
+   * fixed — removing one can break an install that has come to depend on it.
+   *
+   * `dangerouslyAllowAllBuilds` runs every dependency's install scripts
+   * without approval, bypassing the `allowBuilds` allowlist.
+   * `publicHoistPattern` and `shamefullyHoist` both flatten dependencies
+   * into the root `node_modules`, undoing `hoist: false` and letting
+   * undeclared imports resolve — pnpm defines `shamefullyHoist` as
+   * `publicHoistPattern: '*'`, so forbidding only one leaves the hole open.
+   * `trustLockfile` skips the lockfile's supply-chain verification pass.
+   */
+  forbiddenFields: [
+    'dangerouslyAllowAllBuilds',
+    'publicHoistPattern',
+    'shamefullyHoist',
+    'trustLockfile',
+  ],
+  /*
+   * The exclude list is required rather than value-matched: consumers add
+   * their own scopes to it, and `settings` compares whole values, so an
+   * exact match would make `--fix` delete those additions.
+   */
+  requiredFields: ['minimumReleaseAgeExclude'],
+  settings: {
+    engineStrict: true,
+    hoist: false,
+    // 4320 minutes = 3 days, matching the shared Renovate preset's quarantine.
+    minimumReleaseAge: 4320,
+    strictPeerDependencies: true,
+  },
+};

--- a/packages/eslint-config/test/configure.test.ts
+++ b/packages/eslint-config/test/configure.test.ts
@@ -1,6 +1,10 @@
 import { Linter } from 'eslint';
 import { describe, it } from 'vitest';
-import { configure, defaultEntryPoints } from '#src/index.js';
+import {
+  configure,
+  defaultEntryPoints,
+  defaultPnpmWorkspaceSettings,
+} from '#src/index.js';
 
 /**
  * All script file extensions that plugin configs should target.
@@ -23,6 +27,9 @@ const tsOnlyExtensions = ['cts', 'mts', 'ts', 'tsx'];
  */
 const defaultConfigs = configure({ onlyWarn: false });
 
+const findEnforceSettings = (configs: Linter.Config[]) =>
+  configs.find(cfg => cfg.rules?.['pnpm/yaml-enforce-settings'] !== undefined);
+
 describe.concurrent(configure, () => {
   it('includes json configs', async ({ expect }) => {
     const configs = await defaultConfigs;
@@ -42,6 +49,59 @@ describe.concurrent(configure, () => {
     const withoutPnpm = await configure({ onlyWarn: false, pnpm: false });
 
     expect(withPnpm.length).toBeGreaterThan(withoutPnpm.length);
+  });
+
+  it('enforces the default workspace settings policy', async ({ expect }) => {
+    const configs = await defaultConfigs;
+
+    const settingsConfig = findEnforceSettings(configs);
+
+    expect(settingsConfig?.files).toStrictEqual(['pnpm-workspace.yaml']);
+    expect(settingsConfig?.rules?.['pnpm/yaml-enforce-settings']).toStrictEqual(
+      ['error', defaultPnpmWorkspaceSettings],
+    );
+  });
+
+  it('keeps the catalog rules alongside the settings policy', async ({ expect }) => {
+    const configs = await defaultConfigs;
+
+    const settingsConfig = findEnforceSettings(configs);
+
+    expect(settingsConfig?.rules).toHaveProperty(
+      'pnpm/yaml-no-unused-catalog-item',
+    );
+  });
+
+  it('applies a custom workspace settings policy', async ({ expect }) => {
+    const policy = { settings: { engineStrict: true } };
+
+    const configs = await configure({
+      onlyWarn: false,
+      pnpmWorkspaceSettings: policy,
+    });
+
+    expect(findEnforceSettings(configs)?.rules?.['pnpm/yaml-enforce-settings'])
+      .toStrictEqual(['error', policy]);
+  });
+
+  it('drops the settings rule when pnpmWorkspaceSettings is false', async ({ expect }) => {
+    const configs = await configure({
+      onlyWarn: false,
+      pnpmWorkspaceSettings: false,
+    });
+
+    expect(findEnforceSettings(configs)).toBeUndefined();
+    expect(configs.some(cfg => cfg.name?.includes('pnpm'))).toBe(true);
+  });
+
+  /* An empty policy makes the rule throw when it is created. */
+  it('drops the settings rule when the policy is empty', async ({ expect }) => {
+    const configs = await configure({
+      onlyWarn: false,
+      pnpmWorkspaceSettings: {},
+    });
+
+    expect(findEnforceSettings(configs)).toBeUndefined();
   });
 
   it('passes tsconfigRootDir to parser options', async ({ expect }) => {


### PR DESCRIPTION
## Why

`eslint-plugin-pnpm` ships eight rules; the configs we spread (`json` + `yaml`) enable six. Of the two holdouts, `yaml-enforce-settings` is the only one that lints the **settings** keys of `pnpm-workspace.yaml` — the block that absorbed most of `.npmrc` in pnpm 10. The other rules cover only catalogs and package globs, so nothing kept install behavior consistent across repos.

No config enables it upstream because it carries no default policy and throws at rule-creation time unless given one. This supplies that policy.

(The other holdout, `yaml-no-anonymous-catalog`, is deliberately skipped: it bans the anonymous `catalog:` key that this repo uses throughout, and it has no fixer.)

## The default policy

Exported as `defaultPnpmWorkspaceSettings`:

| Knob | Entries | Behavior |
| --- | --- | --- |
| `settings` | `engineStrict: true`, `hoist: false`, `minimumReleaseAge: 4320`, `strictPeerDependencies: true` | exact value, auto-fixed in |
| `requiredFields` | `minimumReleaseAgeExclude` | key must exist, never fixed |
| `forbiddenFields` | `dangerouslyAllowAllBuilds`, `publicHoistPattern`, `shamefullyHoist`, `trustLockfile` | key must not exist, never fixed |

Which knob each setting lands in is forced by the rule's semantics, not by taste:

- **`settings` is destructive for lists.** It compares whole values with deep equality, and its fixer replaces the entire key/value pair. Pinning `minimumReleaseAgeExclude` there would mean a consumer adding `'@acme/*'` reads as a mismatch and `--fix` silently deletes their scope. Requiring the key without pinning its value keeps the setting deliberate and its contents theirs.
- **`settings` cannot express "anything but this value."** A setting that is unsafe in only one direction therefore has to be banned by key. `dangerouslyAllowAllBuilds` runs every dependency's install scripts without approval, bypassing `allowBuilds`. `publicHoistPattern` and `shamefullyHoist` both flatten dependencies into the root `node_modules` — pnpm documents `shamefullyHoist` as `publicHoistPattern: '*'`, so banning one without the other leaves the hole open. `trustLockfile` skips the lockfile's supply-chain verification pass.
- **`settings` entries get inserted into consumer files by `--fix`,** so the set is limited to values that differ from pnpm's own defaults. Restating a default would add a line that changes nothing.

## API

`pnpmWorkspaceSettings?: PnpmWorkspaceSettings | false` **replaces** the default rather than merging into it, and spread is shallow — extending it needs both levels spread. That is documented in the skill with an example. `false` (or an empty policy) drops the rule while keeping the catalog rules; `pnpm: false` still disables everything.

## Verification

Unit tests cover the config shape: the rule is wired with the policy, the catalog rules survive the merge into the plugin's YAML config, a custom policy replaces the default, and both `false` and `{}` drop the rule (the latter guards the throw).

Two e2e tests run `eslint --fix` against a real `pnpm-workspace.yaml` and prove the behavior the design turns on — the scalars get inserted, an extended `minimumReleaseAgeExclude` survives untouched, and a forbidden key is reported but not deleted.

This repo's own `pnpm-workspace.yaml` passes clean under the policy, and `eslint --print-config` confirms the rule is genuinely active on it rather than silently skipped.

## Notes for review

- **Consumers will see new warnings on upgrade** if their workspace file omits these settings. `--fix` resolves the `settings` ones; the required and forbidden ones need a human.
- `lockfileIncludeTarballUrl: false` stays set in this repo's own file but is not part of the policy — enforcing it would insert a line restating pnpm's default into every consumer file.
- The settings list was checked against pnpm's current docs. `minimumReleaseAge` now defaults to one day, so the enforced three days is still a real tightening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)