### PR TITLE
Fix gtb generate task wiring in turbo.json

### DIFF
--- a/.changeset/generate-task-package-configs.md
+++ b/.changeset/generate-task-package-configs.md
@@ -1,0 +1,30 @@
+---
+'@gtbuchanan/cli': minor
+---
+
+Declare `generate:*` tasks so turbo can actually run them
+
+`gtb sync` named every discovered `generate:*` script in the root
+`generate` aggregate's `dependsOn` but never emitted a task definition
+for it. In a monorepo turbo refuses to build the graph at all in that
+state — `Could not find "<pkg>#generate:prisma" in root turbo.json` —
+so any consumer that added a codegen script broke every `turbo run`.
+
+Only the package knows what its codegen reads and writes, and a task
+with no `outputs` restores nothing on a cache hit, so sync no longer
+guesses:
+
+- **Monorepo** — the root aggregate is emitted empty and each package
+  declares its own leaves in a package configuration
+  (`packages/<pkg>/turbo.json` extending `//`), where it can give them
+  real `inputs`/`outputs`. `gtb verify` reports a package that has
+  `generate:*` scripts but no such configuration, a leaf missing from
+  `generate`'s `dependsOn`, or a leaf declaring neither `outputs` nor
+  `cache: false` — without the check, a missing configuration silently
+  skips generation and leaves downstream tasks reading stale files.
+- **Single-package repo** — turbo offers package configurations only
+  for workspace packages, so sync declares the leaves itself with
+  `cache: false`.
+
+Repos with no `generate:*` scripts generate the same `turbo.json` as
+before.

--- a/packages/cli/e2e/turbo-generate.test.ts
+++ b/packages/cli/e2e/turbo-generate.test.ts
@@ -1,0 +1,156 @@
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { type ProjectFixture, createProjectFixture } from '@gtbuchanan/test-utils';
+import * as build from '@gtbuchanan/test-utils/builders';
+import { describe, it } from 'vitest';
+
+/*
+ * These tests drive the real turbo binary over a workspace `gtb sync`
+ * generated, because the failure they guard against is invisible to a
+ * turbo.json snapshot: turbo aborts the whole run when a task in `dependsOn`
+ * resolves to no definition, and silently restores nothing when a cached
+ * task declares no outputs. `gtb turbo` is used rather than turbo directly
+ * so the Android/Termux escape hatch applies.
+ */
+
+const jsonIndent = 2;
+
+const stampScript = (file: string): string =>
+  `node -e "require('fs').mkdirSync('generated',{recursive:true});` +
+  `require('fs').writeFileSync('generated/${file}','stamped')"`;
+
+const writeJson = (dir: string, name: string, data: unknown): void => {
+  const filePath = path.join(dir, name);
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, `${JSON.stringify(data, undefined, jsonIndent)}\n`);
+};
+
+const createFixture = (): ProjectFixture =>
+  createProjectFixture({ packageName: '@gtbuchanan/cli' });
+
+/* eslint-disable vitest/max-expects --
+   Each step of a turbo run is its own observable outcome: the command
+   succeeded, the cache behaved as configured, the file landed */
+describe.concurrent('generate tasks through turbo', () => {
+  it('runs a single-package generate script on every invocation', async ({ expect }) => {
+    using fixture = createFixture();
+    const stamp = `${build.packageName()}.txt`;
+    writeJson(fixture.projectDir, 'package.json', {
+      name: build.packageName(),
+      packageManager: 'npm@11.0.0',
+      scripts: { 'generate:stamp': stampScript(stamp) },
+      version: build.semverVersion(),
+    });
+
+    const sync = await fixture.run('gtb', ['sync', 'turbo']);
+
+    expect(sync).toMatchObject({ exitCode: 0 });
+
+    const generated = path.join(fixture.projectDir, 'generated', stamp);
+    const first = await fixture.run('gtb', ['turbo', 'run', 'generate']);
+
+    expect(first).toMatchObject({ exitCode: 0 });
+    expect(existsSync(generated)).toBe(true);
+
+    /*
+     * sync marks single-package leaves `cache: false`, so turbo must bypass
+     * the cache rather than decide between a hit and a miss — the file being
+     * regenerated is not enough on its own, since a generated file that turbo
+     * counts among the task's default inputs invalidates the hash by going
+     * missing and would re-run either way.
+     */
+    rmSync(generated);
+
+    const second = await fixture.run('gtb', ['turbo', 'run', 'generate']);
+
+    expect(second).toMatchObject({ exitCode: 0 });
+    expect(second.stdout).toContain('cache bypass');
+    expect(existsSync(generated)).toBe(true);
+  });
+
+  it('restores package-declared generate outputs from cache', async ({ expect }) => {
+    using fixture = createFixture();
+    const workspace = path.join(fixture.projectDir, 'workspace');
+    const pkgDir = path.join(workspace, 'packages', build.packageName());
+    const stamp = `${build.packageName()}.txt`;
+    mkdirSync(pkgDir, { recursive: true });
+    writeFileSync(
+      path.join(workspace, 'pnpm-workspace.yaml'),
+      "packages:\n  - 'packages/*'\n",
+    );
+    writeJson(workspace, 'package.json', {
+      name: build.packageName(),
+      packageManager: 'npm@11.0.0',
+      private: true,
+      version: build.semverVersion(),
+      workspaces: ['packages/*'],
+    });
+    /*
+     * turbo builds its package graph from the lockfile. npm never ran in
+     * this nested workspace, so declare the one package by hand.
+     */
+    const pkgName = build.packageName();
+    writeJson(workspace, 'package-lock.json', {
+      lockfileVersion: 3,
+      packages: {
+        '': { workspaces: ['packages/*'] },
+        [`node_modules/${pkgName}`]: { link: true, resolved: path.relative(workspace, pkgDir) },
+        [path.relative(workspace, pkgDir)]: { name: pkgName, version: '0.0.0' },
+      },
+      requires: true,
+    });
+    writeJson(pkgDir, 'package.json', {
+      name: pkgName,
+      scripts: { 'generate:stamp': stampScript(stamp) },
+      version: '0.0.0',
+    });
+
+    const sync = await fixture.run('gtb', ['sync', '-C', workspace, 'turbo']);
+
+    expect(sync).toMatchObject({ exitCode: 0 });
+
+    const rootTasks: unknown = JSON.parse(
+      readFileSync(path.join(workspace, 'turbo.json'), 'utf8'),
+    );
+
+    expect(rootTasks).toHaveProperty('tasks.generate');
+    expect(rootTasks).not.toHaveProperty('tasks.generate.dependsOn');
+    expect(rootTasks).not.toHaveProperty('tasks.generate:stamp');
+
+    const verify = await fixture.run('gtb', ['verify', '-C', workspace, 'turbo']);
+
+    expect(verify).toMatchObject({ exitCode: 1 });
+    expect(verify.stderr).toContain('add a package configuration');
+
+    writeJson(pkgDir, 'turbo.json', {
+      extends: ['//'],
+      tasks: {
+        'generate': { dependsOn: ['generate:stamp'] },
+        'generate:stamp': { outputs: ['generated/**'] },
+      },
+    });
+
+    const verified = await fixture.run('gtb', ['verify', '-C', workspace, 'turbo']);
+
+    expect(verified).toMatchObject({ exitCode: 0 });
+
+    const generated = path.join(pkgDir, 'generated', stamp);
+    const first = await fixture.run('gtb', ['turbo', '--cwd', workspace, 'run', 'generate']);
+
+    expect(first).toMatchObject({ exitCode: 0 });
+    expect(existsSync(generated)).toBe(true);
+
+    /*
+     * The declared outputs are what make a cache hit safe: with them, the
+     * generated file comes back without running the script.
+     */
+    rmSync(generated);
+
+    const second = await fixture.run('gtb', ['turbo', '--cwd', workspace, 'run', 'generate']);
+
+    expect(second).toMatchObject({ exitCode: 0 });
+    expect(second.stdout).toContain('cache hit');
+    expect(existsSync(generated)).toBe(true);
+  });
+});
+/* eslint-enable vitest/max-expects */

--- a/packages/cli/e2e/turbo-generate.test.ts
+++ b/packages/cli/e2e/turbo-generate.test.ts
@@ -34,9 +34,10 @@ const createFixture = (): ProjectFixture =>
 describe.concurrent('generate tasks through turbo', () => {
   it('runs a single-package generate script on every invocation', async ({ expect }) => {
     using fixture = createFixture();
-    const stamp = `${build.packageName()}.txt`;
+    const packageName = build.packageName();
+    const stamp = `${packageName}.txt`;
     writeJson(fixture.projectDir, 'package.json', {
-      name: build.packageName(),
+      name: packageName,
       packageManager: 'npm@11.0.0',
       scripts: { 'generate:stamp': stampScript(stamp) },
       version: build.semverVersion(),
@@ -71,8 +72,16 @@ describe.concurrent('generate tasks through turbo', () => {
   it('restores package-declared generate outputs from cache', async ({ expect }) => {
     using fixture = createFixture();
     const workspace = path.join(fixture.projectDir, 'workspace');
-    const pkgDir = path.join(workspace, 'packages', build.packageName());
-    const stamp = `${build.packageName()}.txt`;
+    const packageName = build.packageName();
+    /*
+     * Lockfile keys are workspace-relative paths, and npm writes them with
+     * forward slashes on every platform — deriving them from `path.relative`
+     * would emit backslashes on Windows and turbo would not match them to
+     * the package.
+     */
+    const pkgPath = `packages/${packageName}`;
+    const pkgDir = path.join(workspace, ...pkgPath.split('/'));
+    const stamp = `${packageName}.txt`;
     mkdirSync(pkgDir, { recursive: true });
     writeFileSync(
       path.join(workspace, 'pnpm-workspace.yaml'),
@@ -89,18 +98,17 @@ describe.concurrent('generate tasks through turbo', () => {
      * turbo builds its package graph from the lockfile. npm never ran in
      * this nested workspace, so declare the one package by hand.
      */
-    const pkgName = build.packageName();
     writeJson(workspace, 'package-lock.json', {
       lockfileVersion: 3,
       packages: {
         '': { workspaces: ['packages/*'] },
-        [`node_modules/${pkgName}`]: { link: true, resolved: path.relative(workspace, pkgDir) },
-        [path.relative(workspace, pkgDir)]: { name: pkgName, version: '0.0.0' },
+        [`node_modules/${packageName}`]: { link: true, resolved: pkgPath },
+        [pkgPath]: { name: packageName, version: '0.0.0' },
       },
       requires: true,
     });
     writeJson(pkgDir, 'package.json', {
-      name: pkgName,
+      name: packageName,
       scripts: { 'generate:stamp': stampScript(stamp) },
       version: '0.0.0',
     });

--- a/packages/cli/e2e/turbo-generate.test.ts
+++ b/packages/cli/e2e/turbo-generate.test.ts
@@ -15,6 +15,14 @@ import { describe, it } from 'vitest';
 
 const jsonIndent = 2;
 
+/*
+ * CI exports remote-cache credentials for the whole job, which these
+ * fixtures would otherwise inherit — pushing throwaway task hashes to the
+ * shared cache and making a local cache decision depend on a network round
+ * trip. Keep each fixture's caching to its own directory.
+ */
+const localCacheOnly = '--cache=local:rw';
+
 const stampScript = (file: string): string =>
   `node -e "require('fs').mkdirSync('generated',{recursive:true});` +
   `require('fs').writeFileSync('generated/${file}','stamped')"`;
@@ -48,7 +56,7 @@ describe.concurrent('generate tasks through turbo', () => {
     expect(sync).toMatchObject({ exitCode: 0 });
 
     const generated = path.join(fixture.projectDir, 'generated', stamp);
-    const first = await fixture.run('gtb', ['turbo', 'run', 'generate']);
+    const first = await fixture.run('gtb', ['turbo', 'run', 'generate', localCacheOnly]);
 
     expect(first).toMatchObject({ exitCode: 0 });
     expect(existsSync(generated)).toBe(true);
@@ -62,7 +70,7 @@ describe.concurrent('generate tasks through turbo', () => {
      */
     rmSync(generated);
 
-    const second = await fixture.run('gtb', ['turbo', 'run', 'generate']);
+    const second = await fixture.run('gtb', ['turbo', 'run', 'generate', localCacheOnly]);
 
     expect(second).toMatchObject({ exitCode: 0 });
     expect(second.stdout).toContain('cache bypass');
@@ -130,11 +138,19 @@ describe.concurrent('generate tasks through turbo', () => {
     expect(verify).toMatchObject({ exitCode: 1 });
     expect(verify.stderr).toContain('add a package configuration');
 
+    /*
+     * `inputs` is pinned to the manifest so the task hash cannot move
+     * between the two runs below. Left to turbo's default (every file in
+     * the package), whether deleting the generated file changes the hash
+     * depends on how that turbo version treats declared outputs — which is
+     * not what this test is about, and differed between the local and CI
+     * versions when it wasn't pinned.
+     */
     writeJson(pkgDir, 'turbo.json', {
       extends: ['//'],
       tasks: {
         'generate': { dependsOn: ['generate:stamp'] },
-        'generate:stamp': { outputs: ['generated/**'] },
+        'generate:stamp': { inputs: ['package.json'], outputs: ['generated/**'] },
       },
     });
 
@@ -143,7 +159,9 @@ describe.concurrent('generate tasks through turbo', () => {
     expect(verified).toMatchObject({ exitCode: 0 });
 
     const generated = path.join(pkgDir, 'generated', stamp);
-    const first = await fixture.run('gtb', ['turbo', '--cwd', workspace, 'run', 'generate']);
+    const first = await fixture.run(
+      'gtb', ['turbo', '--cwd', workspace, 'run', 'generate', localCacheOnly],
+    );
 
     expect(first).toMatchObject({ exitCode: 0 });
     expect(existsSync(generated)).toBe(true);
@@ -154,7 +172,9 @@ describe.concurrent('generate tasks through turbo', () => {
      */
     rmSync(generated);
 
-    const second = await fixture.run('gtb', ['turbo', '--cwd', workspace, 'run', 'generate']);
+    const second = await fixture.run(
+      'gtb', ['turbo', '--cwd', workspace, 'run', 'generate', localCacheOnly],
+    );
 
     expect(second).toMatchObject({ exitCode: 0 });
     expect(second.stdout).toContain('cache hit');

--- a/packages/cli/skills/gtb-build-pipeline/SKILL.md
+++ b/packages/cli/skills/gtb-build-pipeline/SKILL.md
@@ -88,6 +88,31 @@ Leaf tasks, per-package, run via `gtb task <name>`:
 
 Test tasks hash `CI` into their cache key (`env: ["CI"]` in `turbo.json`) so local and CI caches don't collide — Vitest uses different reporters and coverage settings under CI.
 
+### Codegen tasks (`generate:*`)
+
+Any `generate:*` script in a package's `package.json` is picked up as codegen and ordered ahead of `typecheck:ts`, `compile:ts`, and `lint:eslint`, all of which read generated sources.
+
+Where the _leaf_ tasks get declared depends on the repo shape, because only the package knows what its codegen reads and writes. That matters more than it looks: turbo restores a cached task's declared `outputs` on a hit, so a leaf with none replays its logs, skips the run, restores nothing — and the generated files stay missing while every downstream task reports success. A script name tells `gtb sync` nothing about outputs, so it doesn't guess.
+
+**Monorepo** — the root `generate` aggregate is emitted empty, and each package declares its own leaves in a package configuration (`packages/<pkg>/turbo.json`):
+
+```json
+{
+  "extends": ["//"],
+  "tasks": {
+    "generate": { "dependsOn": ["generate:prisma"] },
+    "generate:prisma": {
+      "inputs": ["prisma/schema.prisma"],
+      "outputs": ["src/generated/**"]
+    }
+  }
+}
+```
+
+The aggregate stays empty rather than naming leaves the root can't define, because turbo aborts the entire run when a task in `dependsOn` resolves to no definition anywhere in the config chain (`Could not find "<pkg>#generate:prisma" in root turbo.json`). The flip side is that a package which never writes this file fails quietly — its `generate` node has nothing under it, so codegen is skipped and downstream tasks read whatever is already on disk. `gtb verify` closes that gap: it reports packages with `generate:*` scripts and no package configuration, leaves missing from `generate`'s `dependsOn`, and leaves declaring neither `outputs` nor `cache: false`.
+
+**Single-package repo** — turbo offers package configurations only for workspace packages, and the lone `turbo.json` is sync-owned, so there is no seam to hand off to. Sync declares the leaves itself with `cache: false`. Codegen then re-runs on every invocation, which is slower than a cache hit and the only safe default when the outputs are unknowable.
+
 ### Non-obvious dependencies
 
 - **`lint:eslint` depends on `typecheck:ts`** — prevents confusing linter output from type errors. ESLint (via `typescript-eslint`) runs its own type resolution, so the dep isn't strictly required; consumers who prefer parallelism over cleaner output can remove it.
@@ -116,6 +141,8 @@ Run after adding packages, changing the task graph, or updating tooling. Without
 `mise.tasks.toml` is loaded by a one-time manual `[task_config] includes = ["mise.tasks.toml"]` in `mise.toml` (so sync never round-trips the hand-authored file); `gtb verify mise` asserts the include is present. An explicit `includes` replaces mise's default `mise-tasks/` discovery, so a repo keeping its own script tasks lists both: `includes = ["mise-tasks", "mise.tasks.toml"]`.
 
 `gtb verify` validates no drift from the expected baseline. Exits non-zero if anything is out of sync. Run in CI as a drift gate. Use `--ignore <name>` to skip a specific task or script — prefer fixing the drift. The `mise`/`codecov` checks self-skip when the repo doesn't use those tools (no `mise.toml` / no vitest tests).
+
+Most checks compare a file against what sync would generate. The `turbo` scope carries one that doesn't: the `generate:*` package configurations described above are author-owned, so verify asserts they exist and are wired correctly instead of regenerating them (`--ignore generate:<name>` opts a script out).
 
 ## Pre-commit hooks (`gtb hk`)
 

--- a/packages/cli/skills/gtb-build-pipeline/evals/evals.json
+++ b/packages/cli/skills/gtb-build-pipeline/evals/evals.json
@@ -85,6 +85,18 @@
       "files": [],
       "id": 8,
       "prompt": "Why is turbo reporting `Cached: 0 cached, N total` after I edited one source file in one workspace package?"
+    },
+    {
+      "expectations": [
+        "Explains that the root `generate` aggregate is emitted empty in a monorepo, so the leaf task must be declared by the package itself",
+        "Shows a package configuration at `packages/<pkg>/turbo.json` with `extends: [\"//\"]`, a `generate` task depending on the script, and the script's own task entry",
+        "States that the leaf must declare `outputs` (or `cache: false`), because a cached task without outputs restores nothing on a hit and leaves the generated files missing",
+        "Mentions that `gtb verify` reports the package until the configuration exists and is wired"
+      ],
+      "expected_output": "Activates skill. Explains that gtb discovers `generate:*` scripts but cannot know their outputs, so in a monorepo the root aggregate is left empty and each package declares its leaves in `packages/<pkg>/turbo.json` extending `//`: `generate` depends on `generate:prisma`, and `generate:prisma` declares inputs plus outputs. Notes the cache hazard that motivates the outputs requirement and that `gtb verify` fails until the wiring is present.",
+      "files": [],
+      "id": 9,
+      "prompt": "I added a `generate:prisma` script to one of my packages but `gtb verify` is now failing and turbo never seems to run it. What am I missing?"
     }
   ],
   "skill_name": "gtb-build-pipeline"

--- a/packages/cli/src/commands/root/verify.ts
+++ b/packages/cli/src/commands/root/verify.ts
@@ -5,6 +5,7 @@ import * as v from 'valibot';
 import { checkCodecovSections } from '../../lib/codecov-verify.ts';
 import { type WorkspaceDiscovery, discoverWorkspace } from '../../lib/discovery.ts';
 import { readJsonFile } from '../../lib/file-writer.ts';
+import { checkGenerateConfigs } from '../../lib/generate-tasks.ts';
 import { type Logger, createLogger } from '../../lib/logger.ts';
 import { checkManifests } from '../../lib/manifest-sync.ts';
 import { checkMiseTasksInclude } from '../../lib/mise-tasks.ts';
@@ -206,7 +207,10 @@ export const runVerify = (options: RunVerifyOptions = {}): readonly string[] => 
     mise: () => (discovery.hasMise ? checkMiseTasksInclude(discovery.rootDir) : []),
     scripts: () => checkAllScripts(discovery, ignored),
     tsconfig: () => checkTsconfigs(discovery),
-    turbo: () => checkTurboTasks(discovery.rootDir, generateTurboJson(discovery), ignored),
+    turbo: () => [
+      ...checkTurboTasks(discovery.rootDir, generateTurboJson(discovery), ignored),
+      ...checkGenerateConfigs(discovery, ignored),
+    ],
   };
 
   return syncScopes.flatMap(scope => (scopes.has(scope) ? checks[scope]() : []));

--- a/packages/cli/src/commands/task/names.ts
+++ b/packages/cli/src/commands/task/names.ts
@@ -18,3 +18,10 @@ export const taskNames = {
 
 /** Name of the root `task` subcommand hub. */
 export const taskCommandName = 'task';
+
+/**
+ * Prefix marking author-owned codegen scripts (`generate:prisma`). Unlike
+ * every name above, these have no CLI handler — gtb only discovers them and
+ * wires them into the `generate` aggregate.
+ */
+export const generateTaskPrefix = 'generate:';

--- a/packages/cli/src/lib/discovery.ts
+++ b/packages/cli/src/lib/discovery.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import path from 'node:path';
+import { generateTaskPrefix } from '../commands/task/names.ts';
 import type { Manifest } from './manifest.ts';
 import { hasPackageBlock } from './pkl-project.ts';
 import { localeComparer } from './sort.ts';
@@ -122,7 +123,7 @@ const mergeDeps = (manifest: Manifest): Record<string, string> => ({
 
 const collectGenerateScripts = (manifest: Manifest): readonly string[] =>
   Object.keys(manifest.scripts ?? {})
-    .filter(name => name.startsWith('generate:'))
+    .filter(name => name.startsWith(generateTaskPrefix))
     .toSorted(localeComparer);
 
 const buildCapabilities = (

--- a/packages/cli/src/lib/generate-tasks.ts
+++ b/packages/cli/src/lib/generate-tasks.ts
@@ -1,0 +1,125 @@
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import * as v from 'valibot';
+import type { PackageCapabilities, WorkspaceDiscovery } from './discovery.ts';
+import { readJsonFile } from './file-writer.ts';
+import { StringArray, UnknownRecord } from './schemas.ts';
+import { Aggregate } from './turbo-config.ts';
+
+/**
+ * Package configuration (`packages/<pkg>/turbo.json`) as far as the
+ * generate wiring is concerned. Loose so unrelated keys pass through.
+ */
+const PackageConfigSchema = v.looseObject({
+  extends: v.optional(StringArray),
+  tasks: v.optional(UnknownRecord),
+});
+
+const TaskSchema = v.looseObject({
+  cache: v.optional(v.boolean()),
+  dependsOn: v.optional(StringArray),
+  outputs: v.optional(StringArray),
+});
+
+type PackageConfig = v.InferOutput<typeof PackageConfigSchema>;
+
+const readPackageConfig = (filePath: string): PackageConfig | undefined => {
+  try {
+    return v.parse(PackageConfigSchema, readJsonFile(filePath));
+  } catch {
+    return undefined;
+  }
+};
+
+/**
+ * A cached task restores its declared outputs on a hit and skips the run;
+ * with nothing declared, the hit restores only logs and the generated files
+ * never appear. Either declaration makes that impossible.
+ */
+const isRestorable = (task: v.InferOutput<typeof TaskSchema>): boolean =>
+  task.cache === false || (task.outputs ?? []).length > 0;
+
+const checkLeafTask = (
+  filePath: string,
+  tasks: Record<string, unknown>,
+  script: string,
+): readonly string[] => {
+  if (!Object.hasOwn(tasks, script)) {
+    return [`${filePath}: missing task '${script}'`];
+  }
+  const result = v.safeParse(TaskSchema, tasks[script]);
+  if (!result.success || !isRestorable(result.output)) {
+    return [`${filePath}: task '${script}' must declare outputs or cache: false`];
+  }
+
+  return [];
+};
+
+const checkAggregateWiring = (
+  filePath: string,
+  tasks: Record<string, unknown>,
+  script: string,
+): readonly string[] => {
+  const result = v.safeParse(TaskSchema, tasks[Aggregate.generate]);
+  const dependsOn = result.success ? result.output.dependsOn ?? [] : [];
+
+  return dependsOn.includes(script)
+    ? []
+    : [`${filePath}: task '${Aggregate.generate}' must depend on '${script}'`];
+};
+
+const checkPackageConfig = (
+  filePath: string,
+  config: PackageConfig,
+  scripts: readonly string[],
+): readonly string[] => {
+  /*
+   * turbo rejects a package configuration that doesn't extend the root, so
+   * an unextended one takes the whole workspace down rather than degrading.
+   */
+  if (!(config.extends ?? []).includes('//')) {
+    return [`${filePath}: must extend '//'`];
+  }
+  const tasks = config.tasks ?? {};
+
+  return scripts.flatMap(script => [
+    ...checkAggregateWiring(filePath, tasks, script),
+    ...checkLeafTask(filePath, tasks, script),
+  ]);
+};
+
+const checkPackage = (
+  pkg: PackageCapabilities,
+  ignored: ReadonlySet<string>,
+): readonly string[] => {
+  const scripts = pkg.generateScripts.filter(script => !ignored.has(script));
+  if (scripts.length === 0) {
+    return [];
+  }
+  const filePath = path.join(pkg.dir, 'turbo.json');
+  if (!existsSync(filePath)) {
+    return [`${filePath}: missing — add a package configuration defining generate:* tasks`];
+  }
+  const config = readPackageConfig(filePath);
+
+  return config === undefined
+    ? [`${filePath}: failed to parse`]
+    : checkPackageConfig(filePath, config, scripts);
+};
+
+/**
+ * Asserts every package with `generate:*` scripts wires them into its own
+ * package configuration. The generated root `turbo.json` leaves the
+ * `generate` aggregate empty for monorepos (only the package knows what its
+ * codegen reads and writes), which means a package that never declares its
+ * leaves silently skips generation instead of failing — this check is what
+ * makes that loud. Single-package repos have no package configuration to
+ * check: their leaves are generated into the root config instead.
+ */
+export const checkGenerateConfigs = (
+  discovery: WorkspaceDiscovery,
+  ignored: ReadonlySet<string>,
+): readonly string[] =>
+  discovery.isMonorepo
+    ? discovery.packages.flatMap(pkg => checkPackage(pkg, ignored))
+    : [];

--- a/packages/cli/src/lib/turbo-aggregates.ts
+++ b/packages/cli/src/lib/turbo-aggregates.ts
@@ -7,12 +7,53 @@ import {
   rootTaskKey,
 } from './turbo-config.ts';
 
-const generateAggregate = (flags: ToolFlags): readonly ConditionalEntry<TurboTask>[] => [
+/*
+ * `generate:*` scripts are author-owned codegen. Discovery finds the names,
+ * but nothing in the manifest says what a script writes, so gtb cannot
+ * declare `outputs` for one — and an outputs-less task caches logs only, so a
+ * cache hit replays them, skips the run, and restores nothing. The generated
+ * files then never appear and every downstream task happily reads whatever is
+ * on disk (or nothing).
+ *
+ * Monorepos therefore push the leaves down to the packages, using the seam
+ * turbo provides for exactly this: the root aggregate stays empty and each
+ * package declares `generate` plus its own leaves — with real inputs and
+ * outputs — in a package configuration (`packages/<pkg>/turbo.json` extending
+ * `//`). Only the package knows what its codegen emits. A package that skips
+ * the wiring silently never generates, so `gtb verify` asserts it (see
+ * `checkGenerateConfigs`).
+ *
+ * Single-package repos get no such seam — turbo supports package
+ * configurations only for workspace packages, and the lone turbo.json is
+ * sync-owned — so the leaves are declared here and opted out of caching.
+ * Uncached codegen always runs, which is slower than a cache hit but never
+ * silently absent.
+ */
+const generateLeafTasks = (
+  flags: ToolFlags,
+  isMonorepo: boolean,
+): readonly ConditionalEntry<TurboTask>[] => {
+  if (isMonorepo) {
+    return [];
+  }
+
+  return flags.generateScripts.map(script => ({
+    condition: true,
+    key: script,
+    value: { cache: false },
+  }));
+};
+
+const generateAggregate = (
+  flags: ToolFlags,
+  isMonorepo: boolean,
+): readonly ConditionalEntry<TurboTask>[] => [
   {
     condition: flags.hasGenerate,
     key: Aggregate.generate,
-    value: { dependsOn: [...flags.generateScripts] },
+    value: isMonorepo ? {} : { dependsOn: [...flags.generateScripts] },
   },
+  ...generateLeafTasks(flags, isMonorepo),
 ];
 
 const typecheckAggregate = (flags: ToolFlags): readonly ConditionalEntry<TurboTask>[] => [
@@ -136,12 +177,17 @@ const coverageTasks = (flags: ToolFlags): readonly ConditionalEntry<TurboTask>[]
   },
 ];
 
-/** Collects aggregate and standalone task entries from tool flags. */
+/**
+ * Collects aggregate and standalone task entries from tool flags.
+ * `isMonorepo` is passed separately: it describes the repo's shape rather
+ * than a tool being present, and only the `generate` family reads it.
+ */
 export const aggregateTasks = (
   flags: ToolFlags,
+  isMonorepo: boolean,
 ): readonly ConditionalEntry<TurboTask>[] => [
   ...coverageTasks(flags),
-  ...generateAggregate(flags),
+  ...generateAggregate(flags, isMonorepo),
   ...typecheckAggregate(flags),
   ...compileAggregate(flags),
   ...packAggregate(flags),

--- a/packages/cli/src/lib/turbo-config.ts
+++ b/packages/cli/src/lib/turbo-config.ts
@@ -23,6 +23,8 @@ export const Aggregate = {
 
 /** Turborepo task definition. */
 export interface TurboTask {
+  /** Opts a task out of caching entirely. Omitted means turbo's default (`true`). */
+  readonly cache?: boolean;
   readonly dependsOn?: readonly string[];
   readonly env?: readonly string[];
   readonly inputs?: readonly string[];
@@ -371,7 +373,7 @@ export const generateTurboJson = (discovery: WorkspaceDiscovery): TurboJson => {
     ...rootLintTasks(flags, discovery.packageGlobs),
     ...testTasks(flags),
     ...deploySkillsTasks(flags),
-    ...aggregateTasks(flags),
+    ...aggregateTasks(flags, discovery.isMonorepo),
   ];
   /*
    * Self-hosted workspaces vendor tool-config packages (eslint-config,

--- a/packages/cli/test/generate-tasks.test.ts
+++ b/packages/cli/test/generate-tasks.test.ts
@@ -119,6 +119,35 @@ describe.concurrent('generate task verification', () => {
     expect(verifyTurbo(root)).toStrictEqual([`${configPath}: must extend '//'`]);
   });
 
+  it('reports a configuration with no extends key', ({ expect }) => {
+    const { configPath, pkgDir, root } = createGenerateProject({
+      scripts: ['generate:prisma'],
+      tasks: { generate: {} },
+    });
+    writeJson(pkgDir, 'turbo.json', {
+      tasks: {
+        'generate': { dependsOn: ['generate:prisma'] },
+        'generate:prisma': { outputs: ['generated/**'] },
+      },
+    });
+
+    expect(verifyTurbo(root)).toStrictEqual([`${configPath}: must extend '//'`]);
+  });
+
+  it('reports an aggregate that depends on nothing', ({ expect }) => {
+    const { configPath, root } = createGenerateProject({
+      scripts: ['generate:prisma'],
+      tasks: {
+        'generate': {},
+        'generate:prisma': { outputs: ['generated/**'] },
+      },
+    });
+
+    expect(verifyTurbo(root)).toStrictEqual([
+      `${configPath}: task 'generate' must depend on 'generate:prisma'`,
+    ]);
+  });
+
   it('reports a script left out of the generate aggregate', ({ expect }) => {
     const { configPath, root } = createGenerateProject({
       scripts: ['generate:paraglide', 'generate:prisma'],
@@ -131,6 +160,30 @@ describe.concurrent('generate task verification', () => {
 
     expect(verifyTurbo(root)).toStrictEqual([
       `${configPath}: task 'generate' must depend on 'generate:paraglide'`,
+    ]);
+  });
+
+  it('reports a configuration that declares a leaf but no aggregate', ({ expect }) => {
+    const { configPath, root } = createGenerateProject({
+      scripts: ['generate:prisma'],
+      tasks: { 'generate:prisma': { outputs: ['generated/**'] } },
+    });
+
+    expect(verifyTurbo(root)).toStrictEqual([
+      `${configPath}: task 'generate' must depend on 'generate:prisma'`,
+    ]);
+  });
+
+  it('reports a configuration with no tasks at all', ({ expect }) => {
+    const { configPath, pkgDir, root } = createGenerateProject({
+      scripts: ['generate:prisma'],
+      tasks: { generate: {} },
+    });
+    writeJson(pkgDir, 'turbo.json', { extends: ['//'] });
+
+    expect(verifyTurbo(root)).toStrictEqual([
+      `${configPath}: task 'generate' must depend on 'generate:prisma'`,
+      `${configPath}: missing task 'generate:prisma'`,
     ]);
   });
 

--- a/packages/cli/test/generate-tasks.test.ts
+++ b/packages/cli/test/generate-tasks.test.ts
@@ -1,0 +1,224 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import * as build from '@gtbuchanan/test-utils/builders';
+import { describe, it } from 'vitest';
+import { runVerify } from '#src/commands/root/verify.js';
+import { createTempDir, initProject, writeJson } from './helpers.ts';
+
+/** Task definitions for a package configuration, as authored. */
+type PackageTasks = Record<string, unknown>;
+
+interface GenerateProject {
+  readonly configPath: string;
+  readonly pkgDir: string;
+  readonly root: string;
+}
+
+interface GenerateProjectOptions {
+  /** `generate:*` scripts the package declares. */
+  readonly scripts: readonly string[];
+  /** Package configuration tasks, or `undefined` to write no config at all. */
+  readonly tasks?: PackageTasks | undefined;
+  /** `extends` value for the package configuration. Defaults to `['//']`. */
+  readonly extendsValue?: readonly string[] | undefined;
+  /** Single-package repo (no pnpm-workspace.yaml). Defaults to `false`. */
+  readonly singlePackage?: boolean;
+}
+
+/**
+ * Scaffolds a temp workspace whose one package declares `generate:*`
+ * scripts, then writes the package configuration described by `options`.
+ */
+const createGenerateProject = (options: GenerateProjectOptions): GenerateProject => {
+  const root = createTempDir();
+  const scripts = Object.fromEntries(
+    options.scripts.map(name => [name, `${build.packageName()} generate`]),
+  );
+
+  if (options.singlePackage === true) {
+    writeJson(root, 'package.json', { name: build.packageName(), scripts, version: '0.0.0' });
+    /*
+     * The root is the package here, and `initProject` writes a root
+     * tsconfig.json — so seed one first, otherwise discovery gains a
+     * TypeScript capability between generating turbo.json and verifying it.
+     */
+    writeFileSync(path.join(root, 'tsconfig.json'), '{}');
+    initProject(root);
+    return { configPath: path.join(root, 'turbo.json'), pkgDir: root, root };
+  }
+
+  writeFileSync(path.join(root, 'pnpm-workspace.yaml'), "packages:\n  - 'packages/*'\n");
+  writeJson(root, 'package.json', { name: build.packageName(), private: true });
+
+  const pkgDir = path.join(root, 'packages', build.packageName());
+  mkdirSync(pkgDir, { recursive: true });
+  writeJson(pkgDir, 'package.json', { name: build.scopedPackageName(), scripts });
+  initProject(root);
+
+  const configPath = path.join(pkgDir, 'turbo.json');
+  if (options.tasks !== undefined) {
+    writeJson(pkgDir, 'turbo.json', {
+      extends: options.extendsValue ?? ['//'],
+      tasks: options.tasks,
+    });
+  }
+
+  return { configPath, pkgDir, root };
+};
+
+const verifyTurbo = (root: string, ignored?: ReadonlySet<string>): readonly string[] =>
+  runVerify({
+    cwd: root,
+    ...(ignored !== undefined && { ignored }),
+    scopes: new Set(['turbo'] as const),
+  });
+
+describe.concurrent('generate task verification', () => {
+  it('passes when the package configuration declares outputs', ({ expect }) => {
+    const { root } = createGenerateProject({
+      scripts: ['generate:prisma'],
+      tasks: {
+        'generate': { dependsOn: ['generate:prisma'] },
+        'generate:prisma': { inputs: ['schema.prisma'], outputs: ['generated/**'] },
+      },
+    });
+
+    expect(verifyTurbo(root)).toStrictEqual([]);
+  });
+
+  it('passes when the leaf opts out of caching instead', ({ expect }) => {
+    const { root } = createGenerateProject({
+      scripts: ['generate:prisma'],
+      tasks: {
+        'generate': { dependsOn: ['generate:prisma'] },
+        'generate:prisma': { cache: false },
+      },
+    });
+
+    expect(verifyTurbo(root)).toStrictEqual([]);
+  });
+
+  it('reports a package with generate scripts and no configuration', ({ expect }) => {
+    const { configPath, root } = createGenerateProject({ scripts: ['generate:prisma'] });
+
+    expect(verifyTurbo(root)).toStrictEqual([
+      `${configPath}: missing — add a package configuration defining generate:* tasks`,
+    ]);
+  });
+
+  it('reports a configuration that does not extend the root', ({ expect }) => {
+    const { configPath, root } = createGenerateProject({
+      extendsValue: [],
+      scripts: ['generate:prisma'],
+      tasks: {
+        'generate': { dependsOn: ['generate:prisma'] },
+        'generate:prisma': { outputs: ['generated/**'] },
+      },
+    });
+
+    expect(verifyTurbo(root)).toStrictEqual([`${configPath}: must extend '//'`]);
+  });
+
+  it('reports a script left out of the generate aggregate', ({ expect }) => {
+    const { configPath, root } = createGenerateProject({
+      scripts: ['generate:paraglide', 'generate:prisma'],
+      tasks: {
+        'generate': { dependsOn: ['generate:prisma'] },
+        'generate:paraglide': { outputs: ['messages/**'] },
+        'generate:prisma': { outputs: ['generated/**'] },
+      },
+    });
+
+    expect(verifyTurbo(root)).toStrictEqual([
+      `${configPath}: task 'generate' must depend on 'generate:paraglide'`,
+    ]);
+  });
+
+  it('reports a leaf script with no task definition', ({ expect }) => {
+    const { configPath, root } = createGenerateProject({
+      scripts: ['generate:prisma'],
+      tasks: { generate: { dependsOn: ['generate:prisma'] } },
+    });
+
+    expect(verifyTurbo(root)).toStrictEqual([
+      `${configPath}: missing task 'generate:prisma'`,
+    ]);
+  });
+
+  it('reports a leaf that would cache without restoring its output', ({ expect }) => {
+    const { configPath, root } = createGenerateProject({
+      scripts: ['generate:prisma'],
+      tasks: {
+        'generate': { dependsOn: ['generate:prisma'] },
+        'generate:prisma': { inputs: ['schema.prisma'] },
+      },
+    });
+
+    expect(verifyTurbo(root)).toStrictEqual([
+      `${configPath}: task 'generate:prisma' must declare outputs or cache: false`,
+    ]);
+  });
+
+  it('treats an empty outputs array as no outputs', ({ expect }) => {
+    const { configPath, root } = createGenerateProject({
+      scripts: ['generate:prisma'],
+      tasks: {
+        'generate': { dependsOn: ['generate:prisma'] },
+        'generate:prisma': { outputs: [] },
+      },
+    });
+
+    expect(verifyTurbo(root)).toStrictEqual([
+      `${configPath}: task 'generate:prisma' must declare outputs or cache: false`,
+    ]);
+  });
+
+  it('reports unparseable package configurations', ({ expect }) => {
+    const { configPath, root } = createGenerateProject({
+      scripts: ['generate:prisma'],
+      tasks: { generate: {} },
+    });
+    writeFileSync(configPath, '{ not json');
+
+    expect(verifyTurbo(root)).toStrictEqual([`${configPath}: failed to parse`]);
+  });
+
+  it('ignores a script named in the ignored set', ({ expect }) => {
+    const { root } = createGenerateProject({ scripts: ['generate:prisma'] });
+
+    expect(verifyTurbo(root, new Set(['generate:prisma']))).toStrictEqual([]);
+  });
+
+  it('skips packages without generate scripts', ({ expect }) => {
+    const { root } = createGenerateProject({ scripts: [] });
+
+    expect(verifyTurbo(root)).toStrictEqual([]);
+  });
+
+  it('skips single-package repos, which own no package configuration', ({ expect }) => {
+    const { root } = createGenerateProject({
+      scripts: ['generate:prisma'],
+      singlePackage: true,
+    });
+
+    expect(verifyTurbo(root)).toStrictEqual([]);
+  });
+
+  it('reports every unwired package in a multi-package workspace', ({ expect }) => {
+    const { root } = createGenerateProject({ scripts: ['generate:prisma'] });
+    const secondDir = path.join(root, 'packages', build.packageName());
+    mkdirSync(secondDir, { recursive: true });
+    writeJson(secondDir, 'package.json', {
+      name: build.scopedPackageName(),
+      scripts: { 'generate:paraglide': 'paraglide compile' },
+    });
+
+    const drift = verifyTurbo(root);
+
+    expect(drift).toHaveLength(2);
+    expect(drift).toContain(
+      `${path.join(secondDir, 'turbo.json')}: missing — ` +
+      'add a package configuration defining generate:* tasks',
+    );
+  });
+});

--- a/packages/cli/test/turbo-config.helpers.ts
+++ b/packages/cli/test/turbo-config.helpers.ts
@@ -39,6 +39,12 @@ export interface MakeDiscoveryOverrides extends Partial<PackageCapabilities> {
   readonly dependsOnCli?: boolean;
   /** Overrides {@link WorkspaceDiscovery.hasMise} (defaults to `false`). */
   readonly hasMise?: boolean;
+  /**
+   * Overrides {@link WorkspaceDiscovery.isMonorepo} (defaults to more than
+   * one package). Real discovery also reports a monorepo for a single
+   * package under a `packages/*` glob, which no package count can express.
+   */
+  readonly isMonorepo?: boolean;
   /** Overrides {@link WorkspaceDiscovery.isSelfHosted} (defaults to `false`). */
   readonly isSelfHosted?: boolean;
 }
@@ -50,16 +56,17 @@ export const makeDiscovery = (
   const {
     dependsOnCli: hasCliDependency = false,
     hasMise = false,
+    isMonorepo = packages.length > 1,
     isSelfHosted = false,
     ...rootOverrides
   } = overrides;
   return {
     dependsOnCli: hasCliDependency,
     hasMise,
-    isMonorepo: packages.length > 1,
+    isMonorepo,
     isSelfHosted,
     packages,
-    packageGlobs: packages.length > 1 ? ['packages/*'] : [],
+    packageGlobs: isMonorepo ? ['packages/*'] : [],
     root: makeCapabilities(rootOverrides),
     rootDir: '/fake/root',
   };

--- a/packages/cli/test/turbo-json.test.ts
+++ b/packages/cli/test/turbo-json.test.ts
@@ -3,27 +3,38 @@ import { generateTurboJson } from '#src/lib/turbo-config.js';
 import { makeCapabilities, makeDiscovery } from './turbo-config.helpers.ts';
 
 describe.concurrent(generateTurboJson, () => {
-  it('includes generate aggregate when any package has generate scripts', ({ expect }) => {
-    const discovery = makeDiscovery([
-      makeCapabilities({
-        generateScripts: ['generate:prisma'],
-      }),
-    ]);
+  it('leaves the monorepo generate aggregate empty for packages to fill', ({ expect }) => {
+    const discovery = makeDiscovery(
+      [makeCapabilities({ generateScripts: ['generate:prisma'] })],
+      { isMonorepo: true },
+    );
 
     const result = generateTurboJson(discovery);
 
-    expect(result.tasks['generate']?.dependsOn).toStrictEqual(['generate:prisma']);
+    expect(result.tasks).toHaveProperty('generate');
+    expect(result.tasks['generate']).toStrictEqual({});
   });
 
-  it('deduplicates generate scripts across packages', ({ expect }) => {
-    const discovery = makeDiscovery([
-      makeCapabilities({
-        generateScripts: ['generate:prisma'],
-      }),
-      makeCapabilities({
-        generateScripts: ['generate:paraglide', 'generate:prisma'],
-      }),
-    ]);
+  it('omits generate leaf tasks from a monorepo root', ({ expect }) => {
+    const discovery = makeDiscovery(
+      [
+        makeCapabilities({ generateScripts: ['generate:prisma'] }),
+        makeCapabilities({ generateScripts: ['generate:paraglide'] }),
+      ],
+      { isMonorepo: true },
+    );
+
+    const result = generateTurboJson(discovery);
+
+    expect(result.tasks).not.toHaveProperty('generate:prisma');
+    expect(result.tasks).not.toHaveProperty('generate:paraglide');
+  });
+
+  it('wires generate leaves into the aggregate for a single-package repo', ({ expect }) => {
+    const discovery = makeDiscovery(
+      [makeCapabilities({ generateScripts: ['generate:paraglide', 'generate:prisma'] })],
+      { isMonorepo: false },
+    );
 
     const result = generateTurboJson(discovery);
 
@@ -31,6 +42,17 @@ describe.concurrent(generateTurboJson, () => {
       'generate:paraglide',
       'generate:prisma',
     ]);
+  });
+
+  it('defines single-package generate leaves as uncached', ({ expect }) => {
+    const discovery = makeDiscovery(
+      [makeCapabilities({ generateScripts: ['generate:prisma'] })],
+      { isMonorepo: false },
+    );
+
+    const result = generateTurboJson(discovery);
+
+    expect(result.tasks['generate:prisma']).toStrictEqual({ cache: false });
   });
 
   it('omits generate aggregate when no packages have generate scripts', ({ expect }) => {


### PR DESCRIPTION
## Problem

`gtb sync` named every discovered `generate:*` script in the root `generate` aggregate's `dependsOn` but never emitted a task definition for it. Turbo refuses to build the graph in that state:

```
x Could not find "a#generate:stamp" in root turbo.json or "generate:stamp" in package
```

So any **monorepo** consumer that added a codegen script broke every `turbo run`. (Single-package repos were quietly fine — turbo treats an undefined task as `cache bypass` and runs it anyway. Confirmed against the real binary, both shapes.)

The existing unit tests asserted the generated object's shape, so nothing caught that turbo rejected it.

## Approach

gtb discovers the script names but nothing in a manifest says what a codegen script writes, and a task with no `outputs` restores nothing on a cache hit — it replays logs, skips the run, and the generated files simply stay missing while every downstream task reports success. Reproduced end to end: `FULL TURBO`, exit 0, no files on disk. So sync no longer guesses.

- **Monorepo** — the root aggregate is emitted empty and each package declares its own leaves in a package configuration (`packages/<pkg>/turbo.json` extending `//`), where it can give them real `inputs`/`outputs`.
- **Single-package repo** — turbo offers package configurations only for workspace packages, and the lone `turbo.json` is sync-owned, so there is no seam to hand off to. Sync declares the leaves itself with `cache: false`.

An empty aggregate trades a loud failure for a silent one: a package that never writes the configuration has nothing under its `generate` node, so codegen is skipped and downstream tasks read whatever is on disk. `gtb verify` (scope `turbo`) closes that, reporting a missing package configuration, a config that doesn't extend `//`, a script left out of `generate`'s `dependsOn`, or a leaf declaring neither `outputs` nor `cache: false`. `--ignore generate:<name>` opts a script out.

Repos with no `generate:*` scripts generate the same `turbo.json` as before — this repo's own is unchanged and `gtb verify` is clean.

## Testing

- Unit coverage for both repo shapes in `turbo-json.test.ts`, plus `generate-tasks.test.ts` for every verify rule.
- New `e2e/turbo-generate.test.ts` drives the **real turbo binary** through `gtb turbo` (so the Android/Termux escape hatch applies) over workspaces `gtb sync` generated: the single-package run must bypass the cache, and the monorepo run must restore package-declared outputs from a cache hit.
- Both e2e assertions were checked against a deliberately reverted implementation to confirm they fail for the right reason. The first draft of the single-package assertion did not — it passed either way, because the fixture is not a git repo so the deleted output counted as a default input — so it now keys on turbo's `cache bypass` decision instead.
- Full `pnpm build` green.

## Notes

The `gtb-build-pipeline` skill gains a "Codegen tasks" section documenting the split, and an eval covering the "I added `generate:prisma` and verify fails" case.
