### PR TITLE
Accept agent host SKILL.md frontmatter extensions

### DIFF
--- a/.changeset/agent-skills-claude-code-schema.md
+++ b/.changeset/agent-skills-claude-code-schema.md
@@ -1,0 +1,29 @@
+---
+'@gtbuchanan/eslint-plugin-agent-skills': minor
+---
+
+Add composable host extensions for `SKILL.md` frontmatter
+
+`skillFrontmatterSchema` closes frontmatter to unknown properties, per
+the Agent Skills spec, so a skill using a host's own field — say
+`user-invocable: false` on a building block that shouldn't reach Claude
+Code's `/` menu — had no lever short of replacing the schema wholesale,
+which drops the spec validation entirely.
+
+```js
+export default [
+  ...configs.recommended,
+  ...defineSkillFrontmatterConfig('claude-code', myExtensions),
+];
+```
+
+A source is a host name from the new `skillFrontmatterHosts` registry
+(`claude-code` ships today) or a JSON Schema property map for a host
+this package doesn't. Pass every host a repo targets to one call —
+sources union, and a second overlay would replace the first rather than
+merge with it. `defineSkillFrontmatterSchema` returns the same schema
+for callers wiring the rule themselves.
+
+Only property definitions are layered on, and `configs.recommended` is
+unchanged, so repos targeting the bare standard keep the stricter
+validation.

--- a/.changeset/eslint-config-agent-skills-host.md
+++ b/.changeset/eslint-config-agent-skills-host.md
@@ -1,0 +1,19 @@
+---
+'@gtbuchanan/eslint-config': minor
+---
+
+Add an `agentSkillsHost` option for `SKILL.md` frontmatter extensions
+
+`SKILL.md` frontmatter is validated against the Agent Skills spec, which
+rejects the fields agent hosts document on top of the standard.
+`agentSkillsHost` names the hosts to accept — a host name, a JSON Schema
+property map for a host the plugin doesn't ship, or a list of either for
+skills targeting several at once:
+
+```js
+configure({ agentSkillsHost: ['claude-code', myExtensions] });
+```
+
+Listed hosts union their fields. The default, `'standard'`, keeps
+validating against the bare spec — which is also the "valid under every
+host" setting — so existing configs are unaffected.

--- a/.changeset/md-frontmatter-schema-id-registration.md
+++ b/.changeset/md-frontmatter-schema-id-registration.md
@@ -1,0 +1,16 @@
+---
+'@gtbuchanan/eslint-plugin-md-frontmatter': patch
+---
+
+Stop `md-frontmatter/schema` throwing on a schema that declares `$id`
+
+Ajv registers a schema under its `$id` process-wide and throws
+`schema with key or id "..." already exists` on a second registration.
+The rule guarded against that with a compile cache keyed on schema-object
+identity, but ESLint hands the rule a fresh options object every time a
+config is resolved, so the cache missed and Ajv saw the same id twice —
+one lint pass succeeded and the next died inside the rule.
+
+The rule's Ajv instance now sets `addUsedSchema: false`, so compiling a
+schema no longer registers it under its `$id`. The id still establishes
+the base URI, so a `$ref` written against it resolves as before.

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -70,6 +70,7 @@ export default configure({
 - `eslint-plugin-toml` — TOML linting and structural key/table ordering
 - `@eslint/markdown` — Official Markdown lint plugin (commonmark AST)
 - `@gtbuchanan/eslint-plugin-markdownlint` — Markdown structural linting via markdownlint (gap-filling rules not yet covered by `@eslint/markdown`)
+- `@gtbuchanan/eslint-plugin-agent-skills` — Agent Skills `SKILL.md` and `evals.json` validation (pass `agentSkillsHost` to accept the frontmatter extensions of one or more agent hosts)
 - `eslint-plugin-only-warn` — Downgrades errors to warnings (opt-in)
 
 ## Markdown linting

--- a/packages/eslint-config/skills/gtb-eslint-config/SKILL.md
+++ b/packages/eslint-config/skills/gtb-eslint-config/SKILL.md
@@ -38,6 +38,10 @@ All optional except `tsconfigRootDir` (recommended for type-aware rules):
 - **`target`** — `'server'` (default) or `'browser'`. Server enables
   `require-unicode-regexp` with the `/v` flag. Browser enables
   `no-console` and `no-alert`; entry points are exempt from `no-console`.
+- **`agentSkillsHost`** — Agent hosts whose `SKILL.md` frontmatter
+  extensions are accepted. A host name, a property map for a host the
+  plugin doesn't ship, or a list of either. Defaults to `'standard'`
+  (the bare Agent Skills spec). See below.
 - **`entryPoints`** — Glob patterns exempt from `process.exit` and
   hashbang restrictions (and from `no-console` in browser mode).
   Defaults to `**/bin/**/*.{js,mjs,cjs,ts,mts,cts}` and `**/scripts/**/*`.
@@ -55,6 +59,48 @@ All optional except `tsconfigRootDir` (recommended for type-aware rules):
   `defaultPnpmWorkspaceSettings` (see below). Pass `false` to keep the
   catalog rules but drop the settings policy. Ignored when `pnpm` is
   `false`.
+
+## Agent Skills frontmatter hosts
+
+`SKILL.md` frontmatter is validated against the
+[Agent Skills spec](https://agentskills.io/specification), which closes
+the object to unknown properties. The spec sanctions only the nested
+`metadata` map for client-specific data, so a host that puts fields at
+the top level — as Claude Code does — needs each one declared. There is
+no reserved top-level namespace to pattern-match instead, which is why
+this is a per-host list rather than a wildcard.
+
+```typescript
+export default configure({ agentSkillsHost: 'claude-code' });
+```
+
+Skills that target several hosts list them all — every name the plugin
+ships, plus a JSON Schema property map for any host it doesn't. Fields
+are unioned, so the result accepts every field any listed source
+declares:
+
+```typescript
+export default configure({
+  agentSkillsHost: ['claude-code', { 'x-team-owner': { type: 'string' } }],
+});
+```
+
+An unrecognized host name throws rather than silently contributing no
+fields, so a typo surfaces at config load rather than as unexplained
+frontmatter errors.
+
+`'claude-code'` adds the fields from Claude Code's
+[frontmatter reference](https://code.claude.com/docs/en/skills), plus
+the YAML-list spelling it accepts for `allowed-tools`. The plugin's
+`skillFrontmatterHosts` registry is what each name resolves to.
+
+Every form adds properties only: `name` and `description` stay required
+and every shared constraint still applies, so a skill that validates
+under a host is still portable to a spec-only host apart from the
+extension fields themselves. There is no "valid under every host at
+once" setting — that is `'standard'`, the default, which is also what
+keeps a stray `user_invocable` typo an error rather than a
+silently-ignored field.
 
 ## pnpm workspace settings policy
 

--- a/packages/eslint-config/src/index.ts
+++ b/packages/eslint-config/src/index.ts
@@ -1,6 +1,7 @@
 /* eslint-disable-next-line @typescript-eslint/triple-slash-reference --
    Cross-package tsc needs this to resolve the .d.ts */
 /// <reference path="./eslint-plugin-promise.d.ts" />
+import type { SkillFrontmatterSource } from '@gtbuchanan/eslint-plugin-agent-skills';
 import type { Linter } from 'eslint';
 import { defineConfig } from 'eslint/config';
 import { scriptFileExtensions } from './files.ts';
@@ -27,6 +28,23 @@ export const defaultEntryPoints: readonly string[] = entryPointDirs.flatMap(
 
 /** Options for the shared ESLint configuration. */
 export interface ESLintConfigureOptions {
+  /**
+   * Agent hosts whose `SKILL.md` frontmatter extensions are accepted —
+   * a host name, a property map for a host the plugin doesn't ship, or
+   * a list of either for a repo whose skills target several at once.
+   * `'standard'` validates against the bare
+   * [Agent Skills spec](https://agentskills.io/specification), so any
+   * host extension reads as an unknown property.
+   *
+   * Listing hosts unions their fields; it cannot express "valid under
+   * every host at once", which is what `'standard'` already is. No
+   * shared constraint is relaxed either way.
+   * @defaultValue 'standard'
+   */
+  readonly agentSkillsHost?:
+    | 'standard'
+    | SkillFrontmatterSource
+    | readonly SkillFrontmatterSource[];
   /** Root directory for TypeScript project service. */
   readonly tsconfigRootDir?: string;
   /**
@@ -78,27 +96,30 @@ export type ResolvedOptions =
 /** Factory function that produces ESLint configs from resolved options. */
 export type PluginFactory = (options: ResolvedOptions) => Linter.Config[];
 
+const resolveOptions = (options: ESLintConfigureOptions): ResolvedOptions => ({
+  agentSkillsHost: options.agentSkillsHost ?? 'standard',
+  entryPoints: options.entryPoints ?? [...defaultEntryPoints],
+  ignores: options.ignores ?? [
+    '.claude/worktrees/**',
+    '**/.turbo/**',
+    '**/dist/**',
+    '**/pnpm-lock.yaml',
+    '**/skills-lock.json',
+    '**/skills/*-workspace/**',
+    '**/skills/npm-*/**',
+  ],
+  onlyWarn: options.onlyWarn ?? true,
+  pnpm: options.pnpm ?? true,
+  pnpmWorkspaceSettings: options.pnpmWorkspaceSettings ?? defaultPnpmWorkspaceSettings,
+  target: options.target ?? 'server',
+  ...(options.tsconfigRootDir !== undefined && { tsconfigRootDir: options.tsconfigRootDir }),
+});
+
 /** Creates an ESLint flat config for TypeScript projects. */
 export const configure = async (
   options: ESLintConfigureOptions = {},
 ): Promise<Linter.Config[]> => {
-  const resolved: ResolvedOptions = {
-    entryPoints: options.entryPoints ?? [...defaultEntryPoints],
-    ignores: options.ignores ?? [
-      '.claude/worktrees/**',
-      '**/.turbo/**',
-      '**/dist/**',
-      '**/pnpm-lock.yaml',
-      '**/skills-lock.json',
-      '**/skills/*-workspace/**',
-      '**/skills/npm-*/**',
-    ],
-    onlyWarn: options.onlyWarn ?? true,
-    pnpm: options.pnpm ?? true,
-    pnpmWorkspaceSettings: options.pnpmWorkspaceSettings ?? defaultPnpmWorkspaceSettings,
-    target: options.target ?? 'server',
-    ...(options.tsconfigRootDir !== undefined && { tsconfigRootDir: options.tsconfigRootDir }),
-  };
+  const resolved = resolveOptions(options);
 
   if (resolved.onlyWarn) {
     await import('eslint-plugin-only-warn');

--- a/packages/eslint-config/src/plugins/agent-skills.ts
+++ b/packages/eslint-config/src/plugins/agent-skills.ts
@@ -1,11 +1,33 @@
-import { configs } from '@gtbuchanan/eslint-plugin-agent-skills';
-import type { PluginFactory } from '../index.ts';
+import {
+  configs,
+  defineSkillFrontmatterConfig,
+} from '@gtbuchanan/eslint-plugin-agent-skills';
+import type { SkillFrontmatterSource } from '@gtbuchanan/eslint-plugin-agent-skills';
+import type { PluginFactory, ResolvedOptions } from '../index.ts';
+
+/*
+ * The overlay has to carry every host in one call: it re-points a
+ * single rule, so spreading one overlay per host would leave only the
+ * last host's schema in force.
+ */
+const toSources = (
+  host: ResolvedOptions['agentSkillsHost'],
+): readonly SkillFrontmatterSource[] =>
+  host === 'standard' ? [] : [host].flat();
 
 /**
  * Agent Skills `SKILL.md` validation. Delegates the entire wiring
  * (frontmatter schema rule, name-matches-dir rule, file-length cap)
- * to the plugin's recommended flat-config block.
+ * to the plugin's recommended flat-config block, then layers on the
+ * frontmatter extensions of whichever hosts are selected.
  */
-const plugin: PluginFactory = () => [...configs.recommended];
+const plugin: PluginFactory = ({ agentSkillsHost }) => {
+  const sources = toSources(agentSkillsHost);
+
+  return [
+    ...configs.recommended,
+    ...(sources.length === 0 ? [] : defineSkillFrontmatterConfig(...sources)),
+  ];
+};
 
 export default plugin;

--- a/packages/eslint-config/test/agent-skills.test.ts
+++ b/packages/eslint-config/test/agent-skills.test.ts
@@ -1,0 +1,88 @@
+import { Linter } from 'eslint';
+import { describe, it } from 'vitest';
+import { configure } from '#src/index.js';
+
+const skillFile = 'skills/my-skill/SKILL.md';
+
+/** Wraps extra frontmatter lines in an otherwise spec-valid `SKILL.md`. */
+const skill = (...extra: readonly string[]): string => [
+  '---',
+  'name: my-skill',
+  'description: A skill.',
+  ...extra,
+  '---',
+  '',
+  '# My skill',
+  '',
+].join('\n');
+
+const teamExtensions = { 'x-team-owner': { type: 'string' } };
+
+const schemaMessages = (
+  configs: Linter.Config[],
+  code: string,
+): Linter.LintMessage[] => new Linter()
+  .verify(code, configs, skillFile)
+  .filter(message => message.ruleId === 'md-frontmatter/schema');
+
+describe.concurrent('agentSkillsHost', () => {
+  it('rejects host frontmatter fields by default', async ({ expect }) => {
+    const configs = await configure({ onlyWarn: false });
+
+    const [message, ...rest] = schemaMessages(
+      configs,
+      skill('user-invocable: false'),
+    );
+
+    expect(rest).toStrictEqual([]);
+    expect(message?.message).toMatch(/user-invocable.*additional properties/v);
+  });
+
+  it('accepts a named host\'s fields', async ({ expect }) => {
+    const configs = await configure({
+      agentSkillsHost: 'claude-code',
+      onlyWarn: false,
+    });
+
+    expect(schemaMessages(configs, skill('user-invocable: false')))
+      .toStrictEqual([]);
+  });
+
+  it('accepts fields from every host listed at once', async ({ expect }) => {
+    const configs = await configure({
+      agentSkillsHost: ['claude-code', teamExtensions],
+      onlyWarn: false,
+    });
+    const code = skill('user-invocable: false', 'x-team-owner: platform');
+
+    expect(schemaMessages(configs, code)).toStrictEqual([]);
+  });
+
+  it('rejects a field no listed host declares', async ({ expect }) => {
+    const configs = await configure({
+      agentSkillsHost: ['claude-code', teamExtensions],
+      onlyWarn: false,
+    });
+
+    const [message, ...rest] = schemaMessages(
+      configs,
+      skill('x-team-lead: platform'),
+    );
+
+    expect(rest).toStrictEqual([]);
+    expect(message?.message).toMatch(/additional properties/v);
+  });
+
+  it('keeps the spec constraints a host does not mention', async ({ expect }) => {
+    const configs = await configure({
+      agentSkillsHost: 'claude-code',
+      onlyWarn: false,
+    });
+    const code = '---\nname: my-skill\n---\n\n# My skill\n';
+
+    const [message, ...rest] = schemaMessages(configs, code);
+
+    expect(rest).toStrictEqual([]);
+    expect(message?.message).toMatch(/description/v);
+  });
+});

--- a/packages/eslint-plugin-agent-skills/README.md
+++ b/packages/eslint-plugin-agent-skills/README.md
@@ -8,7 +8,8 @@ Most validation is expressed in JSON Schemas; the rules cover spec
 constraints that pure schemas can't express. This package ships:
 
 - JSON Schemas (exported as `skillFrontmatterSchema` and
-  `skillEvalsSchema`).
+  `skillEvalsSchema`), plus `defineSkillFrontmatterSchema` to extend the
+  frontmatter schema with host-specific fields.
 - Rules covering [spec](https://agentskills.io/specification)
   constraints that pure schemas can't express:
   - `agent-skills/name-matches-dir` — `name` must equal the parent
@@ -27,6 +28,8 @@ constraints that pure schemas can't express. This package ships:
   for `**/skills/*/SKILL.md`, `**/skills/*/references/**/*.md`
   (with a tighter 300-line `max-lines` cap), and
   `**/skills/*/evals/evals.json`.
+- A `defineSkillFrontmatterConfig` composer that overlays the
+  frontmatter extensions of one or more agent hosts.
 
 ## Install
 
@@ -58,6 +61,76 @@ import { configs } from '@gtbuchanan/eslint-plugin-agent-skills';
 
 export default [...configs.recommended];
 ```
+
+### Host extensions
+
+`configs.recommended` validates frontmatter against the bare spec, which
+closes the object to unknown properties — so a host's own field reads as
+an error. The spec sanctions only the nested `metadata` map for
+client-specific data, so a host that puts fields at the top level (as
+[Claude Code](https://code.claude.com/docs/en/skills) does) is describing
+its own surface, and each field has to be declared. There is no reserved
+top-level namespace to pattern-match instead.
+
+`defineSkillFrontmatterConfig` composes an overlay for the hosts a repo
+targets:
+
+```typescript
+// eslint.config.ts
+import {
+  configs,
+  defineSkillFrontmatterConfig,
+} from '@gtbuchanan/eslint-plugin-agent-skills';
+
+export default [
+  ...configs.recommended,
+  ...defineSkillFrontmatterConfig('claude-code'),
+];
+```
+
+It takes any number of sources — a host name from `skillFrontmatterHosts`,
+or a property map of your own for a host this package doesn't ship:
+
+```typescript
+defineSkillFrontmatterConfig('claude-code', {
+  'x-team-owner': { type: 'string' },
+});
+```
+
+Pass them all to **one** call. The overlay re-points a single rule and
+relies on flat config's last-match-wins merge, so spreading one overlay
+per host leaves only the last host's schema in force — and spreading the
+overlay _before_ `recommended` lets the spec schema win.
+
+Sources are unioned: the result accepts every field any of them declares,
+which is what a repo whose skills run under several hosts needs. It
+cannot express "valid under _every_ host at once" — that is the spec
+schema, which is what `configs.recommended` alone already gives you. A
+field two sources both declare takes its definition from the later one,
+so your own map can override a shipped host's field.
+
+Whatever the sources, only property definitions are layered on: `name`
+and `description` stay required and every spec constraint (kebab-case
+`name`, length caps) still applies.
+
+#### Shipped hosts
+
+- **`claude-code`** — the fields in Claude Code's
+  [frontmatter reference](https://code.claude.com/docs/en/skills), plus
+  the YAML-list spelling it accepts for the spec's `allowed-tools`. See
+  [`src/hosts/claude-code.ts`](./src/hosts/claude-code.ts) for the
+  declarations this package actually enforces.
+
+Where the fields are pinned is a judgment call rather than a
+transcription: `context`, `effort`, and `shell` are held to their
+documented value sets, so a typo is caught and a new upstream value
+needs a bump here; `model` and `hooks` stay open, since their value
+spaces are not closed.
+
+Use `defineSkillFrontmatterSchema` with the same arguments if you want
+the composed schema rather than the config block.
+
+### Parser
 
 The plugin needs a parser that exposes the file source as text. If you
 also use `@gtbuchanan/eslint-plugin-markdownlint`, its parser is already
@@ -97,7 +170,8 @@ export default [
 - **Schema-driven** (via `md-frontmatter/schema` + `skillFrontmatterSchema`):
   required `name`/`description`, length limits, kebab-case `name`,
   `metadata` map of strings, optional `license`/`compatibility`/`allowed-tools`,
-  no unknown top-level fields.
+  no unknown top-level fields (see [Host extensions](#host-extensions)
+  to accept a host's own).
 - **Rule-driven** (this plugin): `name === parent directory name`,
   link/image/reference targets exist within the skill root and stay
   within the spec's depth guidance, file length cap, minimum eval

--- a/packages/eslint-plugin-agent-skills/src/frontmatter-schema.ts
+++ b/packages/eslint-plugin-agent-skills/src/frontmatter-schema.ts
@@ -1,0 +1,121 @@
+import markdown from '@eslint/markdown';
+import frontmatter from '@gtbuchanan/eslint-plugin-md-frontmatter';
+import type { SchemaObject } from 'ajv';
+import type { Linter } from 'eslint';
+import { skillFrontmatterHosts } from './hosts/index.ts';
+import type { SkillFrontmatterHost } from './hosts/index.ts';
+import specSchema from './schema.json' with { type: 'json' };
+
+/**
+ * Frontmatter fields a host understands on top of the
+ * [Agent Skills specification](https://agentskills.io/specification),
+ * as a JSON Schema property map. The spec sanctions only the nested
+ * `metadata` map for client-specific data, so a host that puts fields
+ * at the top level — as Claude Code does — is describing its own
+ * surface, and each field has to be declared rather than pattern-matched.
+ */
+export type SkillFrontmatterExtensions = Readonly<Record<string, SchemaObject>>;
+
+/**
+ * A set of frontmatter extensions to layer on: the name of a host this
+ * package ships (see `skillFrontmatterHosts`), or a property map of
+ * your own for a host it doesn't.
+ */
+export type SkillFrontmatterSource =
+  | SkillFrontmatterHost
+  | SkillFrontmatterExtensions;
+
+/*
+ * A name absent from the registry contributes nothing, which would
+ * surface as unexplained frontmatter errors on every skill rather than
+ * as the misconfiguration it is, so it fails loudly instead.
+ */
+const toExtensions = (
+  source: SkillFrontmatterSource,
+): SkillFrontmatterExtensions => {
+  if (typeof source !== 'string') return source;
+  if (!Object.hasOwn(skillFrontmatterHosts, source)) {
+    throw new Error(
+      `Unknown Agent Skills host \`${source}\`. Known hosts: ${
+        Object.keys(skillFrontmatterHosts).join(', ')
+      }.`,
+    );
+  }
+  return skillFrontmatterHosts[source];
+};
+
+/**
+ * Layers host extensions onto the spec frontmatter schema, accepting as
+ * many sources as a repo targets:
+ *
+ * ```typescript
+ * defineSkillFrontmatterSchema('claude-code');
+ * defineSkillFrontmatterSchema('claude-code', { 'x-team-owner': { type: 'string' } });
+ * ```
+ *
+ * Sources are unioned — the result accepts every field any of them
+ * declares, which is what a repo whose skills run under several hosts
+ * needs. It cannot express "valid under *every* host at once"; that is
+ * the spec schema, which is what you get by passing nothing.
+ *
+ * A field two sources both declare takes its definition from the later
+ * one, so a caller can override a shipped host's field by passing their
+ * own map after it. No two shipped hosts currently declare the same
+ * field.
+ *
+ * Property definitions are all that is layered on: `name` and
+ * `description` stay required and every spec constraint still applies,
+ * so a skill validated against the result stays portable apart from the
+ * extension fields themselves.
+ *
+ * The result carries no `$id` — it describes a composition local to the
+ * caller, not the canonical schema published under the spec's id.
+ */
+export const defineSkillFrontmatterSchema = (
+  ...sources: readonly SkillFrontmatterSource[]
+): SchemaObject => {
+  const { $id: _local, ...spec } = specSchema;
+
+  return {
+    ...spec,
+    properties: Object.assign(
+      {},
+      spec.properties,
+      ...sources.map(toExtensions),
+    ) as SchemaObject,
+    title: 'Agent Skills SKILL.md frontmatter with host extensions',
+  };
+};
+
+/**
+ * Flat-config overlay pointing `md-frontmatter/schema` at the spec
+ * schema extended with `sources`:
+ *
+ * ```typescript
+ * export default [
+ *   ...configs.recommended,
+ *   ...defineSkillFrontmatterConfig('claude-code'),
+ * ];
+ * ```
+ *
+ * Spread it *after* `configs.recommended` — it re-points one rule and
+ * relies on flat config's last-match-wins merge, so the spec schema
+ * wins if the order is reversed. For that same reason, compose several
+ * hosts in one call rather than spreading one overlay per host: a
+ * second overlay replaces the first instead of merging with it.
+ */
+export const defineSkillFrontmatterConfig = (
+  ...sources: readonly SkillFrontmatterSource[]
+): readonly Linter.Config[] => [
+  {
+    files: ['**/skills/*/SKILL.md'],
+    language: 'markdown/commonmark',
+    plugins: { markdown, 'md-frontmatter': frontmatter },
+    rules: {
+      'md-frontmatter/schema': [
+        'warn',
+        { schema: defineSkillFrontmatterSchema(...sources) },
+      ],
+    },
+  },
+];

--- a/packages/eslint-plugin-agent-skills/src/hosts/claude-code.ts
+++ b/packages/eslint-plugin-agent-skills/src/hosts/claude-code.ts
@@ -1,0 +1,48 @@
+import type { SkillFrontmatterExtensions } from '../frontmatter-schema.ts';
+
+/*
+ * Claude Code accepts either a scalar or a YAML list wherever the bare
+ * spec types a single delimited string, so the widened fields share one
+ * shape. `allowed-tools` is a spec field Claude Code widens this way;
+ * the rest are extensions.
+ */
+const stringOrList = {
+  anyOf: [
+    { minLength: 1, type: 'string' },
+    { items: { minLength: 1, type: 'string' }, minItems: 1, type: 'array' },
+  ],
+};
+
+/**
+ * Frontmatter fields from Claude Code's
+ * [frontmatter reference](https://code.claude.com/docs/en/skills), which
+ * documents itself as a superset of the Agent Skills specification —
+ * invocation control, subagent execution, tool grants, and the rest —
+ * plus the list spelling it also accepts for the spec's `allowed-tools`.
+ *
+ * `context`, `effort`, and `shell` are pinned to the documented value
+ * sets so a typo is caught; a new upstream value needs a bump here.
+ * `model` and `hooks` stay open, since their value spaces are not.
+ *
+ * Text fields carry no length limit: Claude Code's cap applies to
+ * `description` and `when_to_use` combined and truncates the listing
+ * rather than rejecting the skill, so no per-field limit expresses it.
+ */
+export const claudeCodeFrontmatterExtensions: SkillFrontmatterExtensions = {
+  'agent': { minLength: 1, type: 'string' },
+  'allowed-tools': stringOrList,
+  'argument-hint': { minLength: 1, type: 'string' },
+  'arguments': stringOrList,
+  'background': { type: 'boolean' },
+  'context': { enum: ['fork'] },
+  'disable-model-invocation': { type: 'boolean' },
+  'disallowed-tools': stringOrList,
+  'effort': { enum: ['low', 'medium', 'high', 'xhigh', 'max'] },
+  /* Shape is owned by the hooks reference; validated as a mapping only. */
+  'hooks': { type: 'object' },
+  'model': { minLength: 1, type: 'string' },
+  'paths': stringOrList,
+  'shell': { enum: ['bash', 'powershell'] },
+  'user-invocable': { type: 'boolean' },
+  'when_to_use': { minLength: 1, type: 'string' },
+};

--- a/packages/eslint-plugin-agent-skills/src/hosts/index.ts
+++ b/packages/eslint-plugin-agent-skills/src/hosts/index.ts
@@ -1,0 +1,21 @@
+import type { SkillFrontmatterExtensions } from '../frontmatter-schema.ts';
+import { claudeCodeFrontmatterExtensions } from './claude-code.ts';
+
+/**
+ * Agent hosts whose `SKILL.md` frontmatter extensions ship with this
+ * package, keyed by the name
+ * {@link ../frontmatter-schema.ts | `defineSkillFrontmatterSchema`}
+ * accepts. Adding a host is an entry here — every host is just a
+ * property map layered onto the spec schema.
+ *
+ * The Agent Skills spec sanctions only the nested `metadata` map for
+ * client-specific data, so a host that puts fields at the top level has
+ * to have each one declared. There is no reserved top-level namespace
+ * to pattern-match instead.
+ */
+export const skillFrontmatterHosts = {
+  'claude-code': claudeCodeFrontmatterExtensions,
+} as const satisfies Readonly<Record<string, SkillFrontmatterExtensions>>;
+
+/** Name of an agent host this package ships extensions for. */
+export type SkillFrontmatterHost = keyof typeof skillFrontmatterHosts;

--- a/packages/eslint-plugin-agent-skills/src/index.ts
+++ b/packages/eslint-plugin-agent-skills/src/index.ts
@@ -20,6 +20,17 @@ import schema from './schema.json' with { type: 'json' };
 export { default as skillFrontmatterSchema }
   from './schema.json' with { type: 'json' };
 
+export {
+  defineSkillFrontmatterConfig,
+  defineSkillFrontmatterSchema,
+} from './frontmatter-schema.ts';
+export type {
+  SkillFrontmatterExtensions,
+  SkillFrontmatterSource,
+} from './frontmatter-schema.ts';
+export { skillFrontmatterHosts } from './hosts/index.ts';
+export type { SkillFrontmatterHost } from './hosts/index.ts';
+
 /**
  * JSON Schema for an Agent Skill's `evals/evals.json` file, matching
  * the canonical layout documented by Anthropic's `skill-creator`
@@ -56,6 +67,10 @@ const plugin: ESLint.Plugin = {
  * guidance that ancillary reference files stay focused and smaller
  * than `SKILL.md`; 300 sits just above the p90 line count of files
  * in popular published skills.
+ *
+ * `recommended` validates frontmatter against the bare spec, so a host
+ * extension reads as an unknown property. Repos targeting one or more
+ * hosts spread a `defineSkillFrontmatterConfig(...)` overlay after it.
  */
 export const configs: {
   readonly recommended: readonly Linter.Config[];

--- a/packages/eslint-plugin-agent-skills/test/claude-code.test.ts
+++ b/packages/eslint-plugin-agent-skills/test/claude-code.test.ts
@@ -1,0 +1,133 @@
+import path from 'node:path';
+import { Linter } from 'eslint';
+import { describe, it } from 'vitest';
+import { configs, defineSkillFrontmatterConfig } from '#src/index.js';
+
+const cwd = path.resolve('/repo');
+const skillFile = path.join(cwd, 'skills', 'my-skill', 'SKILL.md');
+
+const linter = new Linter({ cwd });
+const spec = [...configs.recommended];
+const claudeCode = [
+  ...configs.recommended,
+  ...defineSkillFrontmatterConfig('claude-code'),
+];
+
+/** Wraps extra frontmatter lines in an otherwise spec-valid `SKILL.md`. */
+const skill = (extra = ''): string =>
+  `---\nname: my-skill\ndescription: A skill.\n${extra}---\n\n# My skill\n`;
+
+const schemaMessages = (
+  config: readonly Linter.Config[],
+  code: string,
+): readonly Linter.LintMessage[] => linter
+  .verify(code, [...config], skillFile)
+  .filter(message => message.ruleId === 'md-frontmatter/schema');
+
+/*
+ * Every field in Claude Code's frontmatter reference table
+ * (https://code.claude.com/docs/en/skills), exercising the list form of
+ * each field that documents both a scalar and a YAML-list spelling.
+ */
+const everyClaudeCodeField = [
+  'agent: general-purpose',
+  'allowed-tools:',
+  '  - Read',
+  '  - Grep',
+  "argument-hint: '[issue-number]'",
+  'arguments:',
+  '  - issue',
+  '  - branch',
+  'background: false',
+  'context: fork',
+  'disable-model-invocation: true',
+  'disallowed-tools: AskUserQuestion',
+  'effort: high',
+  'hooks:',
+  '  PreToolUse:',
+  '    - matcher: Bash',
+  '      hooks:',
+  '        - type: command',
+  "          command: echo 'hi'",
+  'model: inherit',
+  'paths:',
+  "  - 'src/**/*.ts'",
+  'shell: powershell',
+  'user-invocable: false',
+  'when_to_use: When the user asks about issues.',
+  '',
+].join('\n');
+
+describe('the claude-code frontmatter overlay', () => {
+  it('accepts every documented Claude Code field', ({ expect }) => {
+    const messages = schemaMessages(claudeCode, skill(everyClaudeCodeField));
+
+    expect(messages).toStrictEqual([]);
+  });
+
+  it('accepts the spec fields the extensions do not touch', ({ expect }) => {
+    const code = skill([
+      'compatibility: Requires network access.',
+      'license: MIT',
+      'metadata:',
+      '  author: someone',
+      '',
+    ].join('\n'));
+
+    expect(schemaMessages(claudeCode, code)).toStrictEqual([]);
+  });
+
+  it('still rejects an undocumented field', ({ expect }) => {
+    const [message, ...rest] = schemaMessages(
+      claudeCode,
+      skill('user-invocabel: false\n'),
+    );
+
+    expect(rest).toStrictEqual([]);
+    expect(message?.message).toMatch(/additional properties/v);
+  });
+
+  it('rejects an effort level outside the documented set', ({ expect }) => {
+    const [message, ...rest] = schemaMessages(claudeCode, skill('effort: turbo\n'));
+
+    expect(rest).toStrictEqual([]);
+    expect(message?.message).toMatch(/effort/v);
+  });
+
+  it('rejects a non-boolean user-invocable', ({ expect }) => {
+    const [message, ...rest] = schemaMessages(
+      claudeCode,
+      skill('user-invocable: nope\n'),
+    );
+
+    expect(rest).toStrictEqual([]);
+    expect(message?.message).toMatch(/user-invocable/v);
+  });
+
+  it('keeps the spec constraints on shared fields', ({ expect }) => {
+    const code = '---\nname: My_Skill\ndescription: A skill.\n---\n\n# My skill\n';
+
+    const [message, ...rest] = schemaMessages(claudeCode, code);
+
+    expect(rest).toStrictEqual([]);
+    expect(message?.message).toMatch(/name/v);
+  });
+});
+
+describe('configs.recommended without the Claude Code overlay', () => {
+  it('flags a Claude Code field', ({ expect }) => {
+    const [message, ...rest] = schemaMessages(spec, skill('user-invocable: false\n'));
+
+    expect(rest).toStrictEqual([]);
+    expect(message?.message).toMatch(/additional properties/v);
+  });
+
+  it('flags the list form of allowed-tools the spec types as a string', ({ expect }) => {
+    const code = skill('allowed-tools:\n  - Read\n');
+
+    const [message, ...rest] = schemaMessages(spec, code);
+
+    expect(rest).toStrictEqual([]);
+    expect(message?.message).toMatch(/allowed-tools/v);
+  });
+});

--- a/packages/eslint-plugin-agent-skills/test/frontmatter-schema.test.ts
+++ b/packages/eslint-plugin-agent-skills/test/frontmatter-schema.test.ts
@@ -1,0 +1,175 @@
+import path from 'node:path';
+import markdown from '@eslint/markdown';
+import frontmatter from '@gtbuchanan/eslint-plugin-md-frontmatter';
+import { Linter } from 'eslint';
+import { describe, it } from 'vitest';
+import {
+  configs,
+  defineSkillFrontmatterConfig,
+  defineSkillFrontmatterSchema,
+} from '#src/index.js';
+
+const cwd = path.resolve('/repo');
+const skillFile = path.join(cwd, 'skills', 'my-skill', 'SKILL.md');
+
+const linter = new Linter({ cwd });
+
+/** Extensions for a host this package ships nothing for. */
+const teamExtensions = { 'x-team-owner': { minLength: 1, type: 'string' } };
+
+/** Wraps extra frontmatter lines in an otherwise spec-valid `SKILL.md`. */
+const skill = (extra = ''): string =>
+  `---\nname: my-skill\ndescription: A skill.\n${extra}---\n\n# My skill\n`;
+
+const schemaMessages = (
+  overlay: readonly Linter.Config[],
+  code: string,
+): readonly Linter.LintMessage[] => linter
+  .verify(code, [...configs.recommended, ...overlay], skillFile)
+  .filter(message => message.ruleId === 'md-frontmatter/schema');
+
+describe('defineSkillFrontmatterConfig', () => {
+  it('accepts a field declared by a caller-supplied extension', ({ expect }) => {
+    const overlay = defineSkillFrontmatterConfig(teamExtensions);
+
+    const messages = schemaMessages(overlay, skill('x-team-owner: platform\n'));
+
+    expect(messages).toStrictEqual([]);
+  });
+
+  it('accepts a field declared by a host named in the registry', ({ expect }) => {
+    const overlay = defineSkillFrontmatterConfig('claude-code');
+
+    const messages = schemaMessages(overlay, skill('user-invocable: false\n'));
+
+    expect(messages).toStrictEqual([]);
+  });
+
+  it('rejects a field no source declares', ({ expect }) => {
+    const overlay = defineSkillFrontmatterConfig(teamExtensions);
+
+    const [message, ...rest] = schemaMessages(overlay, skill('x-team-lead: platform\n'));
+
+    expect(rest).toStrictEqual([]);
+    expect(message?.message).toMatch(/additional properties/v);
+  });
+
+  it('enforces the declared type of an extension field', ({ expect }) => {
+    const overlay = defineSkillFrontmatterConfig(teamExtensions);
+
+    const [message, ...rest] = schemaMessages(overlay, skill('x-team-owner: 5\n'));
+
+    expect(rest).toStrictEqual([]);
+    expect(message?.message).toMatch(/x-team-owner/v);
+  });
+
+  it('leaves the spec schema in force with no sources', ({ expect }) => {
+    const overlay = defineSkillFrontmatterConfig();
+
+    const [message, ...rest] = schemaMessages(overlay, skill('user-invocable: false\n'));
+
+    expect(rest).toStrictEqual([]);
+    expect(message?.message).toMatch(/additional properties/v);
+  });
+});
+
+describe('defineSkillFrontmatterConfig with several sources', () => {
+  const overlay = defineSkillFrontmatterConfig('claude-code', teamExtensions);
+
+  it('accepts fields from every source at once', ({ expect }) => {
+    const code = skill('user-invocable: false\nx-team-owner: platform\n');
+
+    expect(schemaMessages(overlay, code)).toStrictEqual([]);
+  });
+
+  it('accepts a field from one source without the others present', ({ expect }) => {
+    expect(schemaMessages(overlay, skill('x-team-owner: platform\n')))
+      .toStrictEqual([]);
+  });
+
+  it('still rejects a field none of the sources declares', ({ expect }) => {
+    const [message, ...rest] = schemaMessages(overlay, skill('x-team-lead: platform\n'));
+
+    expect(rest).toStrictEqual([]);
+    expect(message?.message).toMatch(/additional properties/v);
+  });
+
+  it('takes a contested field from the last source that declares it', ({ expect }) => {
+    /*
+     * `claude-code` types `user-invocable` as a boolean; the override
+     * re-types it as a string, so the boolean is what must now fail.
+     */
+    const overridden = defineSkillFrontmatterConfig(
+      'claude-code',
+      { 'user-invocable': { minLength: 1, type: 'string' } },
+    );
+
+    expect(schemaMessages(overridden, skill('user-invocable: never\n')))
+      .toStrictEqual([]);
+    expect(schemaMessages(overridden, skill('user-invocable: false\n')))
+      .not.toStrictEqual([]);
+  });
+});
+
+describe('defineSkillFrontmatterSchema', () => {
+  /* Hand-wired rather than via the overlay, so the schema is the only
+     thing under test — the config below is the caller's own. */
+  const config: Linter.Config[] = [
+    {
+      files: ['**/skills/*/SKILL.md'],
+      language: 'markdown/commonmark',
+      plugins: { markdown, 'md-frontmatter': frontmatter },
+      rules: {
+        'md-frontmatter/schema': [
+          'warn',
+          { schema: defineSkillFrontmatterSchema('claude-code', teamExtensions) },
+        ],
+      },
+    },
+  ];
+
+  const messagesFor = (code: string): readonly Linter.LintMessage[] => linter
+    .verify(code, config, skillFile)
+    .filter(message => message.ruleId === 'md-frontmatter/schema');
+
+  it('produces a schema usable as rule options directly', ({ expect }) => {
+    const code = skill('user-invocable: false\nx-team-owner: platform\n');
+
+    expect(messagesFor(code)).toStrictEqual([]);
+  });
+
+  /*
+   * Pairs with the case above: on its own, an empty-message assertion
+   * passes just as well when the rule never fires at all, so the same
+   * hand-wired config has to be shown reporting something.
+   */
+  it('reports through that wiring when frontmatter is invalid', ({ expect }) => {
+    const [message, ...rest] = messagesFor(skill('x-team-lead: platform\n'));
+
+    expect(rest).toStrictEqual([]);
+    expect(message?.message).toMatch(/additional properties/v);
+  });
+
+  /*
+   * TypeScript rejects an unshipped name outright; this covers the JS
+   * consumer, for whom the alternative is a registry miss that
+   * contributes no fields and surfaces as unexplained frontmatter
+   * errors on every skill.
+   */
+  it('throws on a host name it does not ship', ({ expect }) => {
+    expect(() =>
+      // @ts-expect-error -- unshipped host name, rejected at runtime
+      defineSkillFrontmatterSchema('claude-cod'),
+    ).toThrow(/claude-cod/v);
+  });
+
+  it('keeps the spec requirements no source mentions', ({ expect }) => {
+    const overlay = defineSkillFrontmatterConfig(teamExtensions);
+    const code = '---\nname: my-skill\nx-team-owner: platform\n---\n\n# My skill\n';
+
+    const [message, ...rest] = schemaMessages(overlay, code);
+
+    expect(rest).toStrictEqual([]);
+    expect(message?.message).toMatch(/description/v);
+  });
+});

--- a/packages/eslint-plugin-agent-skills/test/recommended-plugins.test.ts
+++ b/packages/eslint-plugin-agent-skills/test/recommended-plugins.test.ts
@@ -1,11 +1,11 @@
 import frontmatter from '@gtbuchanan/eslint-plugin-md-frontmatter';
 import type { ESLint } from 'eslint';
 import { describe, it } from 'vitest';
-import plugin, { configs } from '#src/index.js';
+import plugin, { configs, defineSkillFrontmatterConfig } from '#src/index.js';
 import manifest from '../package.json' with { type: 'json' };
 
 /*
- * Every third-party plugin `configs.recommended` registers has to be a peer
+ * Every third-party plugin an exported config registers has to be a peer
  * dependency. ESLint rejects a namespace registered by two configs unless
  * both pass the identical plugin object, so a consumer config that registers
  * the same namespace — `@gtbuchanan/eslint-config` registers `markdown` for
@@ -21,10 +21,14 @@ import manifest from '../package.json' with { type: 'json' };
 const isWorkspacePlugin = (candidate: ESLint.Plugin): boolean =>
   candidate === plugin || candidate === frontmatter;
 
+/* The overlay registers plugins of its own, so it is covered too. */
+const exported = [
+  ...Object.values(configs).flat(),
+  ...defineSkillFrontmatterConfig('claude-code'),
+];
+
 const thirdPartyPlugins = [
-  ...new Set(configs.recommended.flatMap(
-    config => Object.values(config.plugins ?? {}),
-  )),
+  ...new Set(exported.flatMap(config => Object.values(config.plugins ?? {}))),
 ].filter(registered => !isWorkspacePlugin(registered));
 
 const thirdPartyPluginNames = [
@@ -35,7 +39,7 @@ const thirdPartyPluginNames = [
   ),
 ];
 
-describe('configs.recommended plugin resolution', () => {
+describe('exported configs plugin resolution', () => {
   /*
    * `meta.name` is how a third-party plugin is traced back to the package
    * that has to be a peer. One that omits it would otherwise drop out of the

--- a/packages/eslint-plugin-md-frontmatter/src/rules/schema.ts
+++ b/packages/eslint-plugin-md-frontmatter/src/rules/schema.ts
@@ -30,8 +30,16 @@ const ruleOptionsSchema = [
  * once per ESLint run. `validateSchema: false` skips the meta-schema
  * lookup so user schemas can reference any `$schema` URL (or omit it)
  * without forcing us to register the corresponding meta-schema.
+ *
+ * `addUsedSchema: false` keeps compilation from registering a schema
+ * under its `$id`. Registration throws on a second schema carrying an
+ * id already seen, and ESLint hands the rule a fresh options object
+ * every time a config is resolved, so the identity cache below misses
+ * and the same id reaches Ajv on each pass. The id still sets the base
+ * URI, so a `$ref` written against it resolves.
  */
 const ajv = new Ajv({
+  addUsedSchema: false,
   allErrors: true,
   strict: false,
   validateSchema: false,

--- a/packages/eslint-plugin-md-frontmatter/test/schema.test.ts
+++ b/packages/eslint-plugin-md-frontmatter/test/schema.test.ts
@@ -27,6 +27,31 @@ const testSchema = {
   type: 'object',
 } as const;
 
+const schemaId = 'https://example.test/schemas/frontmatter.json';
+
+/** A fresh copy of {@link testSchema} carrying a declared `$id`. */
+const identifiedSchema = () => ({
+  ...structuredClone(testSchema),
+  $id: schemaId,
+});
+
+/**
+ * A schema whose `$ref` is absolute against its own `$id`, rather than
+ * the bare `#/...` fragment form. Resolving it needs the `$id` to still
+ * be establishing the base URI at compile time.
+ */
+const selfReferencingSchema = () => ({
+  $id: 'https://example.test/schemas/self-ref.json',
+  $schema: 'https://json-schema.org/draft-07/schema',
+  additionalProperties: false,
+  definitions: { skillName: { minLength: 1, type: 'string' } },
+  properties: {
+    name: { $ref: 'https://example.test/schemas/self-ref.json#/definitions/skillName' },
+  },
+  required: ['name'],
+  type: 'object',
+});
+
 describe.concurrent('md-frontmatter/schema', () => {
   it('passes for frontmatter that satisfies the schema', ({ expect }) => {
     expect(() => {
@@ -165,6 +190,56 @@ describe.concurrent('md-frontmatter/schema', () => {
         ],
         valid: [],
       });
+    }).not.toThrow();
+  });
+
+  /*
+   * ESLint hands the rule a fresh options object on every run, so the
+   * identity-keyed compile cache always misses and each run reaches Ajv
+   * with an equivalent-but-distinct schema. Ajv registers a schema under
+   * its `$id` process-wide and rejects a second registration of the same
+   * id, so a schema that declares one has to stay compilable.
+   */
+  /*
+   * A `$ref` written against the schema's own `$id` resolves only while
+   * that id is setting the base URI, which is the constraint any guard
+   * against duplicate registration has to respect.
+   */
+  it('resolves a $ref written against the schema $id', ({ expect }) => {
+    expect(() => {
+      ruleTester.run('md-frontmatter/schema', schema, {
+        invalid: [
+          {
+            code: '---\nname: ""\n---\n',
+            errors: [{ message: /`frontmatter\.name`.*fewer than 1 characters/v }],
+            options: [{ schema: selfReferencingSchema() }],
+          },
+        ],
+        valid: [
+          {
+            code: '---\nname: example\n---\n',
+            options: [{ schema: selfReferencingSchema() }],
+          },
+        ],
+      });
+    }).not.toThrow();
+  });
+
+  it('re-compiles a schema that declares an $id', ({ expect }) => {
+    const runs = [identifiedSchema(), identifiedSchema()];
+
+    expect(() => {
+      for (const identified of runs) {
+        ruleTester.run('md-frontmatter/schema', schema, {
+          invalid: [],
+          valid: [
+            {
+              code: '---\nname: example\ndescription: A description.\n---\n',
+              options: [{ schema: identified }],
+            },
+          ],
+        });
+      }
     }).not.toThrow();
   });
 });


### PR DESCRIPTION
Fixes #302

## Problem

`skillFrontmatterSchema` sets `additionalProperties: false` against the [Agent Skills spec](https://agentskills.io/specification), so any skill using a host extension fails `md-frontmatter/schema`:

```
skills/pr-review-apply/SKILL.md
  11:0  warning  `frontmatter.user-invocable` must NOT have additional properties  md-frontmatter/schema
```

Claude Code [documents itself as a superset](https://code.claude.com/docs/en/skills) of that standard, and `user-invocable` is one of its documented fields. The rule's only lever was a wholesale `schema` replacement, which drops the spec validation the rule exists to provide.

## Why per-host declarations rather than a wildcard

The issue floated relaxing `additionalProperties` to a `^[a-z-]+$` pattern "the spec reserves for host extensions." The spec reserves no such thing — its only sanctioned extension mechanism is the nested `metadata` map:

> **`metadata` field** — Clients can use this to store additional properties not defined by the Agent Skills spec. We recommend making your key names reasonably unique to avoid accidental conflicts.

A host that puts fields at the *top* level is describing its own surface, ad hoc. So a pattern-based relaxation wouldn't be "supporting hosts generically" — it would be switching frontmatter validation off, and it wouldn't even cover `when_to_use` (underscore). Each host's fields have to be declared.

## Fix

Host extensions are a **composable, multi-host** input rather than a fixed setting, since the spec is implemented by [many agents](https://www.agensi.io/learn/every-ai-agent-that-supports-skill-md-2026) and a repo's skills may target several at once.

**`@gtbuchanan/eslint-plugin-agent-skills`** — `defineSkillFrontmatterConfig(...sources)` composes an overlay; `defineSkillFrontmatterSchema(...sources)` returns the schema for callers wiring the rule themselves. A source is a host name from the `skillFrontmatterHosts` registry, or a property map of your own for a host this package doesn't ship:

```typescript
export default [
  ...configs.recommended,
  ...defineSkillFrontmatterConfig('claude-code'),
];

// several sources — one call, fields unioned
defineSkillFrontmatterConfig('claude-code', { 'x-team-owner': { type: 'string' } });
```

`claude-code` ships today, covering its documented fields plus the YAML-list spelling it accepts for `allowed-tools`. Adding a host later is a registry entry, not a new public config export.

**`@gtbuchanan/eslint-config`** — `agentSkillsHost` takes the same sources, singly or as a list:

```typescript
configure({ agentSkillsHost: 'claude-code' })
configure({ agentSkillsHost: ['claude-code', { 'x-team-owner': { type: 'string' } }] })
```

The default `'standard'` leaves existing configs untouched.

Whatever the sources, only property definitions are layered on: `name` and `description` stay required and every spec constraint (kebab-case `name`, length caps) still applies.

### Why one call rather than one overlay per host

The overlay re-points a single rule and relies on flat config's last-match-wins merge, so spreading two overlays would leave only the second host's schema in force. Composing inside one call is what makes multi-host actually work — which is also why there is no `configs.claudeCode`-style static per-host config.

## Drive-by: a latent crash in `md-frontmatter/schema`

Writing the tests surfaced a bug that is **reachable on `main`**, not introduced here.

Ajv registers a schema under its `$id` process-wide and throws on a second registration. The rule guarded against that with a compile cache keyed on schema-object identity — but ESLint hands the rule a fresh options object every time a config is resolved, so the cache always misses and Ajv sees the same id twice. One lint pass succeeded, the next died inside the rule with `schema with key or id "..." already exists`. Both shipped frontmatter schemas declare an `$id`; it simply never fired in the single-resolution CLI path.

Fixed with `addUsedSchema: false` on the rule's Ajv instance, which skips both the registration and its uniqueness check while leaving `$id` setting the base URI — so a `$ref` written against it still resolves. Its own commit, patch changeset.

## Trade-offs

- **Union, not intersection.** Listing hosts accepts every field *any* of them declares. "Valid under every host at once" is not a second mode — it is `'standard'`, the default.
- **Contested fields take the last source's definition**, so a caller's map can override a shipped host's. No two shipped hosts currently collide.
- **An unshipped host name throws.** TypeScript rejects it already; for a JS consumer the alternative was a registry miss contributing no fields, surfacing as unexplained frontmatter errors on every skill rather than as the typo it is.
- **`context`, `effort`, and `shell` are pinned to their documented value sets**, so a new upstream value needs a bump rather than passing silently. Deliberate — catching `effort: turbo` is most of the value of validating them. `model` and `hooks` stay open, since their value spaces are not closed.

## Verification

- Every field in Claude Code's frontmatter reference table validates under its overlay, exercising the YAML-list spelling of each field documented with both forms.
- Multi-source composition covered directly: fields from several sources accepted together and independently, a field no source declares still rejected, and a contested field resolving to the later definition (asserted both ways — the overridden type must now fail).
- The same `user-invocable` frontmatter still fails under `configs.recommended` alone, and `user-invocabel` still fails under an overlay — extensions widen what is recognized without opening the object.
- Spec constraints re-asserted through an overlay (missing `description`, `name: My_Skill`).
- The `$id` fix has two regressions: the rule run twice with equivalent-but-distinct schemas (failed with the exact Ajv registration message beforehand), and a schema whose `$ref` is absolute against its own `$id` (failed with `can't resolve reference … from id #`).
- Mutation-checked the new suites rather than trusting green: dropping the composed sources kills 8 of 19, and stubbing the rule to always pass kills 12 of 19 — the survivors being accept-cases, each of which shares a config with a reject-case so a dead rule can't hide.
- Full `pnpm build` green — lint, typecheck, fast + slow + e2e across all packages.
- Documentation updated in both READMEs and the `gtb-eslint-config` skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
