### PR TITLE
Ignore generated CHANGELOG.md in eslint-config

### DIFF
--- a/.changeset/eslint-config-ignore-changelogs.md
+++ b/.changeset/eslint-config-ignore-changelogs.md
@@ -1,0 +1,21 @@
+---
+'@gtbuchanan/eslint-config': minor
+---
+
+Ignore generated `CHANGELOG.md` files by default
+
+Changesets writes `CHANGELOG.md` through its own Prettier resolution,
+which cannot see the options this config hands `format/prettier`. A
+changeset whose body contains a fenced code block comes back reformatted
+— stock Prettier double-quotes string literals where this config's
+`singleQuote` does not — and the diff is unfixable at the source, since
+the `.changeset/*.md` the snippet was authored in is linted the other
+way. Every version PR failed lint on a file no one can correct.
+
+The generated changelog joins build output, lockfiles, and generated
+skills in the default `ignores`: paths another tool generates and owns
+the format of. Authored `.changeset/*.md` are unaffected and stay
+linted.
+
+Repos passing their own `ignores` replace the default list wholesale, so
+add `**/CHANGELOG.md` to keep this behavior.

--- a/packages/eslint-config/e2e/cli.test.ts
+++ b/packages/eslint-config/e2e/cli.test.ts
@@ -93,6 +93,31 @@ describe.concurrent('eslint CLI integration', () => {
     expect(exitCode).toBe(0);
   });
 
+  it('respects global ignores for generated changelogs', async ({ fixture, expect }) => {
+    /*
+     * Changesets writes CHANGELOG.md through its own Prettier resolution,
+     * which double-quotes embedded code regardless of what this config
+     * enforces — a diff no author can fix at the source, since the
+     * .changeset/*.md the snippet came from is linted the other way.
+     * The identical body in a normal .md keeps the run honest: it proves
+     * the content really does violate format/prettier, so the changelog
+     * assertion can't pass vacuously.
+     */
+    const body = [
+      '# Changelog', '',
+      '```js', 'configure({ agentSkillsHost: "claude-code" });', '```', '',
+    ].join('\n');
+
+    const { stdout } = await fixture.run({
+      files: { 'notes.md': body, 'packages/pkg/CHANGELOG.md': body },
+      flags: ['--no-warn-ignored'],
+    });
+
+    expect(stdout).toContain('format/prettier');
+    expect(stdout).toContain('notes.md');
+    expect(stdout).not.toContain('CHANGELOG.md');
+  });
+
   it('detects duplicate keys in JSON files', async ({ fixture, expect }) => {
     const { exitCode, stdout } = await fixture.run({
       files: { 'bad.json': '{\n  "key": 1,\n  "key": 2\n}\n' },

--- a/packages/eslint-config/skills/gtb-eslint-config/SKILL.md
+++ b/packages/eslint-config/skills/gtb-eslint-config/SKILL.md
@@ -45,9 +45,13 @@ All optional except `tsconfigRootDir` (recommended for type-aware rules):
 - **`entryPoints`** — Glob patterns exempt from `process.exit` and
   hashbang restrictions (and from `no-console` in browser mode).
   Defaults to `**/bin/**/*.{js,mjs,cjs,ts,mts,cts}` and `**/scripts/**/*`.
-- **`ignores`** — Global ignore patterns. Defaults to
-  `.claude/worktrees/**`, `**/.turbo/**`, `**/dist/**`,
-  `**/pnpm-lock.yaml`, `**/skills-lock.json`.
+- **`ignores`** — Global ignore patterns. Defaults to the paths another
+  tool generates or owns the format of: `.claude/worktrees/**`,
+  `**/.turbo/**`, `**/CHANGELOG.md`, `**/dist/**`, `**/pnpm-lock.yaml`,
+  `**/skills-lock.json`, `**/skills/*-workspace/**`, `**/skills/npm-*/**`.
+  Changesets formats the changelogs it generates with its own Prettier
+  resolution, so linting them here reports diffs that are unfixable at
+  the source. Passing this option replaces the list wholesale.
 - **`onlyWarn`** — Downgrades all errors to warnings via
   `eslint-plugin-only-warn`. Defaults to `true`. Irreversible within
   a process — uses a side-effect import that monkey-patches the ESLint

--- a/packages/eslint-config/src/index.ts
+++ b/packages/eslint-config/src/index.ts
@@ -48,8 +48,11 @@ export interface ESLintConfigureOptions {
   /** Root directory for TypeScript project service. */
   readonly tsconfigRootDir?: string;
   /**
-   * Global ignore patterns.
-   * @defaultValue Claude Code worktrees and dist output directories
+   * Global ignore patterns. Replaces the default list wholesale rather
+   * than extending it.
+   * @defaultValue Paths another tool generates or owns the format of —
+   * Claude Code worktrees, build output, lockfiles, generated skills, and
+   * changelogs
    */
   readonly ignores?: string[];
   /**
@@ -102,6 +105,14 @@ const resolveOptions = (options: ESLintConfigureOptions): ResolvedOptions => ({
   ignores: options.ignores ?? [
     '.claude/worktrees/**',
     '**/.turbo/**',
+    /*
+     * Changesets generates CHANGELOG.md and formats it through its own
+     * Prettier resolution, which has no access to the options this config
+     * passes format/prettier. Embedded code comes back double-quoted and
+     * unfixable at the source — the .changeset/*.md it was written in is
+     * linted the other way — so the generated file is not ours to lint.
+     */
+    '**/CHANGELOG.md',
     '**/dist/**',
     '**/pnpm-lock.yaml',
     '**/skills-lock.json',


### PR DESCRIPTION
## Problem

Every changesets version PR fails lint on a file nobody can fix. Most recently [#289](https://github.com/gtbuchanan/tooling/pull/289), where both `CI / Build` and `Pre-Commit / Pre-Commit Run` failed with:

```
packages/eslint-plugin-agent-skills/CHANGELOG.md
  18:37  warning  Replace `"claude-code"` with `'claude-code'`  format/prettier
```

`@changesets/apply-release-plan` formats every changelog it writes with Prettier, resolving options via `prettier.resolveConfig(filePath)`. This repo deliberately has no Prettier config file — the options live in the `format/prettier` rule (`packages/eslint-config/src/plugins/format.ts`), which is the whole point of running Prettier through ESLint. So changesets formats with stock defaults and rewrites embedded code to double quotes, and our config then flags the quotes it didn't write.

There is no fix at the source: the `.changeset/*.md` the snippet was authored in is linted with `singleQuote: true`, so the snippet *must* be single-quoted there and *will* come out double-quoted in the changelog. Any string literal in a changeset code fence is a guaranteed CI failure.

## Change

`**/CHANGELOG.md` joins the default global `ignores`. It sits with build output, lockfiles, and generated skills — paths another tool generates and owns the format of. Authored `.changeset/*.md` are unaffected and stay linted.

Considered and rejected: adding a `.prettierrc` (re-introduces the shared Prettier config the design eliminates) and an `eslint --fix` pass inside `gtb version` (couples CD to a lint run for a file we don't need to lint).

## Verification

The e2e test lints a nested `packages/pkg/CHANGELOG.md` and an identical `notes.md` in one run — the control proves the content really does violate `format/prettier`, so the changelog assertion can't pass vacuously, and the nested path fails if the pattern loses its `**/`. Confirmed red before the change, green after. Full `turbo run build` passes.

Once this merges, #289 needs to regenerate off main; changesets rebuilds those changelogs from the `.changeset/*.md` sources, which are intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)