### PR TITLE
Stop eslint-config --fix corrupting JSON files

### DIFF
--- a/.changeset/json-fix-corruption.md
+++ b/.changeset/json-fix-corruption.md
@@ -1,0 +1,13 @@
+---
+'@gtbuchanan/eslint-config': patch
+---
+
+Stop `--fix` corrupting JSON files with unsorted keys
+
+`json/sort-keys` and `format/prettier` were both fixable on the same
+files. ESLint saw their fix ranges as non-overlapping and applied both
+in one pass, interleaving the reordered keys with a Prettier text diff
+computed against the unsorted original — the file came out as invalid
+JSON that no later pass could recover. Prettier already sorts these
+files recursively via `prettier-plugin-sort-json`, so `json/sort-keys`
+is now off and Prettier owns JSON key order outright.

--- a/packages/eslint-config/e2e/cli.test.ts
+++ b/packages/eslint-config/e2e/cli.test.ts
@@ -110,7 +110,12 @@ describe.concurrent('eslint CLI integration', () => {
     expect(exitCode).toBe(0);
   });
 
-  it('warns on unsorted keys in JSON files', async ({ fixture, expect }) => {
+  /*
+   * Key order is Prettier's to enforce (see the --fix test below), so
+   * this covers only severity: a formatting violation is reported, and
+   * it stays a warning even with onlyWarn disabled.
+   */
+  it('reports JSON formatting violations as warnings', async ({ fixture, expect }) => {
     const { exitCode, stdout } = await fixture.run({
       files: { 'unsorted.json': '{\n  "beta": 1,\n  "alpha": 2\n}\n' },
     });

--- a/packages/eslint-config/e2e/cli.test.ts
+++ b/packages/eslint-config/e2e/cli.test.ts
@@ -117,7 +117,36 @@ describe.concurrent('eslint CLI integration', () => {
 
     // Warnings don't cause a non-zero exit code
     expect(exitCode).toBe(0);
-    expect(stdout).toContain('json/sort-keys');
+    expect(stdout).toContain('format/prettier');
+  });
+
+  it('fixes unsorted JSON without losing data', async ({ fixture, expect }) => {
+    /*
+     * Prettier (via prettier-plugin-sort-json) must be the only fixable
+     * key sorter for JSON. A second one reports fixes over ranges ESLint
+     * sees as non-overlapping, so both land in a single pass and the
+     * sorted keys interleave with Prettier's text diff — which was
+     * computed against the *unsorted* original — producing invalid JSON.
+     */
+    const unsorted = [
+      { threadId: 'first', line: 11, action: 'resolve' },
+      { threadId: 'second', line: 15, action: 'reply' },
+    ];
+    // Same records, keys in the order --fix is expected to leave them
+    const sorted = [
+      { action: 'resolve', line: 11, threadId: 'first' },
+      { action: 'reply', line: 15, threadId: 'second' },
+    ];
+
+    const result = await fixture.run({
+      files: { 'data.json': `${JSON.stringify(unsorted, undefined, 2)}\n` },
+      flags: ['--fix'],
+    });
+
+    expect(result).toMatchObject({ exitCode: 0 });
+    expect(result.readFile('data.json')).toBe(
+      `${JSON.stringify(sorted, undefined, 2)}\n`,
+    );
   });
 
   it('allows comments in tsconfig.json via JSONC', async ({ fixture, expect }) => {

--- a/packages/eslint-config/src/plugins/json.ts
+++ b/packages/eslint-config/src/plugins/json.ts
@@ -4,11 +4,17 @@ import type { PluginFactory } from '../index.ts';
 
 // --- JSON ---
 
-const jsonRules: Linter.RulesRecord = {
-  ...json.configs.recommended.rules,
-  // Justification: Alphabetical keys reduce merge conflicts in shared JSON configs
-  'json/sort-keys': 'warn',
-};
+/*
+ * `json/sort-keys` is intentionally absent. Prettier already sorts JSON
+ * keys here (prettier-plugin-sort-json with `jsonRecursiveSort`, see
+ * format.ts), and a second *fixable* sorter corrupts the file: ESLint
+ * sees the two rules' ranges as non-overlapping and applies both in one
+ * pass, interleaving the reordered keys with a Prettier text diff that
+ * was computed against the unsorted original. The result is invalid
+ * JSON, which no later pass can recover. Do not re-enable it without
+ * also dropping Prettier from these files.
+ */
+const jsonRules: Linter.RulesRecord = { ...json.configs.recommended.rules };
 
 /** JSON and JSONC linting configs. */
 const plugin: PluginFactory = () => [


### PR DESCRIPTION
Fixes #301

## Problem

`eslint --fix` on a JSON file with unsorted keys destroyed it — array elements merged, keys duplicated, output not valid JSON. Because `--fix` runs in the pre-commit hook, committing a JSON file could corrupt it.

`json/sort-keys` and `format/prettier` were both fixable on the same files. ESLint saw their fix ranges as non-overlapping and applied both in a single pass, so the reordered keys interleaved with a Prettier text diff that had been computed against the *unsorted* original. The result no longer parsed, so no later fix pass could recover it.

## Fix

Removed `json/sort-keys`, leaving Prettier as the sole fixable key sorter for JSON.

This direction isn't arbitrary — the two options have very different costs:

- **Dropping `json/sort-keys` costs nothing.** Prettier already sorts these exact files recursively (`prettier-plugin-sort-json` + `jsonRecursiveSort: true`). The rule was pure duplication.
- **Dropping Prettier from `**/*.json` costs a lot.** It's the only thing doing indentation/whitespace normalization, `multilineArraysWrapThreshold: 0` (one array element per line), and quote/EOL normalization. `json/sort-keys` only reorders keys.
- **It restores the split the rest of the config already uses** — Prettier owns formatting, the language plugin owns correctness. TOML uses Prettier `reorderKeys` with `toml.ts` lint-only; CSS uses `prettier-plugin-css-order`; `package.json` uses `prettier-plugin-packagejson` (and `json.ts` already ignored it); `markdown.ts` has a `prettierConflicts` block doing this same thing. `json/sort-keys` was the outlier.

YAML is deliberately untouched. No Prettier plugin sorts YAML keys, so `yml/sort-keys` is the only sorter with nothing to interleave against — I confirmed a YAML analogue of the repro round-trips clean. A blanket "prefer Prettier" rule would have silently dropped YAML sorting.

## Trade-off

Unsorted keys used to be reported per key by `json/sort-keys`; they now surface as a generic `format/prettier` replacement diff. Less precise, but the same trade already accepted for TOML and CSS.

## Verification

- Reproduced the issue's exact corruption on `main`; the same fixture now round-trips clean.
- Confirmed `.jsonc` / `tsconfig.json` still sort recursively with comments preserved — the one place "Prettier already covers it" could have failed.
- New e2e test failed with `exitCode: 1` (corrupted file no longer parsed) before the fix and passes after. The `--fix` output is asserted byte-for-byte against an independently written sorted literal.
- Retargeted the existing `warns on unsorted keys in JSON files` test to `format/prettier`, which now owns that diagnostic.
- Full `pnpm build` and eslint-config e2e green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
